### PR TITLE
fix(ui): reject ill-formed UTF-8 so no escape byte reaches the terminal

### DIFF
--- a/scripts/regressions/utf8-lead-byte-smuggles-c1-introducer.sh
+++ b/scripts/regressions/utf8-lead-byte-smuggles-c1-introducer.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Regression: the sanitizer armed its UTF-8 continuation counter from a length
+# classifier, which answers "how many bytes would this lead occupy" and never
+# "is this a legal lead". Ill-formed leads (C0/C1, F5..F7) and ill-formed
+# continuations (overlong, surrogate, beyond U+10FFFF) therefore opened a 1-3
+# byte window in which the raw 8-bit C1 introducers 0x9B (CSI) and 0x9D (OSC)
+# reached the terminal without ever passing the CSI whitelist or the OSC drop.
+#
+# The sanitizer has no standalone CLI surface (it wraps child stdout/stderr), so
+# a standalone ReleaseSafe `zig test` harness drives Sanitizer.feed/flush and
+# scrubInPlace directly and asserts on the emitted bytes. It checks both
+# directions: no hostile form emits a byte in 0x80..0x9F, and legitimate UTF-8 --
+# including a codepoint whose own continuation byte is 0x9B -- still passes
+# byte-identically, so a blanket C1 drop does not make it pass.
+#
+# Exits 0 when the bug is absent, non-zero (with a clear message) when present.
+# No network required; finishes well under 30s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+
+# The standalone harness proves the byte-level property directly, but it cannot
+# notice the real tests being deleted, so guard their names too.
+while IFS= read -r name; do
+  if ! grep -Fqs -- "$name" "$ROOT/tests/term_sanitize_test.zig"; then
+    echo "FAIL: the ill-formed UTF-8 test is missing from tests/term_sanitize_test.zig: $name" >&2
+    exit 1
+  fi
+done <<'NAMES'
+invalid UTF-8 lead does not arm the continuation counter
+overlong sequence cannot carry an 8-bit C1 introducer
+NAMES
+
+# The harness imports the sanitizer via a repo-relative path, so it must sit at
+# the repo root for the source tree's module boundary to resolve; $$ keeps
+# concurrent runs from clobbering each other's file.
+HARNESS="$ROOT/.utf8-lead-c1-regression.$$.zig"
+trap 'rm -f "$HARNESS"' EXIT
+
+cat >"$HARNESS" <<'ZIG'
+const std = @import("std");
+const ts = @import("src/ui/term_sanitize.zig");
+
+const Buf = struct {
+    list: std.ArrayList(u8) = .empty,
+
+    fn sink(self: *Buf) ts.Sink {
+        return .{ .ctx = self, .write_fn = writeFn };
+    }
+    fn writeFn(ctx: *anyopaque, bytes: []const u8) ts.SinkError!void {
+        const self: *Buf = @ptrCast(@alignCast(ctx));
+        self.list.appendSlice(std.testing.allocator, bytes) catch return error.WriteFailed;
+    }
+    fn deinit(self: *Buf) void {
+        self.list.deinit(std.testing.allocator);
+    }
+};
+
+fn run(input: []const u8, out: *Buf) !void {
+    var s = ts.Sanitizer.init();
+    try s.feed(input, out.sink());
+    try s.flush(out.sink());
+}
+
+fn expectNoC1(bytes: []const u8) !void {
+    for (bytes) |b| try std.testing.expect(b < 0x80 or b > 0x9F);
+}
+
+const hostile = [_][]const u8{
+    "\xC0\x9B>4;2m", // C0 is never a legal lead: armed 1 byte
+    "\xC1\x9B>4;2m",
+    "\xF5\x9B\x9D", // F5..F7 armed 3 bytes: two introducers at once
+    "\xF6\x9B\x9D",
+    "\xF7\x9B\x9D",
+    "\xE0\x80\x9B", // overlong 3-byte
+    "\xF0\x80\x80\x9B", // overlong 4-byte
+    "\xED\xA0\x9B", // surrogate
+    "\xF4\x90\x9B\x9D", // beyond U+10FFFF
+};
+
+test "no ill-formed sequence lets an 8-bit C1 introducer through" {
+    for (hostile) |bad| {
+        var b: Buf = .{};
+        defer b.deinit();
+        try run(bad, &b);
+        try expectNoC1(b.list.items);
+
+        var copy: [16]u8 = undefined;
+        @memcpy(copy[0..bad.len], bad);
+        try expectNoC1(ts.scrubInPlace(copy[0..bad.len]));
+    }
+}
+
+test "an OSC 52 clipboard payload introduced by an invalid lead is dropped whole" {
+    var b: Buf = .{};
+    defer b.deinit();
+    try run("\xC0\x9D" ++ "52;c;ZXZpbA==" ++ "\x07", &b);
+    try std.testing.expectEqual(@as(usize, 0), b.list.items.len);
+}
+
+test "legitimate UTF-8 still passes byte-identically" {
+    // U+D6C0 is the case that matters: its continuation byte IS 0x9B, so a
+    // blanket C1 drop would fail here.
+    const good = [_][]const u8{ "\xC3\xA9", "\xF0\x9F\x8D\xBA", "\xED\x9B\x80", "Caf\xC3\xA9 \xE2\x98\x95" };
+    for (good) |ok| {
+        var b: Buf = .{};
+        defer b.deinit();
+        try run(ok, &b);
+        try std.testing.expectEqualStrings(ok, b.list.items);
+
+        var copy: [32]u8 = undefined;
+        @memcpy(copy[0..ok.len], ok);
+        try std.testing.expectEqualStrings(ok, ts.scrubInPlace(copy[0..ok.len]));
+    }
+}
+ZIG
+
+if (cd "$ROOT" && zig test -OReleaseSafe "$HARNESS") >/dev/null 2>&1; then
+  echo "PASS: ill-formed UTF-8 cannot smuggle an 8-bit C1 introducer"
+else
+  echo "FAIL: an ill-formed UTF-8 lead still opens a raw byte window" >&2
+  exit 1
+fi

--- a/src/ui/term_sanitize.zig
+++ b/src/ui/term_sanitize.zig
@@ -1,9 +1,9 @@
 //! malt — terminal escape-sequence sanitizer
 //!
 //! Filters bytes from an untrusted child process before they reach
-//! the user's terminal. Permits printable ASCII + CR/LF/TAB + valid
-//! UTF-8 (tracked with a small continuation counter, so lone C1
-//! controls in 0x80..0x9F drop while real multibyte output passes) +
+//! the user's terminal. Permits printable ASCII + CR/LF/TAB + well-formed
+//! UTF-8 (validated per byte position, so lone C1 controls in 0x80..0x9F
+//! drop while real multibyte output passes) +
 //! a whitelisted subset of CSI sequences, gated on the final byte AND
 //! numeric-only parameters: SGR colours, relative cursor motion
 //! (A–G/E/F), line erase (K), and visible-screen erase (J with no
@@ -50,9 +50,9 @@ pub const Sanitizer = struct {
     csi_overflow: bool = false,
     out_buf: [out_buf]u8 = undefined,
     out_len: usize = 0,
-    // Outstanding UTF-8 continuation bytes expected after a lead byte, so a
-    // continuation in 0x80..0x9F passes while a lone C1 control is dropped.
-    utf8_remaining: u2 = 0,
+    // Pending UTF-8 sequence, so a continuation in 0x80..0x9F passes while a
+    // lone C1 control is dropped.
+    utf8: Utf8State = .{},
 
     const State = enum {
         normal,
@@ -87,9 +87,9 @@ pub const Sanitizer = struct {
             .normal => {
                 if (b == 0x1B) {
                     try self.flush(sink);
-                    self.utf8_remaining = 0;
+                    self.utf8 = .{};
                     self.state = .esc;
-                } else if (self.utf8_remaining == 0) {
+                } else if (self.utf8.remaining == 0) {
                     if (c1Target(b)) |target| {
                         // 8-bit C1 introducer: drop it and its payload just like
                         // the 7-bit ESC form, so an 8-bit terminal can't
@@ -167,32 +167,60 @@ pub const Sanitizer = struct {
 
     fn passable(self: *Sanitizer, b: u8) bool {
         // CR is a stream byte here: child output uses it for in-place progress.
-        return passableByte(b, &self.utf8_remaining) or b == '\r';
+        return passableByte(b, &self.utf8) or b == '\r';
     }
 };
 
-/// Shared pass predicate. The continuation counter is what tells a real
-/// 0x80..0xBF continuation from a lone C1 control, so both callers must
-/// classify through here rather than reimplement the rule.
-fn passableByte(b: u8, utf8_remaining: *u2) bool {
-    if (utf8_remaining.* > 0) switch (b) {
-        0x80...0xBF => {
-            utf8_remaining.* -= 1;
-            return true;
-        },
-        else => utf8_remaining.* = 0, // truncated — reclassify below
+/// Pending multibyte sequence. `lo`/`hi` bound the *next* byte, which is what
+/// separates a well-formed encoding from an overlong, surrogate or
+/// out-of-range one — a plain 0x80..0xBF range check cannot tell them apart.
+const Utf8State = struct {
+    remaining: u2 = 0,
+    lo: u8 = 0x80,
+    hi: u8 = 0xBF,
+};
+
+/// Unicode Table 3-7: the only leads that begin a well-formed sequence, each
+/// with the range its successor byte must fall in. A length classifier is not
+/// a substitute — it accepts 0xC0/0xC1 and 0xF5..0xF7, which are never legal.
+fn leadState(b: u8) ?Utf8State {
+    return switch (b) {
+        0xC2...0xDF => .{ .remaining = 1, .lo = 0x80, .hi = 0xBF },
+        0xE0 => .{ .remaining = 2, .lo = 0xA0, .hi = 0xBF },
+        0xE1...0xEC => .{ .remaining = 2, .lo = 0x80, .hi = 0xBF },
+        0xED => .{ .remaining = 2, .lo = 0x80, .hi = 0x9F },
+        0xEE...0xEF => .{ .remaining = 2, .lo = 0x80, .hi = 0xBF },
+        0xF0 => .{ .remaining = 3, .lo = 0x90, .hi = 0xBF },
+        0xF1...0xF3 => .{ .remaining = 3, .lo = 0x80, .hi = 0xBF },
+        0xF4 => .{ .remaining = 3, .lo = 0x80, .hi = 0x8F },
+        else => null,
     };
+}
+
+/// Shared pass predicate. The pending-sequence state is what tells a real
+/// continuation from a lone C1 control, so both callers must classify through
+/// here rather than reimplement the rule.
+///
+/// Emission stays byte-at-a-time: every byte that passes is part of a
+/// well-formed prefix, so a later rejection leaves a maximal subpart that a
+/// strict decoder eats as one error rather than resyncing into it as C1.
+fn passableByte(b: u8, st: *Utf8State) bool {
+    if (st.remaining > 0) {
+        if (b >= st.lo and b <= st.hi) {
+            st.remaining -= 1;
+            // Only the byte after the lead is range-restricted.
+            st.lo = 0x80;
+            st.hi = 0xBF;
+            return true;
+        }
+        st.* = .{}; // ill-formed — reclassify below
+    }
     return switch (b) {
         0x20...0x7E, '\n', '\t' => true,
-        // UTF-8 lead byte: pass raw and arm the continuation counter. std
-        // rejects continuation bytes and invalid leads (0xF8..0xFF), both of
-        // which fall through to `false` — closing the lone-C1 hole.
-        0x80...0xFF => blk: {
-            const len = std.unicode.utf8ByteSequenceLength(b) catch break :blk false;
-            utf8_remaining.* = @intCast(len - 1);
+        else => if (leadState(b)) |armed| blk: {
+            st.* = armed;
             break :blk true;
-        },
-        else => false, // C0 controls, DEL
+        } else false, // C0 controls, DEL, continuation and invalid lead bytes
     };
 }
 
@@ -203,9 +231,9 @@ fn passableByte(b: u8, utf8_remaining: *u2) bool {
 /// whitelist here and CR drops with the other C0 controls.
 pub fn scrubInPlace(buf: []u8) []u8 {
     var out: usize = 0;
-    var utf8_remaining: u2 = 0;
+    var st: Utf8State = .{};
     for (buf) |b| {
-        if (!passableByte(b, &utf8_remaining)) continue;
+        if (!passableByte(b, &st)) continue;
         buf[out] = b;
         out += 1;
     }
@@ -300,6 +328,86 @@ test "c1Target maps 8-bit introducers to their drop/filter state" {
     for ([_]u8{ 0x9C, 'A', 0x80, 0x1B }) |b| try std.testing.expect(c1Target(b) == null);
 }
 
+test "leadState arms only the leads Unicode Table 3-7 permits" {
+    // Length classifiers accept these; only a table of legal leads rejects them.
+    for ([_]u8{ 0xC0, 0xC1, 0xF5, 0xF6, 0xF7, 0xF8, 0xFD, 0xFF, 0x80, 0x9B, 0xBF }) |b|
+        try std.testing.expect(leadState(b) == null);
+    // Leads that constrain their successor byte, per Table 3-7.
+    try std.testing.expectEqual(Utf8State{ .remaining = 1, .lo = 0x80, .hi = 0xBF }, leadState(0xC2).?);
+    try std.testing.expectEqual(Utf8State{ .remaining = 2, .lo = 0xA0, .hi = 0xBF }, leadState(0xE0).?);
+    try std.testing.expectEqual(Utf8State{ .remaining = 2, .lo = 0x80, .hi = 0x9F }, leadState(0xED).?);
+    try std.testing.expectEqual(Utf8State{ .remaining = 3, .lo = 0x90, .hi = 0xBF }, leadState(0xF0).?);
+    try std.testing.expectEqual(Utf8State{ .remaining = 3, .lo = 0x80, .hi = 0x8F }, leadState(0xF4).?);
+}
+
+test "every well-formed codepoint survives the lead table byte-identically" {
+    // The table is hand-transcribed, so check it against an independent decoder
+    // rather than hand-picked examples: for each lead, sweep the successor byte
+    // (the only other position the table constrains) over a well-formed tail.
+    // Only acceptance is asserted -- a rejected sequence still emits its
+    // maximal subpart, so passthrough is not equivalent to validity.
+    var buf: [4]u8 = undefined;
+    for (0xC0..0x100) |lead| {
+        inline for (.{ 2, 3, 4 }) |n| {
+            for (0x80..0x100) |second| {
+                var seq: [n]u8 = @splat(0x80); // well-formed tail
+                seq[0] = @intCast(lead);
+                seq[1] = @intCast(second);
+                if (!std.unicode.utf8ValidateSlice(&seq)) continue;
+                @memcpy(buf[0..n], &seq);
+                try std.testing.expectEqualSlices(u8, &seq, scrubInPlace(buf[0..n]));
+            }
+        }
+    }
+}
+
+test "passableByte rejects ill-formed leads and out-of-range continuations" {
+    var st: Utf8State = .{};
+    // An invalid lead must drop and leave the counter disarmed, so the C1
+    // introducer behind it is still classified as an introducer.
+    for ([_]u8{ 0xC0, 0xC1, 0xF5, 0xF6, 0xF7, 0xF8, 0xFF }) |b| {
+        try std.testing.expect(!passableByte(b, &st));
+        try std.testing.expectEqual(@as(u2, 0), st.remaining);
+        try std.testing.expect(!passableByte(0x9B, &st));
+    }
+    // Overlong, surrogate and out-of-range forms all use continuation bytes in
+    // 0x80..0xBF, so only the per-position bounds reject them.
+    for ([_][2]u8{ .{ 0xE0, 0x80 }, .{ 0xED, 0xA0 }, .{ 0xF0, 0x80 }, .{ 0xF4, 0x90 } }) |seq| {
+        st = .{};
+        try std.testing.expect(passableByte(seq[0], &st));
+        try std.testing.expect(!passableByte(seq[1], &st));
+        try std.testing.expectEqual(@as(u2, 0), st.remaining);
+    }
+    // Only the second byte is range-restricted; the rest are plain continuations.
+    st = .{};
+    for ([_]u8{ 0xF0, 0x90, 0x80, 0x80 }) |b| try std.testing.expect(passableByte(b, &st));
+    try std.testing.expectEqual(@as(u2, 0), st.remaining);
+}
+
+test "passableByte reclassifies the byte that broke a sequence" {
+    // A truncated codepoint must not swallow the byte that follows it.
+    var st: Utf8State = .{};
+    try std.testing.expect(passableByte(0xE2, &st));
+    try std.testing.expect(passableByte('a', &st)); // ASCII resumes immediately
+    try std.testing.expectEqual(@as(u2, 0), st.remaining);
+    // A fresh lead in the broken position arms a fresh sequence.
+    st = .{};
+    try std.testing.expect(passableByte(0xE2, &st));
+    try std.testing.expect(passableByte(0xC3, &st));
+    try std.testing.expectEqual(@as(u2, 1), st.remaining);
+    try std.testing.expect(passableByte(0xA9, &st));
+}
+
+test "CR resets an armed sequence instead of counting as a continuation" {
+    // `passable` ORs in CR after `passableByte`; the reset must still happen or
+    // a CR mid-codepoint would leave the counter armed for the next byte.
+    var s = Sanitizer.init();
+    try std.testing.expect(s.passable(0xE2));
+    try std.testing.expect(s.passable('\r'));
+    try std.testing.expectEqual(@as(u2, 0), s.utf8.remaining);
+    try std.testing.expect(!s.passable(0x9B));
+}
+
 test "passable drops lone C1 but passes UTF-8 continuation under an armed counter" {
     var s = Sanitizer.init();
     // Printable ASCII and whitespace pass; C0 and DEL drop.
@@ -358,6 +466,12 @@ test "scrubInPlace strips a whole OSC 52 clipboard payload of its controls" {
     try std.testing.expect(std.mem.indexOfScalar(u8, got, 0x07) == null);
     try std.testing.expect(std.mem.startsWith(u8, got, "evil"));
     try std.testing.expect(std.mem.endsWith(u8, got, "tail"));
+}
+
+test "scrubInPlace drops CR mid-codepoint without arming the next byte" {
+    // CR is a C0 control here, so it both drops and disarms.
+    var buf = [_]u8{ 0xE2, '\r', 0x9B, 'x' };
+    try std.testing.expectEqualStrings("\xe2x", scrubInPlace(&buf));
 }
 
 test "scrubInPlace handles an empty buffer" {

--- a/tests/term_sanitize_test.zig
+++ b/tests/term_sanitize_test.zig
@@ -239,6 +239,74 @@ test "incomplete UTF-8 lead is flushed when a control follows" {
     try check("x\xe2\x1b[?25ly", "x\xe2y");
 }
 
+test "invalid UTF-8 lead does not arm the continuation counter" {
+    // C0/C1 and F5..F7 are never legal leads, yet a length classifier hands
+    // them a 1- and 3-byte window. The lead must drop and the C1 introducer
+    // behind it must still reach the CSI/OSC filter.
+    try check("a\xc0\x9b>4;2mb", "ab");
+    try check("a\xc1\x9b>4;2mb", "ab");
+    // 'm' terminates the CSI the introducer opened, so the tail is plain text.
+    try check("a\xf5\x9b\x9dmb", "ab");
+    try check("a\xf6\x9b\x9dmb", "ab");
+    try check("a\xf7\x9b\x9dmb", "ab");
+    // A whitelisted CSI behind an invalid lead is still filtered, not smuggled.
+    try check("\xc0\x9b1;31m", "\x1b[1;31m");
+    // An invalid lead followed by an OSC introducer drops the whole payload.
+    try check("a\xc0\x9d52;c;ZXZpbA==\x07b", "ab");
+}
+
+test "overlong sequence cannot carry an 8-bit C1 introducer" {
+    // The continuation bytes below are all in 0x80..0xBF, so a range-only
+    // check accepts them; only per-position bounds reject the encoding.
+    try check("\xe0\x80\x9b>4;2m", "\xe0"); // overlong 3-byte
+    try check("\xf0\x80\x80\x9b>4;2m", "\xf0"); // overlong 4-byte
+    try check("\xed\xa0\x9b>4;2m", "\xed"); // UTF-16 surrogate
+    try check("\xf4\x90\x9b\x9d", "\xf4"); // beyond U+10FFFF
+}
+
+test "well-formed boundary codepoints still pass byte-identically" {
+    // Guards against fixing the bug by dropping multibyte output wholesale.
+    try check("\xc2\x80", "\xc2\x80"); // U+0080, lowest 2-byte
+    try check("\xdf\xbf", "\xdf\xbf"); // U+07FF, highest 2-byte
+    try check("\xe0\xa0\x80", "\xe0\xa0\x80"); // U+0800, lowest 3-byte
+    try check("\xed\x9f\xbf", "\xed\x9f\xbf"); // U+D7FF, last before surrogates
+    try check("\xee\x80\x80", "\xee\x80\x80"); // U+E000, first after surrogates
+    try check("\xef\xbf\xbf", "\xef\xbf\xbf"); // U+FFFF
+    try check("\xf0\x90\x80\x80", "\xf0\x90\x80\x80"); // U+10000
+    try check("\xf4\x8f\xbf\xbf", "\xf4\x8f\xbf\xbf"); // U+10FFFF, highest legal
+    // U+D6C0: its own continuation byte is 0x9B, the 8-bit CSI introducer.
+    try check("\xed\x9b\x80", "\xed\x9b\x80");
+}
+
+test "a dropped escape disarms a pending UTF-8 sequence" {
+    // Without the reset, the introducer lands inside the lead's continuation
+    // window and is emitted raw instead of opening a filtered CSI.
+    try check("\xe2\x1bZ\x9b>4;2m", "\xe2");
+    // ESC immediately followed by the 8-bit introducer: both drop as a two-byte
+    // escape, so the parameters that follow are plain text.
+    try check("\xe2\x1b\x9b>4;2m", "\xe2>4;2m");
+    // A whitelisted CSI between the lead and the introducer must not rearm it.
+    try check("\xe2\x1b[0m\x9b>4;2m", "\xe2\x1b[0m");
+}
+
+test "CR mid-codepoint disarms the sequence" {
+    // Child progress output uses CR; it must not be mistaken for a continuation
+    // nor leave the counter armed for whatever follows.
+    try check("\xe2\ry", "\xe2\ry");
+    try check("\xe2\r\x9b>4;2m", "\xe2\r");
+}
+
+test "an ill-formed sequence split across feed() calls still drops" {
+    var buf: Buf = .{};
+    defer buf.deinit();
+    var s = ts.Sanitizer.init();
+    try s.feed("\xed", buf.sink());
+    try s.feed("\xa0", buf.sink());
+    try s.feed("\x9b>4;2m", buf.sink());
+    try s.flush(buf.sink());
+    try testing.expectEqualSlices(u8, "\xed", buf.list.items);
+}
+
 // ── OSC always dropped ──────────────────────────────────────────────
 
 test "OSC 52 clipboard attempt dropped" {


### PR DESCRIPTION
## Description

The terminal sanitizer decided how many raw bytes to trust by asking how long a UTF-8 sequence *would* be, not whether it was legal. Ill-formed input therefore opened a short window in which raw 8-bit CSI/OSC introducers reached the terminal without passing the escape filter at all - a hostile formula's post_install output could drive terminal extensions or attempt a clipboard write. Bytes are now validated per position, so only well-formed UTF-8 passes and every escape byte still goes through the existing filter.

## Related Issue

- None

## Notes for Reviewers

- None