### PR TITLE
fix(ui): stop child output from repainting lines it never wrote

### DIFF
--- a/scripts/regressions/csi-whitelist-ignores-private-parameter-bytes.sh
+++ b/scripts/regressions/csi-whitelist-ignores-private-parameter-bytes.sh
@@ -71,7 +71,7 @@ test "private-parameter and intermediate CSI forms drop" {
         "\x1b[=5m",
         "\x1b[0;1$m",
         "\x1b[!K",
-        "\x1b[ A", // SL (scroll left) smuggled under the cursor-up arm
+        "\x1b[ A", // SL (scroll left) must not read as any whitelisted final
     };
     for (hostile) |bad| {
         var b: Buf = .{};
@@ -88,7 +88,7 @@ test "legitimate numeric sequences still pass byte-identically" {
         "\x1b[4:3m", // SGR subparameters: curly underline
         "\x1b[2K",
         "\x1b[2J",
-        "\x1b[3A",
+        "\x1b[5C",
     };
     for (good) |ok| {
         var b: Buf = .{};

--- a/scripts/regressions/unbounded-relative-cursor-motion-enables-spoofing.sh
+++ b/scripts/regressions/unbounded-relative-cursor-motion-enables-spoofing.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Regression: the CSI whitelist admitted A/B/E/F with any count, so a child could
+# emit `ESC[999A`, erase the line and repaint it -- a deterministic seek to any
+# earlier row of the visible screen. H/f were banned to deny exactly that
+# primitive; relative motion handed it back. Capping the count only prices the
+# attack (small hops repeat, and any count clamps at the viewport edge), so
+# vertical motion drops outright and CR remains the way to redraw a line.
+#
+# The sanitizer has no standalone CLI surface (it wraps child stdout/stderr), so
+# a standalone ReleaseSafe `zig test` harness drives Sanitizer.feed/flush through
+# a capturing sink and asserts on the emitted bytes. It checks both directions:
+# every vertical form drops to nothing, and CR progress plus horizontal motion
+# still pass byte-identically -- so deleting the whitelist does not make it pass.
+#
+# Exits 0 when the bug is absent, non-zero (with a clear message) when present.
+# No network required; finishes well under 30s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+
+# The standalone harness proves the byte-level property directly, but it cannot
+# notice the real tests being deleted, so guard their names too.
+while IFS= read -r name; do
+  if ! grep -Fqs -- "$name" "$ROOT/tests/term_sanitize_test.zig"; then
+    echo "FAIL: the cursor motion test is missing from tests/term_sanitize_test.zig: $name" >&2
+    exit 1
+  fi
+done <<'NAMES'
+vertical cursor motion dropped
+CR still redraws the child's own line
+a seek split across feed() calls still drops
+NAMES
+
+# The harness imports the sanitizer via a repo-relative path, so it must sit at
+# the repo root for the source tree's module boundary to resolve; $$ keeps
+# concurrent runs from clobbering each other's file.
+HARNESS="$ROOT/.relative-motion-regression.$$.zig"
+trap 'rm -f "$HARNESS"' EXIT
+
+cat >"$HARNESS" <<'ZIG'
+const std = @import("std");
+const ts = @import("src/ui/term_sanitize.zig");
+
+const Buf = struct {
+    list: std.ArrayList(u8) = .empty,
+
+    fn sink(self: *Buf) ts.Sink {
+        return .{ .ctx = self, .write_fn = writeFn };
+    }
+    fn writeFn(ctx: *anyopaque, bytes: []const u8) ts.SinkError!void {
+        const self: *Buf = @ptrCast(@alignCast(ctx));
+        self.list.appendSlice(std.testing.allocator, bytes) catch return error.WriteFailed;
+    }
+    fn deinit(self: *Buf) void {
+        self.list.deinit(std.testing.allocator);
+    }
+};
+
+fn run(input: []const u8, out: *Buf) !void {
+    var s = ts.Sanitizer.init();
+    try s.feed(input, out.sink());
+    try s.flush(out.sink());
+}
+
+test "a seek across the viewport loses its motion" {
+    // The line erase stays: the child owns the line it is writing. Only the
+    // vertical seek onto rows malt printed is dropped.
+    var b: Buf = .{};
+    defer b.deinit();
+    try run("\x1b[10A\x1b[2Kok: verified\x1b[10B", &b);
+    try std.testing.expectEqualStrings("\x1b[2Kok: verified", b.list.items);
+}
+
+test "every vertical motion form drops" {
+    const hostile = [_][]const u8{
+        "\x1b[A", // default count: still another line
+        "\x1b[1A", // one hop, repeatable to any distance
+        "\x1b[9A",
+        "\x1b[999A",
+        "\x1b[1B",
+        "\x1b[99B",
+        "\x1b[9E",
+        "\x1b[40F",
+        "\x1b[99999999999999999999A", // wider than any integer the parser could hold
+        "\x1b[0000000009A", // leading zeros hide the magnitude from a digit count
+        "\x1b[1;999A",
+        "\x9b9A", // the 8-bit CSI introducer must not be a second door
+    };
+    for (hostile) |bad| {
+        var b: Buf = .{};
+        defer b.deinit();
+        try run(bad, &b);
+        try std.testing.expectEqual(@as(usize, 0), b.list.items.len);
+    }
+}
+
+test "repeated small hops cannot accumulate into a seek" {
+    // The reason a count cap was not enough: nine of these reached 81 rows.
+    var b: Buf = .{};
+    defer b.deinit();
+    try run("\x1b[9A" ** 9, &b);
+    try std.testing.expectEqual(@as(usize, 0), b.list.items.len);
+}
+
+test "a seek split across write boundaries still drops" {
+    // The child picks its own write boundaries; the params buffer spans them.
+    var b: Buf = .{};
+    defer b.deinit();
+    var s = ts.Sanitizer.init();
+    try s.feed("a\x1b[9", b.sink());
+    try s.feed("9", b.sink());
+    try s.feed("Ab", b.sink());
+    try s.flush(b.sink());
+    try std.testing.expectEqualStrings("ab", b.list.items);
+}
+
+test "CR progress and horizontal motion still pass byte-identically" {
+    const good = [_][]const u8{
+        "50%\r100%", // in-place progress needs no CSI at all
+        "\x1b[C",
+        "\x1b[5C",
+        "\x1b[40G",
+        "\x1b[2K",
+        "\x1b[0m",
+        "\x1b[1;31m",
+    };
+    for (good) |ok| {
+        var b: Buf = .{};
+        defer b.deinit();
+        try run(ok, &b);
+        try std.testing.expectEqualStrings(ok, b.list.items);
+    }
+}
+ZIG
+
+if (cd "$ROOT" && zig test -OReleaseSafe "$HARNESS") >/dev/null 2>&1; then
+  echo "PASS: child output cannot reach another line"
+else
+  echo "FAIL: sanitized child output can still reach an earlier visible line" >&2
+  exit 1
+fi

--- a/src/ui/term_sanitize.zig
+++ b/src/ui/term_sanitize.zig
@@ -5,13 +5,15 @@
 //! UTF-8 (validated per byte position, so lone C1 controls in 0x80..0x9F
 //! drop while real multibyte output passes) +
 //! a whitelisted subset of CSI sequences, gated on the final byte AND
-//! numeric-only parameters: SGR colours, relative cursor motion
-//! (A–G/E/F), line erase (K), and visible-screen erase (J with no
-//! param or 0/1/2).
+//! numeric-only parameters: SGR colours, horizontal cursor motion
+//! (C/D/G), line erase (K), and visible-screen erase (J with no
+//! param or 0/1/2). CR passes too, so a child can still redraw the
+//! line it is writing.
 //! Everything else — OSC (including clipboard-reading OSC 52), DCS,
 //! SOS/PM/APC, 8-bit C1 introducers, absolute positioning (H/f),
-//! cursor save/restore (s/u), scrollback erase (CSI 3 J), other CSI
-//! commands, C0 controls, stray/mid-sequence ESC, and any CSI carrying
+//! cursor save/restore (s/u), vertical motion (A/B/E/F), scrollback
+//! erase (CSI 3 J), other CSI commands, C0 controls,
+//! stray/mid-sequence ESC, and any CSI carrying
 //! a private prefix or intermediate byte (`CSI > 4 ; 2 m` is XTMODKEYS,
 //! not SGR) — is dropped.
 //!
@@ -260,13 +262,12 @@ fn csiAllowed(final: u8, params: []const u8) bool {
     };
     return switch (final) {
         'm' => true, // SGR: colours, bold, underline
-        'A', 'B', 'C', 'D' => true, // cursor up/down/right/left
-        'E', 'F' => true, // cursor next/prev line
-        'G' => true, // cursor column
-        // H/f absolute positioning and s/u save/restore enable screen
-        // spoofing and no in-repo progress output uses them (relative motion
-        // only); dropped, keeping save/restore uniformly out (ESC 7/8 already
-        // drop as stray ESC).
+        // C/D move relative, G jumps to an absolute column; none leaves the line.
+        'C', 'D', 'G' => true,
+        // Vertical motion (A/B/E/F) joins H/f and s/u: each one puts the cursor
+        // on a line malt wrote, where the permitted erase can repaint it. No
+        // count is safe either, because the attack is net-zero (up, erase,
+        // forge, back down), so only removing the reach closes it.
         'J' => eraseDisplayAllowed(params), // reject CSI 3 J (erase scrollback)
         'K' => true, // erase line
         else => false,
@@ -288,10 +289,16 @@ fn eraseDisplayAllowed(params: []const u8) bool {
 // Full feed()/flush() byte-stream behaviour lives in tests/term_sanitize_test.zig;
 // these cover the file-private classifiers that the integration file can't reach.
 
-test "csiAllowed whitelists SGR/relative motion, drops positioning + save/restore" {
-    for ("mABCDEFGK") |f| try std.testing.expect(csiAllowed(f, ""));
-    // Absolute positioning (H/f) and cursor save/restore (s/u) are spoofing aids.
-    for ("Hfsu") |f| try std.testing.expect(!csiAllowed(f, ""));
+test "csiAllowed whitelists SGR/horizontal motion, drops every way onto another line" {
+    for ("mCDGK") |f| try std.testing.expect(csiAllowed(f, ""));
+    // Absolute positioning (H/f), save/restore (s/u) and vertical motion
+    // (A/B/E/F) all reach a line the child never wrote.
+    for ("HfsuABEF") |f| try std.testing.expect(!csiAllowed(f, ""));
+    // No count rehabilitates vertical motion; horizontal motion needs no cap
+    // because it cannot leave the current line.
+    for ([_][]const u8{ "", "1", "3", "999" }) |p| try std.testing.expect(!csiAllowed('A', p));
+    try std.testing.expect(csiAllowed('C', "999"));
+    try std.testing.expect(csiAllowed('G', "80"));
     // J is param-gated, not final-byte-only.
     try std.testing.expect(csiAllowed('J', "2"));
     try std.testing.expect(!csiAllowed('J', "3"));
@@ -311,7 +318,7 @@ test "csiAllowed rejects private-prefix and intermediate parameter bytes" {
     // Numeric params, including SGR subparameters, stay allowed.
     try std.testing.expect(csiAllowed('m', "1;31"));
     try std.testing.expect(csiAllowed('m', "4:3"));
-    try std.testing.expect(csiAllowed('A', "3"));
+    try std.testing.expect(csiAllowed('C', "3"));
 }
 
 test "eraseDisplayAllowed permits only visible-screen variants" {

--- a/tests/term_sanitize_test.zig
+++ b/tests/term_sanitize_test.zig
@@ -89,10 +89,34 @@ test "SGR with multiple params passes" {
     try check("\x1b[1;32;40mx", "\x1b[1;32;40mx");
 }
 
-// ── CSI cursor motion allowed ───────────────────────────────────────
+// ── CSI cursor motion ───────────────────────────────────────────────
 
-test "cursor up passes" {
-    try check("\x1b[3A", "\x1b[3A");
+test "horizontal motion passes" {
+    // The child already owns the line it is writing, so moving along it grants
+    // nothing a bare CR would not.
+    try check("\x1b[C", "\x1b[C");
+    try check("\x1b[5C", "\x1b[5C");
+    try check("\x1b[3D", "\x1b[3D");
+    try check("\x1b[40G", "\x1b[40G");
+}
+
+test "vertical cursor motion dropped" {
+    // Reaching another line is the whole spoofing primitive: with the line
+    // erase, a child that can move up repaints output malt printed. No count is
+    // safe -- small hops repeat, and any count clamps at the viewport edge --
+    // so A/B/E/F drop outright, like H/f.
+    try check("\x1b[10A\x1b[2Kok: verified\x1b[10B", "\x1b[2Kok: verified");
+    for ([_][]const u8{ "A", "1A", "3A", "999A", "1B", "99B", "9E", "10E", "40F", "0000000009A", "1;999A", "99999999999999999999A" }) |seq| {
+        var in: [40]u8 = undefined;
+        const s = std.fmt.bufPrint(&in, "a\x1b[{s}b", .{seq}) catch unreachable;
+        try check(s, "ab");
+    }
+}
+
+test "CR still redraws the child's own line" {
+    // The escape hatch the ban leaves open: in-place progress needs no CSI.
+    try check("50%\r100%", "50%\r100%");
+    try check("50%\r\x1b[2K100%", "50%\r\x1b[2K100%");
 }
 
 test "absolute cursor position dropped" {
@@ -296,6 +320,14 @@ test "CR mid-codepoint disarms the sequence" {
     try check("\xe2\r\x9b>4;2m", "\xe2\r");
 }
 
+test "8-bit CSI introducer cannot reach another line either" {
+    // 0x9B is CSI: the ban must not be bypassable through the 8-bit door.
+    try check("a\x9b99Ab", "ab");
+    try check("a\x9b9Ab", "ab");
+    // The 8-bit form of a permitted command still normalises to 7-bit ESC [.
+    try check("a\x9b5Cb", "a\x1b[5Cb");
+}
+
 test "an ill-formed sequence split across feed() calls still drops" {
     var buf: Buf = .{};
     defer buf.deinit();
@@ -364,6 +396,18 @@ test "CSI split across feed() calls is reassembled" {
     try s.feed("1mred\x1b[0m bye", buf.sink());
     try s.flush(buf.sink());
     try testing.expectEqualStrings("hi \x1b[31mred\x1b[0m bye", buf.list.items);
+}
+
+test "a seek split across feed() calls still drops" {
+    // A hostile child picks its own write boundaries; the final byte decides,
+    // and it can land in any chunk.
+    var buf: Buf = .{};
+    defer buf.deinit();
+    var s = ts.Sanitizer.init();
+    try s.feed("a\x1b[99", buf.sink());
+    try s.feed("Ab", buf.sink());
+    try s.flush(buf.sink());
+    try testing.expectEqualStrings("ab", buf.list.items);
 }
 
 test "OSC split across chunks is dropped end-to-end" {


### PR DESCRIPTION
## Description

The sanitizer let a formula's child move the cursor to another line, so
`ESC[999A` was a reliable seek to the top of the screen. With the line erase it
already permits, a hostile formula could blank and rewrite lines malt printed -
forging a `✓ signature verified` over malt's own output. Absolute positioning
was banned for exactly this; relative motion handed the same capability back.

Vertical motion now drops outright, alongside `H`/`f`. Capping the count was the
obvious smaller fix and does not work: the attack is net-zero (up, erase, forge,
back down), so no budget on cumulative drift ever sees it, and bounding maximum
excursion instead would need the viewport height and starting row - which a
blind byte filter cannot know. Removing the reach is what closes it. Horizontal
motion and CR are untouched, and CR is what in-place progress uses, so a child
can still redraw its own line.

## Related Issue

- None

## Notes for Reviewers

- Cost of the ban is a child doing *multi-line* redraw; its escapes drop and the
  text still prints. malt's own multi-line progress is unaffected - `progress.zig`
  writes through `output.zig`, never the sanitizer.
- The fix assumes the child's first byte lands on a line it owns. It does:
  `writePrefixLine` always terminates malt's own output with a newline, so CR
  plus the still-permitted erase cannot reach malt's text.