### PR TITLE
fix(tui): drop 8-bit control bytes from row content before it reaches the terminal

### DIFF
--- a/scripts/regressions/frame-putcontent-passes-lone-c1-bytes.sh
+++ b/scripts/regressions/frame-putcontent-passes-lone-c1-bytes.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Regression: Frame.putContent filtered row content with a flat byte switch that
+# dropped 0x00-0x1F and 0x7F and passed everything else. Every byte >= 0x80 was
+# therefore treated as "printable or continuation" with no notion of a pending
+# sequence, so a lone 8-bit C1 introducer -- 0x9B (CSI), 0x9D (OSC), 0x9C (ST) --
+# in a row reached the terminal verbatim, on an already-positioned cursor.
+#
+# putContent has no CLI surface (it paints into a TUI frame that needs a pty), so
+# a standalone ReleaseSafe `zig test` harness drives Frame.putContent directly and
+# asserts on the emitted bytes. It checks both directions: no hostile row emits a
+# byte in 0x80..0x9F, and legitimate UTF-8 -- including a codepoint whose own
+# continuation byte is 0x9B -- still passes byte-identically, so a blanket C1 drop
+# does not make it pass.
+#
+# Exits 0 when the bug is absent, non-zero (with a clear message) when present.
+# No network required; finishes well under 30s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+
+# The standalone harness proves the byte-level property directly, but it cannot
+# notice the real tests being deleted, so guard their names too.
+while IFS= read -r name; do
+  if ! grep -Fqs -- "$name" "$ROOT/src/tui/tab.zig"; then
+    echo "FAIL: the C1 row-content test is missing from src/tui/tab.zig: $name" >&2
+    exit 1
+  fi
+done <<'NAMES'
+putContent drops a lone 8-bit C1 introducer from row content
+putContent passes well-formed UTF-8 through byte-identically
+putContent state is per call, so a split rune cannot arm the next row
+NAMES
+
+# The harness imports the tab module via a repo-relative path, so it must sit at
+# the repo root for `../ui/*.zig` to resolve; $$ keeps concurrent runs from
+# clobbering each other's file.
+HARNESS="$ROOT/.putcontent-c1-regression.$$.zig"
+trap 'rm -f "$HARNESS"' EXIT
+
+cat >"$HARNESS" <<'ZIG'
+const std = @import("std");
+const tab = @import("src/tui/tab.zig");
+
+fn paint(buf: []u8, bytes: []const u8) []const u8 {
+    var f: tab.Frame = .{ .buf = buf };
+    f.putContent(bytes);
+    return f.slice();
+}
+
+const hostile = [_][]const u8{
+    "\x9b31mX", // lone 8-bit CSI: an SGR a hostile package name might carry
+    "a\x9d0;pwn\x9c", // 8-bit OSC title-set closed by an 8-bit ST
+    "\xc0\xaf", // overlong: C0 is never a legal lead
+    "\x80", // lone continuation byte
+    "\xf5\x9b\x9d", // invalid lead: would have armed a 3-byte window
+};
+
+test "putContent drops a lone 8-bit C1 introducer from row content" {
+    for (hostile) |bad| {
+        var buf: [64]u8 = undefined;
+        for (paint(&buf, bad)) |b| try std.testing.expect(b < 0x80 or b > 0x9F);
+    }
+}
+
+test "putContent passes well-formed UTF-8 through byte-identically" {
+    // U+065B is the case that matters: its continuation byte IS 0x9B, so a
+    // blanket C1 drop would fail here.
+    const good = [_][]const u8{ "caf\u{00e9} \u{2014} \u{1d7f6}", "\xd9\x9b", "\xed\x9b\x80" };
+    for (good) |ok| {
+        var buf: [64]u8 = undefined;
+        try std.testing.expectEqualStrings(ok, paint(&buf, ok));
+    }
+}
+ZIG
+
+if (cd "$ROOT" && zig test -OReleaseSafe "$HARNESS") >/dev/null 2>&1; then
+  echo "PASS: a lone 8-bit control byte cannot reach the frame through row content"
+else
+  echo "FAIL: Frame.putContent still lets a lone 8-bit control byte reach the frame" >&2
+  exit 1
+fi

--- a/src/tui/layout.zig
+++ b/src/tui/layout.zig
@@ -1,11 +1,11 @@
 //! malt — responsive layout engine for `mt tui`.
 //!
-//! Leaf module: imports only `std` and the read-only `ui/term_sanitize` helper
-//! (via `scroll_list`). The frame is a *pure function of `(cols, rows)`* so a
-//! terminal resize is just a re-render, not a data refetch, and the whole layer
-//! is testable without a PTY. Splits the screen into five stacked, full-width
-//! regions — header / tab-bar / filter / content / footer — and, below a minimum size,
-//! renders a clean "terminal too small" fallback instead of a corrupt frame.
+//! Leaf module: imports only `std` and `scroll_list`. The frame is a *pure
+//! function of `(cols, rows)`* so a terminal resize is just a re-render, not a
+//! data refetch, and the whole layer is testable without a PTY. Splits the
+//! screen into five stacked, full-width regions — header / tab-bar / filter /
+//! content / footer — and, below a minimum size, renders a clean "terminal too
+//! small" fallback instead of a corrupt frame.
 //! Nothing here touches the terminal, so a degenerate size yields the fallback,
 //! never a panic that would bypass the caller's `errdefer` restoration.
 

--- a/src/tui/scroll_list.zig
+++ b/src/tui/scroll_list.zig
@@ -99,7 +99,8 @@ fn escapeEnd(row: []const u8, i: usize) usize {
 }
 
 /// Byte length of the rune at `row[i]`, clamped to what remains. An invalid lead
-/// byte counts as one raw byte (term_sanitize passes UTF-8 through unvalidated).
+/// counts as one byte: this measures pre-scrub bytes, so it only has to avoid
+/// splitting one — whether the byte survives is `putContent`'s call.
 fn runeLen(row: []const u8, i: usize) usize {
     const want = std.unicode.utf8ByteSequenceLength(row[i]) catch return 1;
     return @min(@as(usize, want), row.len - i);
@@ -145,7 +146,8 @@ test "truncate handles an empty row and an all-escape row" {
 }
 
 test "truncate counts an invalid UTF-8 byte as one raw column and never splits it" {
-    // 0xff is never a valid lead; treat it as one opaque byte (term_sanitize stance).
+    // 0xff is never a valid lead; count it as one column rather than splitting it.
+    // Truncation runs before the scrub, so a dropped byte only ever shrinks a row.
     try std.testing.expectEqualStrings("a\xff", truncate("a\xffb", 2));
     try std.testing.expectEqualStrings("a", truncate("a\xffb", 1)); // stops before the bad byte
 }

--- a/src/tui/tab.zig
+++ b/src/tui/tab.zig
@@ -17,6 +17,7 @@ const layout = @import("layout.zig");
 const filter_input = @import("filter_input.zig");
 const keys = @import("keys.zig");
 const term = @import("term.zig");
+const term_sanitize = @import("../ui/term_sanitize.zig");
 
 pub const Key = keys.Key;
 pub const Rect = layout.Rect;
@@ -79,18 +80,26 @@ pub const Frame = struct {
     }
 
     /// Paint untrusted row content as inert text: TAB becomes a space and every
-    /// C0 control byte — ESC included — plus DEL is dropped, so a child-derived
-    /// row can neither re-drive the cursor (ESC/CSI), set the window title (OSC),
-    /// inject an extra frame line (LF/CR/VT/FF), nor disturb column alignment
-    /// (TAB). Printable bytes and UTF-8 continuation bytes (≥ 0x80) pass through.
+    /// control byte is dropped, so a child-derived row can neither re-drive the
+    /// cursor (ESC/CSI), set the window title (OSC), inject an extra frame line
+    /// (LF/CR/VT/FF), nor disturb column alignment (TAB). Only well-formed UTF-8
+    /// passes: a lone 0x9B/0x9D is an 8-bit CSI/OSC that needs no ESC, and only
+    /// the pending-sequence state tells it from a continuation byte — so
+    /// `term_sanitize.passableByte` owns that rule for both choke points.
     /// Every tab paints row content through here, so frame integrity is enforced
-    /// in this one choke point rather than trusted to each renderer.
+    /// in this one place rather than trusted to each renderer.
     pub fn putContent(self: *Frame, bytes: []const u8) void {
-        for (bytes) |b| switch (b) {
-            '\t' => self.put(" "), // tab: collapse to one column
-            0x00...0x08, 0x0a...0x1f, 0x7f => {}, // C0 controls (incl. ESC), CR/LF, DEL: drop
-            else => self.put(&[_]u8{b}),
-        };
+        // Per call, not a Frame field: a codepoint never spans two calls, so a
+        // reused Frame cannot inherit a half-armed sequence from the last frame.
+        var st: term_sanitize.Utf8State = .{};
+        for (bytes) |b| {
+            if (!term_sanitize.passableByte(b, &st)) continue;
+            switch (b) {
+                '\t' => self.put(" "), // tab: collapse to one column
+                '\n' => {}, // passable for the stream caller; a row must not break the line
+                else => self.put(&[_]u8{b}),
+            }
+        }
     }
 };
 
@@ -381,10 +390,10 @@ test "Frame.moveClear positions then erases to end of line" {
     try std.testing.expectEqualStrings("\x1b[3;5H\x1b[K", f.slice());
 }
 
-test "Frame.putContent strips line breakers and turns tab into a space" {
+test "Frame.putContent strips line breakers and DEL, and turns tab into a space" {
     var buf: [32]u8 = undefined;
     var f: Frame = .{ .buf = &buf };
-    f.putContent("a\nb\tc\rd\x0b\x0ce"); // LF, TAB, CR, VT, FF
+    f.putContent("a\nb\tc\rd\x0b\x0ce\x7f"); // LF, TAB, CR, VT, FF, DEL
     try std.testing.expectEqualStrings("ab cde", f.slice());
 }
 
@@ -405,6 +414,44 @@ test "putContent strips the control introducers from a hostile row (OSC + BEL + 
     try std.testing.expect(std.mem.indexOfScalar(u8, out, 0x1b) == null); // no ESC → no CSI/OSC executes
     try std.testing.expect(std.mem.indexOfScalar(u8, out, 0x07) == null); // BEL dropped
     try std.testing.expect(std.mem.indexOf(u8, out, "x") != null and std.mem.indexOf(u8, out, "y") != null);
+}
+
+test "putContent drops a lone 8-bit C1 introducer from row content" {
+    var buf: [64]u8 = undefined;
+    // A lone 0x9B/0x9D/0x9C is an 8-bit CSI/OSC/ST: no ESC, yet a terminal that
+    // honours C1 controls executes it on the cursor moveClear just positioned.
+    for ([_][]const u8{
+        "\x9b31mX",
+        "a\x9d0;pwn\x9c",
+        "\xc0\xaf", // overlong: C0 is never a legal lead
+        "\x80", // lone continuation byte
+        "\xf5\x9b\x9d", // invalid lead: a length classifier would arm 3 bytes here
+    }) |bad| {
+        var f: Frame = .{ .buf = &buf };
+        f.putContent(bad);
+        for (f.slice()) |b| try std.testing.expect(b < 0x80 or b > 0x9F);
+    }
+}
+
+test "putContent passes well-formed UTF-8 through byte-identically" {
+    var buf: [64]u8 = undefined;
+    // U+065B's own continuation byte is 0x9B, and app.zig paints a 4-byte
+    // U+1D7F6: the filter must be UTF-8-aware, not a blanket C1 drop.
+    for ([_][]const u8{ "caf\u{00e9} \u{2014} \u{1d7f6}", "\u{065b}", "\u{d6c0}" }) |ok| {
+        var f: Frame = .{ .buf = &buf };
+        f.putContent(ok);
+        try std.testing.expectEqualStrings(ok, f.slice());
+    }
+}
+
+test "putContent state is per call, so a split rune cannot arm the next row" {
+    var buf: [64]u8 = undefined;
+    var f: Frame = .{ .buf = &buf };
+    f.putContent("a\xe2\x80"); // a rune cut short by a narrow-width hard break
+    f.putContent("\x94b"); // fresh state: the orphan tail is a lone continuation
+    // The truncated prefix stays as the maximal subpart a decoder eats as one
+    // error; what must not happen is the next row completing it.
+    try std.testing.expectEqualStrings("a\xe2\x80b", f.slice());
 }
 
 test "paintRows self-erases every painted row so a shorter repaint drops no tail" {

--- a/src/ui/term_sanitize.zig
+++ b/src/ui/term_sanitize.zig
@@ -176,7 +176,7 @@ pub const Sanitizer = struct {
 /// Pending multibyte sequence. `lo`/`hi` bound the *next* byte, which is what
 /// separates a well-formed encoding from an overlong, surrogate or
 /// out-of-range one — a plain 0x80..0xBF range check cannot tell them apart.
-const Utf8State = struct {
+pub const Utf8State = struct {
     remaining: u2 = 0,
     lo: u8 = 0x80,
     hi: u8 = 0xBF,
@@ -200,13 +200,13 @@ fn leadState(b: u8) ?Utf8State {
 }
 
 /// Shared pass predicate. The pending-sequence state is what tells a real
-/// continuation from a lone C1 control, so both callers must classify through
+/// continuation from a lone C1 control, so every caller must classify through
 /// here rather than reimplement the rule.
 ///
 /// Emission stays byte-at-a-time: every byte that passes is part of a
 /// well-formed prefix, so a later rejection leaves a maximal subpart that a
 /// strict decoder eats as one error rather than resyncing into it as C1.
-fn passableByte(b: u8, st: *Utf8State) bool {
+pub fn passableByte(b: u8, st: *Utf8State) bool {
     if (st.remaining > 0) {
         if (b >= st.lo and b <= st.hi) {
             st.remaining -= 1;


### PR DESCRIPTION
## Description

A TUI row could carry a raw 8-bit C1 control byte - `0x9B` (CSI), `0x9D` (OSC), `0x9C` (ST) - straight to the terminal. Row content was filtered by a flat byte switch that passed everything at or above `0x80`, so a terminal honouring 8-bit controls would execute the sequence on a cursor the frame had just positioned. No feed reaches it today, but the gate depended on `std.json`'s incidental strictness rather than on a rule of its own.

Row content now passes through the same UTF-8 classifier the child-output sanitizer already uses, so both places malt writes untrusted bytes to a terminal enforce one rule instead of two that disagree. Well-formed UTF-8 - including glyphs whose continuation byte happens to be `0x9B` - still renders unchanged.

## Related Issue

- None

## Notes for Reviewers

- The UTF-8-encoded form (`C2 9B`) still passes and is deliberately left open: closing it needs a codepoint-level rule affecting both callers, tracked separately.
