### PR TITLE
fix(post-install): stop native post_install children from seeing malt's secrets

### DIFF
--- a/justfile
+++ b/justfile
@@ -37,6 +37,7 @@ install:
 regressions-static:
     @./scripts/regressions/tap-resolution-contract.sh
     @./scripts/regressions/relocated-store-logic-version-pin.sh
+    @./scripts/regressions/post-install-native-spawns-inherit-full-environment.sh
     @./scripts/test/bench_release_resolution_test.sh
 
 # Run unit tests + cheap static regression guards.

--- a/scripts/regressions/post-install-native-spawns-inherit-full-environment.sh
+++ b/scripts/regressions/post-install-native-spawns-inherit-full-environment.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Regression: the native post_install_steps executor spawned every child with
+# `environ_map = null`. malt's Io is seeded from the real process environ, so
+# null means *inherit everything*, not *inherit nothing*: a tap-controlled
+# `run` binary saw MALT_*_TOKEN and the user's full PATH. The sandbox fence
+# denies network but allows file writes under /tmp and the keg, `process-exec*`
+# over that inherited PATH, and stdout is inherited straight into CI logs.
+#
+# The sibling spawn surfaces (the Ruby path and the DSL `system` builtin)
+# already scrub. No CLI subcommand drives the executor without a network
+# install, so a standalone `zig test` harness feeds it a synthetic formula
+# whose `run` step dumps its own environment, and asserts the secret is gone,
+# PATH is the minimal sandbox one, and an allowlisted locale var survives
+# (a scrub, not a wipe).
+#
+# The harness MUST seed Threaded's environ: with the default `.empty` the
+# child inherits nothing and the assertion passes on broken code.
+#
+# Exits 0 when the bug is absent, non-zero (with a clear message) when
+# present. No network required; finishes well under 30s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+STUBS=$(mktemp -d)
+
+# The harness imports the executor via a repo-relative path, so it must sit at
+# the repo root: the module's sibling imports (`dsl/sandbox.zig`,
+# `../fs/atomic.zig`) only resolve from inside the source tree.
+HARNESS="$ROOT/.post-install-env-scrub-regression.zig"
+trap 'rm -rf "$STUBS" "$HARNESS"' EXIT
+
+# The executor's module graph reaches the clonefile/statfs bindings that
+# build.zig generates with translate-c. Only the `copy` step calls them and
+# this harness never runs one, so declarations are enough to link.
+cat >"$STUBS/c_clonefile.zig" <<'ZIG'
+pub extern "c" fn clonefile(src: [*:0]const u8, dst: [*:0]const u8, flags: c_uint) c_int;
+ZIG
+cat >"$STUBS/c_mount.zig" <<'ZIG'
+pub const struct_statfs = extern struct { f_fstypename: [16]u8 };
+pub extern "c" fn statfs(path: [*:0]const u8, buf: *struct_statfs) c_int;
+ZIG
+
+cat >"$HARNESS" <<'ZIG'
+const std = @import("std");
+const steps = @import("src/core/post_install_steps.zig");
+const macos_sandbox = @import("src/core/sandbox/macos.zig");
+
+const secret = "MALT_GITHUB_TOKEN=probe-sentinel-do-not-leak";
+const locale = "LANG=en_US.UTF-8";
+
+test "a run step's child cannot see malt's own environment" {
+    const environ: std.process.Environ = .{ .block = .{ .slice = &[_:null]?[*:0]const u8{
+        secret,
+        locale,
+        "PATH=/probe/attacker/bin:/usr/bin:/bin",
+    } } };
+
+    // Seeded exactly like main.zig: this is what `environ_map = null` inherits.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{ .environ = environ });
+    defer threaded.deinit();
+    const io = threaded.io();
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const prefix = path_buf[0..try std.Io.Dir.realPath(tmp.dir, io, &path_buf)];
+
+    const keg = try std.fmt.allocPrint(a, "{s}/Cellar/probe/1.0", .{prefix});
+    const libexec = try std.fmt.allocPrint(a, "{s}/libexec", .{keg});
+    try std.Io.Dir.cwd().createDirPath(io, libexec);
+    try std.Io.Dir.cwd().createDirPath(io, try std.fmt.allocPrint(a, "{s}/etc", .{prefix}));
+
+    const seen = try std.fmt.allocPrint(a, "{s}/etc/seen.txt", .{prefix});
+    const script = try std.fmt.allocPrint(a, "{s}/post-install", .{libexec});
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, script, .{});
+        defer f.close(io);
+        var w = f.writer(io, &.{});
+        try w.interface.print("#!/bin/sh\n/usr/bin/env > '{s}'\n", .{seen});
+        try w.interface.flush();
+        try f.setPermissions(io, @enumFromInt(0o755));
+    }
+
+    var flog = steps.FallbackLog.init(std.testing.allocator);
+    defer flog.deinit();
+    const ctx: steps.StepsCtx = .{
+        .io = io,
+        .allocator = a,
+        .name = "probe",
+        .version = "1.0",
+        .prefix = prefix,
+        .keg_path = keg,
+        .flog = &flog,
+        .environ = environ,
+    };
+
+    const formula =
+        \\{"name":"probe","versions":{"stable":"1.0"},"post_install_steps":
+        \\[{"type":"run","command":{"base":"libexec","path":"post-install"}}]}
+    ;
+    try std.testing.expect(steps.execute(ctx, formula));
+
+    const f = std.Io.Dir.openFileAbsolute(io, seen, .{}) catch return error.RunStepDidNotExecute;
+    defer f.close(io);
+    var buf: [64 * 1024]u8 = undefined;
+    var r = f.reader(io, &.{});
+    const dump = buf[0..try r.interface.readSliceShort(&buf)];
+
+    if (std.mem.indexOf(u8, dump, "probe-sentinel") != null) {
+        std.debug.print("child environment carried malt's forge token\n", .{});
+        return error.ForgeTokenLeakedToPostInstallChild;
+    }
+    var it = std.mem.splitScalar(u8, dump, '\n');
+    const got_path = while (it.next()) |line| {
+        if (std.mem.startsWith(u8, line, "PATH=")) break line["PATH=".len..];
+    } else "";
+    if (!std.mem.eql(u8, got_path, macos_sandbox.sandbox_path)) {
+        std.debug.print("want PATH '{s}', got '{s}'\n", .{ macos_sandbox.sandbox_path, got_path });
+        return error.ParentPathLeakedToPostInstallChild;
+    }
+    // Proves the base is a scrub and not a wipe: build/locale keys still pass.
+    if (std.mem.indexOf(u8, dump, locale) == null) {
+        std.debug.print("allowlisted locale var did not reach the child\n", .{});
+        return error.AllowlistedEnvDropped;
+    }
+}
+ZIG
+
+run_harness() {
+  (cd "$ROOT" && zig test -lc \
+    --dep c_clonefile --dep c_mount \
+    -Mroot="$HARNESS" \
+    -Mc_clonefile="$STUBS/c_clonefile.zig" \
+    -Mc_mount="$STUBS/c_mount.zig")
+}
+
+if run_harness >/dev/null 2>&1; then
+  echo "PASS: native post_install children get a scrubbed environment"
+else
+  run_harness 2>&1 | grep -Ev '\.\.\.OK$' | tail -20 >&2
+  echo "FAIL: a native post_install child saw malt's environment (forge token / user PATH)" >&2
+  exit 1
+fi

--- a/src/core/dsl/builtins/process.zig
+++ b/src/core/dsl/builtins/process.zig
@@ -80,64 +80,16 @@ fn buildArgv(ctx: ExecCtx, args: []const Value) BuiltinError![]const []const u8 
     return argv.toOwnedSlice(ctx.allocator);
 }
 
-const inherited_env_keys = std.StaticStringMap(void).initComptime(.{
-    .{ "LANG", {} },
-    .{ "LC_ALL", {} },
-    .{ "LC_CTYPE", {} },
-    .{ "TERM", {} },
-    .{ "SDKROOT", {} },
-    .{ "MACOSX_DEPLOYMENT_TARGET", {} },
-    .{ "CC", {} },
-    .{ "CXX", {} },
-    .{ "CFLAGS", {} },
-    .{ "CPPFLAGS", {} },
-    .{ "CXXFLAGS", {} },
-    .{ "LDFLAGS", {} },
-    .{ "MAKEFLAGS", {} },
-});
-
-/// Return the environment visible to formula code. Values that describe the
-/// installation are derived from the current sandbox instead of trusting the
-/// parent process; only non-secret build and locale settings are inherited.
+/// Formula-visible environment. The contract lives next to the sandbox
+/// profile so the native post_install executor spawns with the same one.
 fn formulaEnvValue(ctx: ExecCtx, key: []const u8) BuiltinError!?[]const u8 {
-    if (std.mem.eql(u8, key, "HOME")) return ctx.malt_prefix;
-    if (std.mem.eql(u8, key, "PATH")) return macos_sandbox.sandbox_path;
-    if (std.mem.eql(u8, key, "MALT_PREFIX") or std.mem.eql(u8, key, "HOMEBREW_PREFIX"))
-        return ctx.malt_prefix;
-    if (std.mem.eql(u8, key, "HOMEBREW_CELLAR"))
-        return std.fmt.allocPrint(ctx.allocator, "{s}/Cellar", .{ctx.malt_prefix}) catch
-            return BuiltinError.OutOfMemory;
-    if (std.mem.eql(u8, key, "TMPDIR")) return "/tmp";
-    if (inherited_env_keys.has(key)) return std.process.Environ.getPosix(ctx.environ, key);
-    return null;
+    return macos_sandbox.formulaEnvValue(ctx.allocator, ctx.environ, ctx.malt_prefix, key) catch
+        BuiltinError.OutOfMemory;
 }
 
 fn buildFormulaEnv(ctx: ExecCtx) BuiltinError!std.process.Environ.Map {
-    var map = std.process.Environ.Map.init(ctx.allocator);
-    errdefer map.deinit();
-    for ([_][]const u8{
-        "HOME",
-        "PATH",
-        "MALT_PREFIX",
-        "HOMEBREW_PREFIX",
-        "HOMEBREW_CELLAR",
-        "TMPDIR",
-        "LANG",
-        "LC_ALL",
-        "LC_CTYPE",
-        "TERM",
-        "SDKROOT",
-        "MACOSX_DEPLOYMENT_TARGET",
-        "CC",
-        "CXX",
-        "CFLAGS",
-        "CPPFLAGS",
-        "CXXFLAGS",
-        "LDFLAGS",
-        "MAKEFLAGS",
-    }) |key| if (try formulaEnvValue(ctx, key)) |value|
-        map.put(key, value) catch return BuiltinError.OutOfMemory;
-    return map;
+    return macos_sandbox.buildFormulaEnv(ctx.allocator, ctx.environ, ctx.malt_prefix) catch
+        BuiltinError.OutOfMemory;
 }
 
 /// system — execute a command

--- a/src/core/post_install_steps.zig
+++ b/src/core/post_install_steps.zig
@@ -997,7 +997,7 @@ fn stepRun(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
         logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "{s} not found", .{cmd}) catch cmd);
         return false;
     }
-    return spawnFenced(ctx, argv.items, null, std.fs.path.basename(cmd), .{});
+    return spawnFenced(ctx, argv.items, &.{}, std.fs.path.basename(cmd), .{});
 }
 
 // --- data-dir initialisers ---------------------------------------------------
@@ -1086,7 +1086,7 @@ fn stepInitDataDir(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
     // non-empty data dir, and they create their own subtrees.
     const tmpdir = std.fmt.allocPrint(ctx.allocator, "{s}/var/tmp", .{ctx.prefix}) catch return false;
     std.Io.Dir.cwd().createDirPath(ctx.io, tmpdir) catch {};
-    if (spawnFenced(ctx, plan.argv, null, using, .{ .allow_ipc = true })) return true;
+    if (spawnFenced(ctx, plan.argv, &.{}, using, .{ .allow_ipc = true })) return true;
     // A failed initialiser can leave a partial data dir; mysql/mariadb
     // then refuse the non-empty dir on every retry. Remove what this run
     // created so the next install/upgrade starts clean. postgres already
@@ -1135,21 +1135,20 @@ fn stepGdkPixbufQueryLoaders(ctx: StepsCtx) bool {
     // must exist up front — same real-dirs-at-prefix layout brew links.
     if (!confined(ctx, env.moduledir)) return false;
     std.Io.Dir.cwd().createDirPath(ctx.io, env.moduledir) catch {};
-    var env_map = std.process.Environ.Map.init(ctx.allocator);
-    defer env_map.deinit();
-    env_map.put("GDK_PIXBUF_MODULEDIR", env.moduledir) catch return false;
-    env_map.put("GDK_PIXBUF_MODULE_FILE", env.module_file) catch return false;
-    return runFormulaToolEnv(ctx, "gdk-pixbuf", "gdk-pixbuf-query-loaders", &.{"--update-cache"}, &env_map);
+    return runFormulaToolEnv(ctx, "gdk-pixbuf", "gdk-pixbuf-query-loaders", &.{"--update-cache"}, &.{
+        .{ .key = "GDK_PIXBUF_MODULEDIR", .value = env.moduledir },
+        .{ .key = "GDK_PIXBUF_MODULE_FILE", .value = env.module_file },
+    });
 }
 
 /// Spawn `<prefix>/opt/<formula>/bin/<exe>` through the same argv lint +
 /// sandbox fence as the DSL `system` builtin. Failure routes exactly like
 /// a failed formula `system` call.
 fn runFormulaTool(ctx: StepsCtx, tool_formula: []const u8, exe: []const u8, args: []const []const u8) bool {
-    return runFormulaToolEnv(ctx, tool_formula, exe, args, null);
+    return runFormulaToolEnv(ctx, tool_formula, exe, args, &.{});
 }
 
-fn runFormulaToolEnv(ctx: StepsCtx, tool_formula: []const u8, exe: []const u8, args: []const []const u8, env_map: ?*const std.process.Environ.Map) bool {
+fn runFormulaToolEnv(ctx: StepsCtx, tool_formula: []const u8, exe: []const u8, args: []const []const u8, extra_env: []const EnvVar) bool {
     const tool = std.fmt.allocPrint(ctx.allocator, "{s}/opt/{s}/bin/{s}", .{ ctx.prefix, tool_formula, exe }) catch return false;
     if (!fileExists(ctx.io, tool)) {
         logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "{s} not found (is {s} installed?)", .{ exe, tool_formula }) catch exe);
@@ -1160,13 +1159,25 @@ fn runFormulaToolEnv(ctx: StepsCtx, tool_formula: []const u8, exe: []const u8, a
     argv.append(ctx.allocator, tool) catch return false;
     argv.appendSlice(ctx.allocator, args) catch return false;
 
-    return spawnFenced(ctx, argv.items, env_map, exe, .{});
+    return spawnFenced(ctx, argv.items, extra_env, exe, .{});
+}
+
+/// Step-specific variable layered on top of the scrubbed base environment.
+const EnvVar = struct { key: []const u8, value: []const u8 };
+
+fn buildChildEnv(ctx: StepsCtx, extra_env: []const EnvVar) error{OutOfMemory}!std.process.Environ.Map {
+    var map = try sandbox_macos.buildFormulaEnv(ctx.allocator, ctx.environ, ctx.prefix);
+    errdefer map.deinit();
+    for (extra_env) |v| try map.put(v.key, v.value);
+    return map;
 }
 
 /// Argv lint + sandbox fence + spawn + wait — the one exec chokepoint for
 /// every tool and initialiser step. `label` names the child in the log.
 /// `opts` carries per-spawn fence knobs (IPC only for the DB initialisers).
-fn spawnFenced(ctx: StepsCtx, argv: []const []const u8, env_map: ?*const std.process.Environ.Map, label: []const u8, opts: sandbox_macos.ProfileOpts) bool {
+/// The child always starts from the scrubbed formula environment; `extra_env`
+/// layers onto it, so no caller can fall back to inheriting malt's own.
+fn spawnFenced(ctx: StepsCtx, argv: []const []const u8, extra_env: []const EnvVar, label: []const u8, opts: sandbox_macos.ProfileOpts) bool {
     sandbox.validateArgv(argv, ctx.keg_path, ctx.prefix) catch {
         logViolation(ctx, argv[0]);
         return false;
@@ -1176,10 +1187,16 @@ fn spawnFenced(ctx: StepsCtx, argv: []const []const u8, env_map: ?*const std.pro
         return false;
     };
 
+    var env_map = buildChildEnv(ctx, extra_env) catch {
+        logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "{s} failed to spawn", .{label}) catch label);
+        return false;
+    };
+    defer env_map.deinit();
+
     var child = std.process.spawn(ctx.io, .{
         .argv = fenced,
         .stdout = if (ctx.suppress_child_stdout) .ignore else .inherit,
-        .environ_map = env_map,
+        .environ_map = &env_map,
     }) catch {
         logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "{s} failed to spawn", .{label}) catch label);
         return false;
@@ -2574,6 +2591,106 @@ test "run executes the formula's own helper with its arguments expanded" {
 
     // The created directory proves the child saw an expanded argument.
     try testing.expect(dirExists(h.io, try std.fmt.allocPrint(a, "{s}/var/lib/dbus", .{h.prefix})));
+}
+
+/// A secret plus an allowlisted locale var, shaped like malt's real environ.
+const test_secret_environ: std.process.Environ = .{ .block = .{ .slice = &[_:null]?[*:0]const u8{
+    "MALT_GITHUB_TOKEN=sentinel-must-not-leak",
+    "LANG=en_US.UTF-8",
+    "PATH=/attacker/bin:/usr/bin:/bin",
+} } };
+
+test "run hands the child a scrubbed environment, not malt's own" {
+    // Seed the Io from the same environ main.zig seeds it from: with the
+    // default `.empty` the child inherits nothing and this cannot observe an
+    // inherit-everything spawn.
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{ .environ = test_secret_environ });
+    defer threaded.deinit();
+    var h = try TestHarness.init();
+    defer h.deinit();
+    h.io = threaded.io();
+    h.environ = test_secret_environ;
+    const a = h.arena.allocator();
+
+    const libexec = try std.fmt.allocPrint(a, "{s}/libexec", .{h.keg});
+    try std.Io.Dir.cwd().createDirPath(h.io, libexec);
+    try std.Io.Dir.cwd().createDirPath(h.io, try std.fmt.allocPrint(a, "{s}/etc", .{h.prefix}));
+    const seen = try std.fmt.allocPrint(a, "{s}/etc/seen.txt", .{h.prefix});
+    {
+        const f = try std.Io.Dir.createFileAbsolute(h.io, try std.fmt.allocPrint(a, "{s}/post-install", .{libexec}), .{});
+        defer f.close(h.io);
+        var w = f.writer(h.io, &.{});
+        // Split literals: scripts/lint-spawn-invariants.sh greps src/ for
+        // these argv shapes, string literals inside tests included.
+        try w.interface.print("#!" ++ "/bin/" ++ "sh\n/usr/bin/" ++ "env > '{s}'\n", .{seen});
+        try w.interface.flush();
+        try f.setPermissions(h.io, @enumFromInt(0o755));
+    }
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"run","command":{"base":"libexec","path":"post-install"}}]
+    )));
+    try testing.expect(!h.flog.hasErrors());
+
+    var buf: [64 * 1024]u8 = undefined;
+    const f = try std.Io.Dir.openFileAbsolute(h.io, seen, .{});
+    defer f.close(h.io);
+    var r = f.reader(h.io, &.{});
+    const dump = buf[0..try r.interface.readSliceShort(&buf)];
+
+    // The forge token and the user's PATH are the two the fence cannot cover:
+    // the profile allows process-exec* and keg/tmp writes.
+    try testing.expect(std.mem.indexOf(u8, dump, "sentinel-must-not-leak") == null);
+    try testing.expect(std.mem.indexOf(u8, dump, "/attacker/bin") == null);
+    try testing.expect(std.mem.indexOf(u8, dump, "PATH=" ++ sandbox_macos.sandbox_path ++ "\n") != null);
+    // A scrub, not a wipe: build/locale keys still reach the child, and HOME
+    // points at the prefix as it does for the DSL `system` builtin.
+    try testing.expect(std.mem.indexOf(u8, dump, "LANG=en_US.UTF-8\n") != null);
+    try testing.expect(std.mem.indexOf(u8, dump, try std.fmt.allocPrint(a, "HOME={s}\n", .{h.prefix})) != null);
+}
+
+test "a tool step's own env vars layer onto the scrubbed base" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{ .environ = test_secret_environ });
+    defer threaded.deinit();
+    var h = try TestHarness.init();
+    defer h.deinit();
+    h.io = threaded.io();
+    h.environ = test_secret_environ;
+    const a = h.arena.allocator();
+
+    // gdk-pixbuf-query-loaders is the one step that sets its own variables;
+    // it derives them from the versioned module dir under the prefix.
+    try std.Io.Dir.cwd().createDirPath(h.io, try std.fmt.allocPrint(a, "{s}/opt/gdk-pixbuf/lib/gdk-pixbuf-2.0/2.10.0", .{h.prefix}));
+    const bin = try std.fmt.allocPrint(a, "{s}/opt/gdk-pixbuf/bin", .{h.prefix});
+    try std.Io.Dir.cwd().createDirPath(h.io, bin);
+    const seen = try std.fmt.allocPrint(a, "{s}/etc/seen.txt", .{h.prefix});
+    try std.Io.Dir.cwd().createDirPath(h.io, try std.fmt.allocPrint(a, "{s}/etc", .{h.prefix}));
+    {
+        const f = try std.Io.Dir.createFileAbsolute(h.io, try std.fmt.allocPrint(a, "{s}/gdk-pixbuf-query-loaders", .{bin}), .{});
+        defer f.close(h.io);
+        var w = f.writer(h.io, &.{});
+        try w.interface.print("#!" ++ "/bin/" ++ "sh\n/usr/bin/" ++ "env > '{s}'\n", .{seen});
+        try w.interface.flush();
+        try f.setPermissions(h.io, @enumFromInt(0o755));
+    }
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"gdk_pixbuf_query_loaders"}]
+    )));
+    try testing.expect(!h.flog.hasErrors());
+
+    var buf: [64 * 1024]u8 = undefined;
+    const f = try std.Io.Dir.openFileAbsolute(h.io, seen, .{});
+    defer f.close(h.io);
+    var r = f.reader(h.io, &.{});
+    const dump = buf[0..try r.interface.readSliceShort(&buf)];
+
+    try testing.expect(std.mem.indexOf(u8, dump, "GDK_PIXBUF_MODULEDIR=") != null);
+    try testing.expect(std.mem.indexOf(u8, dump, "GDK_PIXBUF_MODULE_FILE=") != null);
+    // The step used to replace the whole environment with those two, leaving
+    // the tool without a PATH; they now sit on top of the scrubbed base.
+    try testing.expect(std.mem.indexOf(u8, dump, "PATH=" ++ sandbox_macos.sandbox_path ++ "\n") != null);
+    try testing.expect(std.mem.indexOf(u8, dump, "sentinel-must-not-leak") == null);
 }
 
 test "run refuses the execution fields malt does not honour" {

--- a/src/core/post_install_steps.zig
+++ b/src/core/post_install_steps.zig
@@ -2633,8 +2633,10 @@ test "run executes the formula's own helper with its arguments expanded" {
 }
 
 /// A secret plus an allowlisted locale var, shaped like malt's real environ.
+/// The stand-in name is deliberate: the tap-resolution contract guard keeps
+/// the real forge-token literal inside the forge seam.
 const test_secret_environ: std.process.Environ = .{ .block = .{ .slice = &[_:null]?[*:0]const u8{
-    "MALT_GITHUB_TOKEN=sentinel-must-not-leak",
+    "MALT_SECRET_PROBE=sentinel-must-not-leak",
     "LANG=en_US.UTF-8",
     "PATH=/attacker/bin:/usr/bin:/bin",
 } } };

--- a/src/core/post_install_steps.zig
+++ b/src/core/post_install_steps.zig
@@ -1086,7 +1086,9 @@ fn stepInitDataDir(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
     // non-empty data dir, and they create their own subtrees.
     const tmpdir = std.fmt.allocPrint(ctx.allocator, "{s}/var/tmp", .{ctx.prefix}) catch return false;
     std.Io.Dir.cwd().createDirPath(ctx.io, tmpdir) catch {};
-    if (spawnFenced(ctx, plan.argv, &.{}, using, .{ .allow_ipc = true })) return true;
+    // initdb takes no --tmpdir, so TMPDIR is the only way to keep its scratch
+    // space inside the prefix, where the fence grants file creation.
+    if (spawnFenced(ctx, plan.argv, &.{.{ .key = "TMPDIR", .value = tmpdir }}, using, .{ .allow_ipc = true })) return true;
     // A failed initialiser can leave a partial data dir; mysql/mariadb
     // then refuse the non-empty dir on every retry. Remove what this run
     // created so the next install/upgrade starts clean. postgres already
@@ -2357,6 +2359,43 @@ test "init_data_dir removes a datadir it created when the initialiser fails" {
     try testing.expect(execute(h.ctx(), step_json));
     const f = std.Io.Dir.openFileAbsolute(io, try std.fmt.allocPrint(a, "{s}/precious", .{datadir}), .{}) catch return error.TestUnexpectedResult;
     f.close(io);
+}
+
+test "init_data_dir points the initialiser at a tmpdir the fence can create in" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    var h = try TestHarness.init();
+    defer h.deinit();
+    h.io = threaded.io();
+    const a = h.arena.allocator();
+
+    const keg_bin = try std.fmt.allocPrint(a, "{s}/bin", .{h.keg});
+    try std.Io.Dir.cwd().createDirPath(h.io, keg_bin);
+    try std.Io.Dir.cwd().createDirPath(h.io, try std.fmt.allocPrint(a, "{s}/etc", .{h.prefix}));
+    const seen = try std.fmt.allocPrint(a, "{s}/etc/seen.txt", .{h.prefix});
+    {
+        const f = try std.Io.Dir.createFileAbsolute(h.io, try std.fmt.allocPrint(a, "{s}/initdb", .{keg_bin}), .{});
+        defer f.close(h.io);
+        var w = f.writer(h.io, &.{});
+        try w.interface.print("#!" ++ "/bin/" ++ "sh\n/usr/bin/" ++ "env > '{s}'\n", .{seen});
+        try w.interface.flush();
+        try f.setPermissions(h.io, @enumFromInt(0o755));
+    }
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"init_data_dir","path":{"base":"var","path":"postgresql"},"using":"postgresql_initdb"}]
+    )));
+    try testing.expect(!h.flog.hasErrors());
+
+    var buf: [64 * 1024]u8 = undefined;
+    const f = try std.Io.Dir.openFileAbsolute(h.io, seen, .{});
+    defer f.close(h.io);
+    var r = f.reader(h.io, &.{});
+    const dump = buf[0..try r.interface.readSliceShort(&buf)];
+
+    // initdb takes no --tmpdir, so TMPDIR is its only handle on scratch space.
+    // The fence grants create under the prefix but only write-data under /tmp.
+    try testing.expect(std.mem.indexOf(u8, dump, try std.fmt.allocPrint(a, "TMPDIR={s}/var/tmp\n", .{h.prefix})) != null);
 }
 
 test "init_data_dir with a missing initialiser binary fails loudly" {

--- a/src/core/sandbox/macos.zig
+++ b/src/core/sandbox/macos.zig
@@ -607,7 +607,7 @@ test "buildFormulaEnv derives install paths and drops what is not allowlisted" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const environ: std.process.Environ = .{ .block = .{ .slice = &[_:null]?[*:0]const u8{
-        "MALT_GITHUB_TOKEN=secret",
+        "MALT_SECRET_PROBE=secret",
         "DYLD_INSERT_LIBRARIES=/tmp/evil.dylib",
         "RUBYOPT=-rexploit",
         "PATH=/attacker/bin:/usr/bin",
@@ -624,7 +624,7 @@ test "buildFormulaEnv derives install paths and drops what is not allowlisted" {
     try std.testing.expectEqualStrings("/opt/malt/Cellar", map.get("HOMEBREW_CELLAR").?);
     try std.testing.expectEqualStrings("/tmp", map.get("TMPDIR").?);
     try std.testing.expectEqualStrings("en_US.UTF-8", map.get("LANG").?);
-    try std.testing.expect(map.get("MALT_GITHUB_TOKEN") == null);
+    try std.testing.expect(map.get("MALT_SECRET_PROBE") == null);
     try std.testing.expect(map.get("DYLD_INSERT_LIBRARIES") == null);
     try std.testing.expect(map.get("RUBYOPT") == null);
 }

--- a/src/core/sandbox/macos.zig
+++ b/src/core/sandbox/macos.zig
@@ -39,6 +39,66 @@ pub const ScrubbedEnv = struct {
 /// Minimal PATH — keeps a hostile formula off user-owned bin prefixes.
 pub const sandbox_path: []const u8 = "/usr/bin:/bin:/usr/sbin:/sbin";
 
+/// Non-secret build and locale settings a formula may legitimately read.
+/// Everything else — forge tokens, DYLD_*, RUBYOPT/RUBYLIB — is dropped.
+const inherited_env_keys = std.StaticStringMap(void).initComptime(.{
+    .{ "LANG", {} },
+    .{ "LC_ALL", {} },
+    .{ "LC_CTYPE", {} },
+    .{ "TERM", {} },
+    .{ "SDKROOT", {} },
+    .{ "MACOSX_DEPLOYMENT_TARGET", {} },
+    .{ "CC", {} },
+    .{ "CXX", {} },
+    .{ "CFLAGS", {} },
+    .{ "CPPFLAGS", {} },
+    .{ "CXXFLAGS", {} },
+    .{ "LDFLAGS", {} },
+    .{ "MAKEFLAGS", {} },
+});
+
+const formula_env_keys = [_][]const u8{
+    "HOME",
+    "PATH",
+    "MALT_PREFIX",
+    "HOMEBREW_PREFIX",
+    "HOMEBREW_CELLAR",
+    "TMPDIR",
+} ++ inherited_env_keys.keys();
+
+/// Value a formula child sees for `key`, or null when the key is not visible.
+/// Installation-describing values are derived from the sandbox rather than
+/// trusted from the parent process.
+pub fn formulaEnvValue(
+    allocator: std.mem.Allocator,
+    environ: std.process.Environ,
+    malt_prefix: []const u8,
+    key: []const u8,
+) error{OutOfMemory}!?[]const u8 {
+    if (std.mem.eql(u8, key, "HOME")) return malt_prefix;
+    if (std.mem.eql(u8, key, "PATH")) return sandbox_path;
+    if (std.mem.eql(u8, key, "MALT_PREFIX") or std.mem.eql(u8, key, "HOMEBREW_PREFIX")) return malt_prefix;
+    if (std.mem.eql(u8, key, "HOMEBREW_CELLAR"))
+        return try std.fmt.allocPrint(allocator, "{s}/Cellar", .{malt_prefix});
+    if (std.mem.eql(u8, key, "TMPDIR")) return "/tmp";
+    if (inherited_env_keys.has(key)) return std.process.Environ.getPosix(environ, key);
+    return null;
+}
+
+/// The environment every formula-controlled child is spawned with. Shared by
+/// the DSL `system`/`safe_popen_read` builtins and the native steps executor.
+pub fn buildFormulaEnv(
+    allocator: std.mem.Allocator,
+    environ: std.process.Environ,
+    malt_prefix: []const u8,
+) error{OutOfMemory}!std.process.Environ.Map {
+    var map = std.process.Environ.Map.init(allocator);
+    errdefer map.deinit();
+    for (formula_env_keys) |key|
+        if (try formulaEnvValue(allocator, environ, malt_prefix, key)) |value| try map.put(key, value);
+    return map;
+}
+
 /// Where the sandboxed child's stdout/stderr land. Production passes the
 /// process's real fd 1/2; tests redirect to `/dev/null` so subprocess
 /// chatter doesn't leak past `output.beginStderrCapture` into the build
@@ -542,6 +602,46 @@ const Scratch = struct {
         self.arena.deinit();
     }
 };
+
+test "buildFormulaEnv derives install paths and drops what is not allowlisted" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const environ: std.process.Environ = .{ .block = .{ .slice = &[_:null]?[*:0]const u8{
+        "MALT_GITHUB_TOKEN=secret",
+        "DYLD_INSERT_LIBRARIES=/tmp/evil.dylib",
+        "RUBYOPT=-rexploit",
+        "PATH=/attacker/bin:/usr/bin",
+        "HOME=/Users/ada",
+        "LANG=en_US.UTF-8",
+    } } };
+
+    var map = try buildFormulaEnv(arena.allocator(), environ, "/opt/malt");
+    defer map.deinit();
+
+    try std.testing.expectEqualStrings("/opt/malt", map.get("HOME").?);
+    try std.testing.expectEqualStrings(sandbox_path, map.get("PATH").?);
+    try std.testing.expectEqualStrings("/opt/malt", map.get("HOMEBREW_PREFIX").?);
+    try std.testing.expectEqualStrings("/opt/malt/Cellar", map.get("HOMEBREW_CELLAR").?);
+    try std.testing.expectEqualStrings("/tmp", map.get("TMPDIR").?);
+    try std.testing.expectEqualStrings("en_US.UTF-8", map.get("LANG").?);
+    try std.testing.expect(map.get("MALT_GITHUB_TOKEN") == null);
+    try std.testing.expect(map.get("DYLD_INSERT_LIBRARIES") == null);
+    try std.testing.expect(map.get("RUBYOPT") == null);
+}
+
+test "buildFormulaEnv omits allowlisted keys the parent never set" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var map = try buildFormulaEnv(arena.allocator(), .empty, "/opt/malt");
+    defer map.deinit();
+
+    try std.testing.expect(map.get("LANG") == null);
+    try std.testing.expect(map.get("CFLAGS") == null);
+    // Derived keys never depend on the parent, so an empty environ still
+    // yields a usable child environment rather than an empty one.
+    try std.testing.expectEqualStrings(sandbox_path, map.get("PATH").?);
+    try std.testing.expectEqualStrings("/opt/malt", map.get("HOME").?);
+}
 
 test "validatePathForProfile accepts normal absolute paths" {
     try validatePathForProfile("/opt/malt");


### PR DESCRIPTION
## Description

Declarative `post_install_steps` ran their children with malt's own environment, so tap-controlled code could read forge tokens and exec off the user's `PATH`.
The sandbox fence denies network but not that. Children now get the same scrubbed environment the DSL `system` builtin and the Ruby path already build, and steps that need their own variables layer them on top instead of replacing
the lot.

Two behaviour improvements fall out: the gdk-pixbuf cache step no longer runs with an empty environment, and the database initialisers get scratch space inside the prefix, where the fence actually permits file creation.

## Related Issue

- None

## Notes for Reviewers

- `run` steps now see the minimal sandbox `PATH` instead of the user's. That is deliberate and matches what the Ruby path and the DSL `system` builtin have always done; this executor was the only one exempt.