### PR TITLE
fix(net): refuse a cleartext hop when resolving a redirecting artifact URL

### DIFF
--- a/scripts/regressions/head-resolved-follows-https-to-http-downgrade.sh
+++ b/scripts/regressions/head-resolved-follows-https-to-http-downgrade.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Regression: the manual HEAD redirect loop must refuse a hop that drops from
+# https to cleartext.
+#
+# The bug: `headResolved` checked the caller-supplied URL once with
+# `requireSecureOrigin`, then followed `Location` for up to five hops with no
+# further scheme inspection — while both GET loops already compared the hop's
+# scheme against the origin's and returned `TlsDowngradeRefused`. An https cask
+# URL that 301s to `http://` therefore issued a cleartext HEAD, and the
+# `final_url` plus `Content-Disposition` harvested from that response are what
+# pick the cask's artifact type — `.pkg` being the one that routes the install
+# through `sudo installer -target /`.
+#
+# The fix routes all three loops through one `nextHopUrl` helper that resolves
+# the location against the current base and refuses the downgrade in one place,
+# so the rule cannot drift between them again.
+#
+# Presenting a real https origin needs a TLS fixture, so the guard is judged
+# through the colocated inline unit tests (`lib_tests`). This script builds and
+# runs only that binary: no network, well under 30s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+SRC="src/net/client.zig"
+TEST_NAME="nextHopUrl refuses an https to http downgrade"
+
+# If the guard or its test is ever dropped, the unit binary would go green
+# vacuously. Fail loudly instead.
+if ! grep -Fqs -- "$TEST_NAME" "$SRC"; then
+  echo "FAIL: the downgrade-refusal test is missing from $SRC" >&2
+  exit 1
+fi
+if ! grep -Fqs -- "nextHopUrl" "$SRC"; then
+  echo "FAIL: the shared redirect-hop helper is missing from $SRC" >&2
+  exit 1
+fi
+
+# Every loop must route its hop through the helper. Asserting the pre-fix shape
+# is absent is the load-bearing half: a range-extraction check could run away
+# and pass on a reverted body, and a gate that fails open is worse than none.
+if grep -Fqs -- "replaceFinalUrl(loc)" "$SRC"; then
+  echo "FAIL: headResolved still follows Location without a scheme check" >&2
+  exit 1
+fi
+if [[ "$(grep -Fc -- "nextHopUrl(uri, loc)" "$SRC")" -ne 3 ]]; then
+  echo "FAIL: not all three redirect loops resolve their hop through the helper" >&2
+  exit 1
+fi
+
+BIN="$ROOT/zig-out/test-bin/lib_tests"
+# Always rebuild so the binary reflects current source — a prebuilt lib_tests
+# could predate the fix. Zig's cache makes a no-op rebuild cheap.
+if ! zig build test-bin >/dev/null 2>&1; then
+  echo "FAIL: could not build the unit test binary (zig build test-bin)" >&2
+  exit 1
+fi
+
+OUT=$("$BIN" 2>&1) && STATUS=0 || STATUS=$?
+if [[ "$STATUS" -ne 0 ]]; then
+  echo "FAIL: an https to http redirect hop was accepted" >&2
+  printf '%s\n' "$OUT" | grep -iE "failed|leaked|panic" >&2 || true
+  exit 1
+fi
+
+echo "PASS: redirect hops refuse an https to http downgrade"

--- a/src/net/client.zig
+++ b/src/net/client.zig
@@ -680,7 +680,16 @@ pub const HttpClient = struct {
             const status: u16 = @intFromEnum(response.head.status);
             if (status >= 301 and status <= 308) {
                 if (response.head.location) |loc| {
-                    try resolved.replaceFinalUrl(loc);
+                    const next = self.nextHopUrl(uri, loc) catch |e| switch (e) {
+                        // A refusal must reach the caller: silently returning the
+                        // pre-hop url would read as a successful resolution.
+                        error.OutOfMemory, error.TlsDowngradeRefused => return e,
+                        // A malformed Location ends resolution here, as it did
+                        // when the raw value failed to parse on the next hop.
+                        else => break,
+                    };
+                    defer self.allocator.free(next);
+                    try resolved.replaceFinalUrl(next);
                     continue;
                 }
             }
@@ -965,6 +974,19 @@ pub const HttpClient = struct {
         return try out.toOwnedSlice();
     }
 
+    /// Resolve one redirect hop, refusing it when the origin's TLS is dropped.
+    /// Shared by all three redirect loops so the rule cannot drift between them.
+    /// Resolving first matters: a relative `Location` carries no scheme and
+    /// would otherwise read as a downgrade. Caller owns the returned slice.
+    fn nextHopUrl(self: *HttpClient, base: std.Uri, location: []const u8) ![]const u8 {
+        const next = try self.resolveRedirectUrl(base, location);
+        errdefer self.allocator.free(next);
+        const next_uri = std.Uri.parse(next) catch return error.HttpRedirectLocationInvalid;
+        if (schemeIsHttps(base.scheme) and !schemeIsHttps(next_uri.scheme))
+            return error.TlsDowngradeRefused;
+        return next;
+    }
+
     /// Release a request whose response carries no body. stdlib's `deinit`
     /// decides by method alone, so on a bodiless status it drains until the
     /// peer closes — on a keep-alive 304 that is a full idle timeout.
@@ -1003,7 +1025,6 @@ pub const HttpClient = struct {
 
         while (true) : (hops += 1) {
             const uri = try std.Uri.parse(current);
-            const https_origin = schemeIsHttps(uri.scheme);
 
             var req = try self.client.request(.GET, uri, .{
                 .extra_headers = live_creds,
@@ -1021,11 +1042,8 @@ pub const HttpClient = struct {
                 // than hand the redirect's body back to the caller as a "success".
                 const loc = response.head.location orelse return error.HttpRedirectLocationMissing;
                 if (hops >= max_get_redirects) return error.TooManyHttpRedirects;
-                const next = try self.resolveRedirectUrl(uri, loc);
+                const next = try self.nextHopUrl(uri, loc);
                 errdefer self.allocator.free(next);
-                const next_uri = std.Uri.parse(next) catch return error.HttpRedirectLocationInvalid;
-                if (https_origin and !schemeIsHttps(next_uri.scheme))
-                    return error.TlsDowngradeRefused;
                 if (!credsSurviveRedirect(current, next)) live_creds = &.{};
                 // Hop committed: no fallible op past here, so the errdefers
                 // stay dormant while we hand `req`/`current` off cleanly.
@@ -1177,7 +1195,6 @@ pub const HttpClient = struct {
 
         while (true) : (hops += 1) {
             const uri = std.Uri.parse(current) catch return error.RequestFailed;
-            const https_origin = schemeIsHttps(uri.scheme);
 
             var req = self.client.request(.GET, uri, .{
                 .extra_headers = live_creds,
@@ -1193,14 +1210,12 @@ pub const HttpClient = struct {
             if (isFollowableRedirect(status)) {
                 const loc = response.head.location orelse return error.HttpRedirectInvalid;
                 if (hops >= max_get_redirects) return error.TooManyHttpRedirects;
-                const next = self.resolveRedirectUrl(uri, loc) catch |e| switch (e) {
+                const next = self.nextHopUrl(uri, loc) catch |e| switch (e) {
                     error.OutOfMemory => return error.OutOfMemory,
+                    error.TlsDowngradeRefused => return error.TlsDowngradeRefused,
                     else => return error.HttpRedirectInvalid,
                 };
                 errdefer self.allocator.free(next);
-                const next_uri = std.Uri.parse(next) catch return error.HttpRedirectInvalid;
-                if (https_origin and !schemeIsHttps(next_uri.scheme))
-                    return error.TlsDowngradeRefused;
                 if (!credsSurviveRedirect(current, next)) live_creds = &.{};
                 req.deinit();
                 self.allocator.free(current);
@@ -1989,6 +2004,84 @@ test "credsSurviveRedirect: dropped on https to http downgrade" {
 
 test "credsSurviveRedirect: dropped for a look-alike suffix without a dot boundary" {
     try std.testing.expect(!HttpClient.credsSurviveRedirect("https://github.com/x", "https://evilgithub.com/y"));
+}
+
+// --- redirect hop resolution (shared by the HEAD and both GET loops) ---
+
+fn expectHop(base_url: []const u8, location: []const u8, want: []const u8) !void {
+    const a = std.testing.allocator;
+    var http = HttpClient.init(std.Options.debug_io, .empty, a);
+    defer http.deinit();
+    const next = try http.nextHopUrl(try std.Uri.parse(base_url), location);
+    defer a.free(next);
+    try std.testing.expectEqualStrings(want, next);
+}
+
+fn expectHopError(base_url: []const u8, location: []const u8, want: anyerror) !void {
+    const a = std.testing.allocator;
+    var http = HttpClient.init(std.Options.debug_io, .empty, a);
+    defer http.deinit();
+    try std.testing.expectError(want, http.nextHopUrl(try std.Uri.parse(base_url), location));
+}
+
+test "nextHopUrl refuses an https to http downgrade" {
+    // The headers harvested from the hop pick a cask's artifact type, and the
+    // pkg type reaches `sudo installer -target /`.
+    try expectHopError("https://example.com/a", "http://example.com/b", error.TlsDowngradeRefused);
+}
+
+test "nextHopUrl refuses a downgrade announced with an upper-case scheme" {
+    try expectHopError("https://example.com/a", "HTTP://example.com/b", error.TlsDowngradeRefused);
+}
+
+test "nextHopUrl allows an https to https hop" {
+    try expectHop("https://example.com/a", "https://cdn.example.com/b", "https://cdn.example.com/b");
+}
+
+test "nextHopUrl allows a cleartext origin to hop to cleartext" {
+    // Loopback fixtures dial http and must keep working; the rule is "do not
+    // lose TLS", not "require TLS" — the origin guard already decides that.
+    try expectHop("http://127.0.0.1:8080/a", "http://127.0.0.1:9090/b", "http://127.0.0.1:9090/b");
+}
+
+test "nextHopUrl allows a cleartext origin to upgrade to https" {
+    try expectHop("http://example.com/a", "https://example.com/b", "https://example.com/b");
+}
+
+test "nextHopUrl keeps a relative location on the base scheme" {
+    // A relative Location carries no scheme, so it must be resolved before the
+    // comparison or every relative hop would read as a downgrade.
+    try expectHop("https://example.com/a/b", "/c", "https://example.com/c");
+    try expectHop("http://127.0.0.1:8080/a/b", "/c", "http://127.0.0.1:8080/c");
+}
+
+test "nextHopUrl inherits the base scheme for a scheme-relative location" {
+    try expectHop("https://example.com/a", "//cdn.example.com/b", "https://cdn.example.com/b");
+}
+
+test "nextHopUrl accepts a location landing exactly on the size cap" {
+    // Pins which side of the cap is inclusive, so the reject test above cannot
+    // drift into rejecting locations that were always legal.
+    const a = std.testing.allocator;
+    const at_cap = try a.alloc(u8, 8 * 1024);
+    defer a.free(at_cap);
+    at_cap[0] = '/';
+    @memset(at_cap[1..], 'a');
+
+    var want: std.Io.Writer.Allocating = .init(a);
+    defer want.deinit();
+    try want.writer.writeAll("https://example.com");
+    try want.writer.writeAll(at_cap);
+
+    try expectHop("https://example.com/a", at_cap, want.written());
+}
+
+test "nextHopUrl rejects an oversize location before resolving it" {
+    const a = std.testing.allocator;
+    const huge = try a.alloc(u8, 9 * 1024);
+    defer a.free(huge);
+    @memset(huge, 'x');
+    try expectHopError("https://example.com/a", huge, error.HttpRedirectLocationOversize);
 }
 
 test "isFollowableRedirect: follows 301/302/303/307/308" {

--- a/tests/net_redirect_auth_test.zig
+++ b/tests/net_redirect_auth_test.zig
@@ -21,6 +21,8 @@ const Hop = struct {
     target_len: usize = 0,
     // When set, answer 302 to this Location; otherwise 200 with `blob_body`.
     redirect_to: ?[]const u8 = null,
+    // When set, the 200 carries this Content-Disposition.
+    content_disposition: ?[]const u8 = null,
 };
 
 // Serves exactly one request. Records whether the client sent Authorization and
@@ -49,6 +51,10 @@ fn serveOne(hop: *Hop) void {
         req.respond("redirecting\n", .{
             .status = .found,
             .extra_headers = &.{.{ .name = "location", .value = loc }},
+        }) catch return;
+    } else if (hop.content_disposition) |cd| {
+        req.respond(blob_body, .{
+            .extra_headers = &.{.{ .name = "content-disposition", .value = cd }},
         }) catch return;
     } else {
         req.respond(blob_body, .{}) catch return;
@@ -167,4 +173,50 @@ test "auth headers kept across a same-host redirect" {
     try std.testing.expectEqual(@as(u16, 200), resp.status);
     try std.testing.expect(hop1.saw_auth);
     try std.testing.expect(hop2.saw_auth);
+}
+
+test "headResolved follows a hop and harvests the artifact headers from it" {
+    // The HEAD loop is what picks a cask's artifact type, and it was the one
+    // redirect loop with no fixture coverage. The scheme-relative Location also
+    // pins that a hop is resolved against the base rather than taken verbatim.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const cd = "attachment; filename=\"artifact.zip\"";
+    var l2 = try bindIp4(io);
+    defer l2.deinit(io);
+    const p2 = l2.socket.address.getPort();
+    var hop2 = Hop{ .io = io, .listener = &l2, .content_disposition = cd };
+    const t2 = try std.Thread.spawn(.{}, serveOne, .{&hop2});
+
+    var loc_buf: [64]u8 = undefined;
+    const loc = try std.fmt.bufPrint(&loc_buf, "//127.0.0.1:{d}/artifact", .{p2});
+
+    var l1 = try bindIp4(io);
+    defer l1.deinit(io);
+    const p1 = l1.socket.address.getPort();
+    var hop1 = Hop{ .io = io, .listener = &l1, .redirect_to = loc };
+    const t1 = try std.Thread.spawn(.{}, serveOne, .{&hop1});
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/start", .{p1});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+    defer http.deinit();
+
+    const result = http.headResolved(url);
+
+    t1.join();
+    t2.join();
+
+    var resolved = try result;
+    defer resolved.deinit();
+
+    var want_buf: [64]u8 = undefined;
+    const want = try std.fmt.bufPrint(&want_buf, "http://127.0.0.1:{d}/artifact", .{p2});
+    try std.testing.expectEqualStrings(want, resolved.final_url);
+    try std.testing.expectEqualStrings(cd, resolved.content_disposition.?);
+    try std.testing.expectEqualStrings("/artifact", hopTarget(&hop2));
 }


### PR DESCRIPTION
## Description

Resolving a cask's artifact URL over HEAD checked the caller's URL once and then followed `Location` blindly, so an https origin that redirects to `http://` silently continued over cleartext. The headers harvested from that hop decide the cask's artifact type - including the `.pkg` type that routes an install through `sudo installer` - so an on-path attacker got to pick the classification.

Both GET loops already refused that hop. All three now share one hop-resolution helper, so the rule holds everywhere and cannot drift apart again. A refusal degrades to "unsupported cask format" instead of a download.

## Related Issue

- None

## Notes for Reviewers

- Cleartext origins still hop to cleartext; the rule is "do not lose TLS", not "require TLS" - that call stays with the origin guard.
- Relative locations are resolved before the comparison, so the HEAD loop now follows a relative redirect it previously abandoned.
