### PR TITLE
fix(net): stop passing off a failed artifact-URL resolution as a successful one

### DIFF
--- a/scripts/regressions/head-resolved-redirect-range-and-swallowed-errors.sh
+++ b/scripts/regressions/head-resolved-redirect-range-and-swallowed-errors.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Regression: the manual HEAD redirect loop must follow only real redirects,
+# and must report a failed walk as a failure.
+#
+# Two defects lived in the same loop. It gated the follow on a raw
+# `301..308` range instead of the `isFollowableRedirect` predicate twelve
+# lines above it, so 304/305/306 — none of them redirects — had their
+# `Location` followed. And every transport failure (`Uri.parse`, `request`,
+# `sendBodiless`, `receiveHead`) did a bare `break`, which is the same exit
+# the terminal-response path takes: a DNS failure before hop 0 came back
+# indistinguishable from a resolved URL. The cask installer then classified
+# that untouched extensionless URL as `.unknown` and told the user
+# "Unsupported cask format" when the truth was that the network was down.
+#
+# Both halves are loopback-reproducible, so the fixture test binary is the
+# honest gate here. Source preconditions guard the one-line predicate call
+# from drifting back, and are written fail-closed: they assert the pre-fix
+# shape is ABSENT rather than trying to prove a shape is present.
+#
+# No network, no temp state, well under 30s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+SRC="src/net/client.zig"
+CONSUMER="src/cli/install.zig"
+
+if grep -Fqs -- "status >= 301 and status <= 308" "$SRC"; then
+  echo "FAIL: the HEAD loop still follows non-redirect statuses" >&2
+  exit 1
+fi
+if ! grep -Fqs -- "isFollowableRedirect(status)" "$SRC"; then
+  echo "FAIL: the HEAD loop no longer uses the follow predicate" >&2
+  exit 1
+fi
+
+# A bare `catch break` on a transport call is the swallow. The loop must
+# surface the failure instead.
+if grep -Eqs -- "(request|sendBodiless|receiveHead)\(.*\) catch break" "$SRC"; then
+  echo "FAIL: a transport failure in the HEAD loop is still swallowed" >&2
+  exit 1
+fi
+
+# The consumer must keep the error channel it was widened to, or the honest
+# error would be flattened back into the misleading format message.
+if grep -Fqs -- "http.headResolved(url) catch return .unknown" "$CONSUMER"; then
+  echo "FAIL: the cask installer still reports a network failure as an unknown format" >&2
+  exit 1
+fi
+
+# Always rebuild so the binaries reflect current source. Zig's cache makes a
+# no-op rebuild cheap.
+if ! zig build test-bin >/dev/null 2>&1; then
+  echo "FAIL: could not build the test binaries (zig build test-bin)" >&2
+  exit 1
+fi
+
+for name in net_redirect_auth_test lib_tests; do
+  BIN="$ROOT/zig-out/test-bin/$name"
+  OUT=$("$BIN" 2>&1) && STATUS=0 || STATUS=$?
+  if [[ "$STATUS" -ne 0 ]]; then
+    echo "FAIL: $name — a non-redirect hop was followed or a failed walk was reported as resolved" >&2
+    printf '%s\n' "$OUT" | grep -iE "failed|leaked|panic" >&2 || true
+    exit 1
+  fi
+done
+
+echo "PASS: the HEAD redirect loop follows only redirects and reports failed walks"

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -1316,14 +1316,27 @@ fn mapApiFetchError(e: api_mod.ApiError) ?InstallError {
     };
 }
 
+/// Classify a failed artifact-URL resolution. A walk that never completed
+/// says nothing about the cask's format, so `.unknown` stays reserved for a
+/// URL malt actually resolved and could not classify.
+fn mapHeadResolveError(e: anyerror) InstallError {
+    // OOM is handled by the caller: it is not a property of the URL.
+    return switch (e) {
+        // Both mean the artifact would be fetched in the clear.
+        error.InsecureUrlScheme, error.TlsDowngradeRefused => InstallError.InsecureArchiveUrl,
+        else => InstallError.NetworkError,
+    };
+}
+
 /// HEAD-based fallback for extensionless cask URLs.
-/// Follows redirects to discover the real file extension.
-fn resolveCaskArtifactViaHead(ctx: *const AppCtx, allocator: std.mem.Allocator, url: []const u8) cask_mod.ArtifactType {
+/// Follows redirects to discover the real file extension. The walk's own
+/// error reaches the caller, which reports it before classifying.
+fn resolveCaskArtifactViaHead(ctx: *const AppCtx, allocator: std.mem.Allocator, url: []const u8) !cask_mod.ArtifactType {
     var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);
     defer http.deinit();
     http.offline = ctx.offline;
 
-    var resolved = http.headResolved(url) catch return .unknown;
+    var resolved = try http.headResolved(url);
     defer resolved.deinit();
 
     return cask_mod.resolveArtifactType(allocator, resolved.final_url, resolved.content_disposition);
@@ -1403,7 +1416,15 @@ fn installCask(
     // Extensionless URLs (e.g. download APIs that 302 to the real file):
     // resolve via HEAD to discover the final URL and Content-Disposition.
     if (artifact_type == .unknown) {
-        artifact_type = resolveCaskArtifactViaHead(ctx, allocator, cask.url);
+        artifact_type = resolveCaskArtifactViaHead(ctx, allocator, cask.url) catch |e| switch (e) {
+            // Report the walk's own error — "NetworkError" would say less than
+            // the message already does.
+            error.OutOfMemory => return e,
+            else => {
+                sink.err("Could not resolve the download URL for '{s}': {s} — URL: {s}", .{ cask.token, @errorName(e), cask.url });
+                return mapHeadResolveError(e);
+            },
+        };
     }
 
     if (flags.dry_run) {
@@ -1622,6 +1643,17 @@ test "mapApiFetchError surfaces ApiUnreachable as NetworkError" {
     // path-specific "not found" tag, so the dispatch summary said
     // FormulaNotFound or CaskNotFound when the cause was a flaky DNS.
     try std.testing.expectEqual(InstallError.NetworkError, mapApiFetchError(error.ApiUnreachable).?);
+}
+
+test "mapHeadResolveError reports a dead walk as a network failure, not a format one" {
+    try std.testing.expectEqual(InstallError.NetworkError, mapHeadResolveError(error.RequestFailed));
+    try std.testing.expectEqual(InstallError.NetworkError, mapHeadResolveError(error.OfflineRequired));
+    try std.testing.expectEqual(InstallError.NetworkError, mapHeadResolveError(error.HttpRedirectLocationMissing));
+}
+
+test "mapHeadResolveError keeps a cleartext artifact URL distinct from a network failure" {
+    try std.testing.expectEqual(InstallError.InsecureArchiveUrl, mapHeadResolveError(error.InsecureUrlScheme));
+    try std.testing.expectEqual(InstallError.InsecureArchiveUrl, mapHeadResolveError(error.TlsDowngradeRefused));
 }
 
 test "mapApiFetchError leaves other ApiError variants for the path's own fallback" {

--- a/src/net/client.zig
+++ b/src/net/client.zig
@@ -658,18 +658,21 @@ pub const HttpClient = struct {
         };
         errdefer resolved.deinit();
 
+        // Every exit below returns an error rather than what the walk reached
+        // so far: a partial walk is indistinguishable from a resolved url, and
+        // the caller picks a cask's artifact type from it.
         for (0..max_head_redirects) |_| {
-            const uri = std.Uri.parse(resolved.final_url) catch break;
+            const uri = std.Uri.parse(resolved.final_url) catch return error.RequestFailed;
 
             var req = self.client.request(.HEAD, uri, .{
                 .extra_headers = &.{},
-            }) catch break;
+            }) catch return error.RequestFailed;
             defer req.deinit();
 
-            req.sendBodiless() catch break;
+            req.sendBodiless() catch return error.RequestFailed;
 
             var redirect_buf: [32 * 1024]u8 = undefined;
-            const response = req.receiveHead(&redirect_buf) catch break;
+            const response = req.receiveHead(&redirect_buf) catch return error.RequestFailed;
 
             if (resolved.content_disposition == null) {
                 if (response.head.content_disposition) |cd| {
@@ -678,22 +681,12 @@ pub const HttpClient = struct {
             }
 
             const status: u16 = @intFromEnum(response.head.status);
-            if (status >= 301 and status <= 308) {
-                if (response.head.location) |loc| {
-                    const next = self.nextHopUrl(uri, loc) catch |e| switch (e) {
-                        // A refusal must reach the caller: silently returning the
-                        // pre-hop url would read as a successful resolution.
-                        error.OutOfMemory, error.TlsDowngradeRefused => return e,
-                        // A malformed Location ends resolution here, as it did
-                        // when the raw value failed to parse on the next hop.
-                        else => break,
-                    };
-                    defer self.allocator.free(next);
-                    try resolved.replaceFinalUrl(next);
-                    continue;
-                }
-            }
-            break;
+            if (!isFollowableRedirect(status)) break;
+
+            const loc = response.head.location orelse return error.HttpRedirectLocationMissing;
+            const next = try self.nextHopUrl(uri, loc);
+            defer self.allocator.free(next);
+            try resolved.replaceFinalUrl(next);
         }
 
         return resolved;

--- a/tests/net_redirect_auth_test.zig
+++ b/tests/net_redirect_auth_test.zig
@@ -19,9 +19,10 @@ const Hop = struct {
     // per-request read buffer so it outlives `serveOne`.
     target_buf: [512]u8 = undefined,
     target_len: usize = 0,
-    // When set, answer 302 to this Location; otherwise 200 with `blob_body`.
+    // Non-null: answer this status, carrying `redirect_to` as Location and
+    // `content_disposition` when they are set. Null: 200 with `blob_body`.
+    status: ?std.http.Status = null,
     redirect_to: ?[]const u8 = null,
-    // When set, the 200 carries this Content-Disposition.
     content_disposition: ?[]const u8 = null,
 };
 
@@ -46,12 +47,21 @@ fn serveOne(hop: *Hop) void {
     while (it.next()) |h| {
         if (std.ascii.eqlIgnoreCase(h.name, "authorization")) hop.saw_auth = true;
     }
-    if (hop.redirect_to) |loc| {
-        // A non-empty 302 body exercises the redirect-body drain on hop teardown.
-        req.respond("redirecting\n", .{
-            .status = .found,
-            .extra_headers = &.{.{ .name = "location", .value = loc }},
-        }) catch return;
+    if (hop.status) |status| {
+        var hdrs: [2]std.http.Header = undefined;
+        var n: usize = 0;
+        if (hop.redirect_to) |loc| {
+            hdrs[n] = .{ .name = "location", .value = loc };
+            n += 1;
+        }
+        if (hop.content_disposition) |cd| {
+            hdrs[n] = .{ .name = "content-disposition", .value = cd };
+            n += 1;
+        }
+        // A non-empty 302 body exercises the redirect-body drain on hop
+        // teardown; 304 must stay bodiless.
+        const body = if (status == .found) "redirecting\n" else "";
+        req.respond(body, .{ .status = status, .extra_headers = hdrs[0..n] }) catch return;
     } else if (hop.content_disposition) |cd| {
         req.respond(blob_body, .{
             .extra_headers = &.{.{ .name = "content-disposition", .value = cd }},
@@ -68,6 +78,15 @@ fn hopTarget(hop: *const Hop) []const u8 {
 fn bindIp4(io: std.Io) !net.Server {
     var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
     return try addr.listen(io, .{ .reuse_address = true });
+}
+
+// A port bound and released again: a connection to it is refused immediately,
+// so a hop the client must not take fails fast instead of hanging the test.
+fn closedPort(io: std.Io) !u16 {
+    var l = try bindIp4(io);
+    const port = l.socket.address.getPort();
+    l.deinit(io);
+    return port;
 }
 
 fn bindIp6(io: std.Io) !net.Server {
@@ -101,7 +120,7 @@ test "auth headers stripped on redirect across a cross-domain hop" {
     var l1 = try bindIp4(io);
     defer l1.deinit(io);
     const p1 = l1.socket.address.getPort();
-    var hop1 = Hop{ .io = io, .listener = &l1, .redirect_to = loc };
+    var hop1 = Hop{ .io = io, .listener = &l1, .redirect_to = loc, .status = .found };
     const t1 = try std.Thread.spawn(.{}, serveOne, .{&hop1});
 
     var url_buf: [64]u8 = undefined;
@@ -151,7 +170,7 @@ test "auth headers kept across a same-host redirect" {
     var l1 = try bindIp4(io);
     defer l1.deinit(io);
     const p1 = l1.socket.address.getPort();
-    var hop1 = Hop{ .io = io, .listener = &l1, .redirect_to = loc };
+    var hop1 = Hop{ .io = io, .listener = &l1, .redirect_to = loc, .status = .found };
     const t1 = try std.Thread.spawn(.{}, serveOne, .{&hop1});
 
     var url_buf: [64]u8 = undefined;
@@ -196,7 +215,7 @@ test "headResolved follows a hop and harvests the artifact headers from it" {
     var l1 = try bindIp4(io);
     defer l1.deinit(io);
     const p1 = l1.socket.address.getPort();
-    var hop1 = Hop{ .io = io, .listener = &l1, .redirect_to = loc };
+    var hop1 = Hop{ .io = io, .listener = &l1, .redirect_to = loc, .status = .found };
     const t1 = try std.Thread.spawn(.{}, serveOne, .{&hop1});
 
     var url_buf: [64]u8 = undefined;
@@ -219,4 +238,122 @@ test "headResolved follows a hop and harvests the artifact headers from it" {
     try std.testing.expectEqualStrings(want, resolved.final_url);
     try std.testing.expectEqualStrings(cd, resolved.content_disposition.?);
     try std.testing.expectEqualStrings("/artifact", hopTarget(&hop2));
+}
+
+// Stands up one hop answering `status` with a Location pointing at a dead
+// port, and returns what `headResolved` made of it.
+fn resolveAgainstNonRedirect(status: std.http.Status) !void {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var loc_buf: [64]u8 = undefined;
+    const loc = try std.fmt.bufPrint(&loc_buf, "http://127.0.0.1:{d}/artifact.pkg", .{try closedPort(io)});
+
+    var l1 = try bindIp4(io);
+    defer l1.deinit(io);
+    const p1 = l1.socket.address.getPort();
+    var hop1 = Hop{ .io = io, .listener = &l1, .redirect_to = loc, .status = status };
+    const t1 = try std.Thread.spawn(.{}, serveOne, .{&hop1});
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/start", .{p1});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+    defer http.deinit();
+
+    const result = http.headResolved(url);
+    t1.join();
+
+    var resolved = try result;
+    defer resolved.deinit();
+
+    // Unchanged: the hop was terminal, so the walk never moved off the origin.
+    try std.testing.expectEqualStrings(url, resolved.final_url);
+}
+
+test "headResolved does not follow Location on a non-redirect status" {
+    // 304, 305 and 306 sit inside the 301..308 range but none is a redirect.
+    // The port each one points at is never bound, so a follow is unmistakable.
+    try resolveAgainstNonRedirect(.not_modified);
+    try resolveAgainstNonRedirect(.use_proxy);
+    try resolveAgainstNonRedirect(@enumFromInt(306));
+}
+
+test "headResolved reports an unreachable origin instead of the untouched url" {
+    // The pre-fix loop returned the caller's own url here, which the cask
+    // installer classified as an unreadable format rather than a dead network.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/download", .{try closedPort(io)});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+    defer http.deinit();
+
+    try std.testing.expectError(error.RequestFailed, http.headResolved(url));
+}
+
+test "headResolved reports a dead hop instead of a half-walked resolution" {
+    // Hop 1 hands over a Content-Disposition on its way to a dead hop 2.
+    // Returning that harvested header against a stale final_url would let a
+    // cask be classified from partial data.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var loc_buf: [64]u8 = undefined;
+    const loc = try std.fmt.bufPrint(&loc_buf, "http://127.0.0.1:{d}/artifact", .{try closedPort(io)});
+
+    var l1 = try bindIp4(io);
+    defer l1.deinit(io);
+    const p1 = l1.socket.address.getPort();
+    var hop1 = Hop{
+        .io = io,
+        .listener = &l1,
+        .redirect_to = loc,
+        .status = .found,
+        .content_disposition = "attachment; filename=\"artifact.pkg\"",
+    };
+    const t1 = try std.Thread.spawn(.{}, serveOne, .{&hop1});
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/start", .{p1});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+    defer http.deinit();
+
+    const result = http.headResolved(url);
+    t1.join();
+
+    try std.testing.expectError(error.RequestFailed, result);
+}
+
+test "headResolved reports a redirect with no Location instead of the pre-hop url" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var l1 = try bindIp4(io);
+    defer l1.deinit(io);
+    const p1 = l1.socket.address.getPort();
+    var hop1 = Hop{ .io = io, .listener = &l1, .status = .moved_permanently };
+    const t1 = try std.Thread.spawn(.{}, serveOne, .{&hop1});
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/start", .{p1});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+    defer http.deinit();
+
+    const result = http.headResolved(url);
+    t1.join();
+
+    try std.testing.expectError(error.HttpRedirectLocationMissing, result);
 }


### PR DESCRIPTION
## Description

An extensionless cask URL is resolved by walking redirects with a HEAD request; where that walk lands is what picks the artifact type, `.pkg` included.

The walk could lie twice. It treated any status from 301 to 308 as a redirect, so 304, 305 and 306 moved it off the real URL. And a walk that failed - dead origin, dead hop, unusable `Location` - returned however far it got, so the installer classified an untouched URL and told the user "Unsupported cask format" when the network was simply down.

Now only real redirects are followed, and a walk that cannot finish is an error the installer reports for what it is.

## Related Issue

- None

## Notes for Reviewers

- No install that used to succeed now fails; these paths already ended in an error, just with the wrong message.