### PR TITLE
fix(update): run the exact cosign the trust guard approved

### DIFF
--- a/scripts/regressions/cosign-guard-fails-open-and-spawn-not-pinned.sh
+++ b/scripts/regressions/cosign-guard-fails-open-and-spawn-not-pinned.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Regression: the self-update trust guard walked PATH itself, approved the
+# first entry it could `access(X_OK)`, then discarded that resolution and
+# spawned the bare name `cosign`. The kernel ran its own PATH walk, which
+# continues past an entry whose execve returns ENOENT -- exactly what a script
+# with a missing shebang interpreter returns. So the guard vetted one binary
+# and the kernel ran another, which could be `<prefix>/bin/cosign`: a rubber
+# stamp inside malt's own prefix turned every `mt version update` into a
+# no-op signature check.
+#
+# The second arm was fail-open resolution: both realpath sites exited the
+# guard on the success path, so any resolution error read as "trusted".
+#
+# There is no CLI surface that reaches the guard without a real release
+# download, so a standalone ReleaseSafe `zig test` harness drives
+# verifyCosignBlob directly with a broken-shebang decoy ahead of a runnable
+# shim in the prefix, and asserts the call refuses. The harness lives at the
+# repo root because src/update/verify.zig imports sibling modules by relative
+# path.
+#
+# Exits 0 when the bug is absent, non-zero (with a clear message) when present.
+# No network required; finishes well under 30s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+
+# Source-shape pin for the fail-open arm: no resolution error may leave the
+# guard on its success path.
+if rg -q 'realPathFile\(.*\) catch return;' "$ROOT/src/update/verify.zig"; then
+  echo "FAIL: the cosign resolver still treats a realpath error as trusted" >&2
+  exit 1
+fi
+
+# Pin the defect itself: argv[0] must come from the resolver, never from the
+# caller-supplied name, or the spawn resolves PATH a second time.
+if rg -q '^\s+args\.cosign_bin,$' "$ROOT/src/update/verify.zig"; then
+  echo "FAIL: the cosign spawn takes argv[0] from the unresolved input again" >&2
+  exit 1
+fi
+
+# The harness cannot notice the in-tree tests being deleted, so guard them too.
+while IFS= read -r name; do
+  if ! rg -Fq -- "$name" "$ROOT/src/update/verify.zig" "$ROOT/tests/verify_test.zig"; then
+    echo "FAIL: a cosign pinning test is missing: $name" >&2
+    exit 1
+  fi
+done <<'NAMES'
+the resolver pins the spawn to the candidate it vetted
+the spawned cosign is the one the guard resolved
+NAMES
+
+HARNESS="$ROOT/.cosign-pin-regression.$$.zig"
+TMP=$(mktemp -d)
+trap 'rm -f "$HARNESS"; rm -rf "$TMP"' EXIT
+
+cat >"$HARNESS" <<'ZIG'
+const std = @import("std");
+const verify = @import("src/update/verify.zig");
+
+extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+
+fn processEnviron() std.process.Environ {
+    var n: usize = 0;
+    while (std.c.environ[n] != null) : (n += 1) {}
+    return .{ .block = .{ .slice = std.c.environ[0..n :null] } };
+}
+
+fn writeExec(io: std.Io, path: []const u8, body: []const u8) !void {
+    const f = try std.Io.Dir.createFileAbsolute(io, path, .{ .truncate = true });
+    defer f.close(io);
+    try f.writeStreamingAll(io, body);
+    try f.setPermissions(io, std.Io.File.Permissions.fromMode(0o755));
+}
+
+test "a cosign the guard never vetted cannot be spawned" {
+    const a = std.testing.allocator;
+    const dio = std.Options.debug_io;
+    const root = std.process.Environ.getPosix(processEnviron(), "MALT_COSIGN_PIN_TMP").?;
+
+    const decoy_dir = try std.fmt.allocPrint(a, "{s}/decoy", .{root});
+    defer a.free(decoy_dir);
+    const prefix = try std.fmt.allocPrint(a, "{s}/prefix", .{root});
+    defer a.free(prefix);
+    const prefix_bin = try std.fmt.allocPrint(a, "{s}/bin", .{prefix});
+    defer a.free(prefix_bin);
+    try std.Io.Dir.cwd().createDirPath(dio, decoy_dir);
+    try std.Io.Dir.cwd().createDirPath(dio, prefix_bin);
+
+    // access(X_OK) says yes, execve says ENOENT: the kernel walks past it.
+    const decoy = try std.fmt.allocPrint(a, "{s}/cosign", .{decoy_dir});
+    defer a.free(decoy);
+    try writeExec(dio, decoy, "#!/nonexistent/interp\n");
+
+    // The rubber stamp the kernel would reach next.
+    const shim = try std.fmt.allocPrint(a, "{s}/cosign", .{prefix_bin});
+    defer a.free(shim);
+    try writeExec(dio, shim, "#!" ++ "/bin/sh\nexit 0\n");
+
+    // The spawn reads PATH from the runtime's environ, the guard from the
+    // injected one; set both or the test proves nothing.
+    const path_val = try std.fmt.allocPrintSentinel(a, "{s}:{s}", .{ decoy_dir, prefix_bin }, 0);
+    defer a.free(path_val);
+    if (setenv("PATH", path_val.ptr, 1) != 0) return error.SetEnvFailed;
+
+    // debug_io cannot spawn -- it fails with OutOfMemory, which reads as a pass.
+    var threaded: std.Io.Threaded = .init(a, .{ .environ = processEnviron() });
+    defer threaded.deinit();
+
+    const result = verify.verifyCosignBlob(threaded.io(), .{
+        .cosign_bin = "cosign",
+        .environ = processEnviron(),
+        .prefix = prefix,
+        .blob_path = "/dev/null",
+        .bundle_path = "/dev/null",
+        .cert_identity_regex = "^x$",
+        .oidc_issuer = "https://example.invalid",
+    });
+    if (result) |_| return error.UnvettedCosignRan else |_| {}
+}
+ZIG
+
+if OUT=$(cd "$ROOT" && MALT_COSIGN_PIN_TMP="$TMP" zig test -lc -OReleaseSafe "$HARNESS" 2>&1); then
+  echo "PASS: the cosign spawn is pinned to the vetted resolution"
+elif printf '%s' "$OUT" | rg -q 'UnvettedCosignRan'; then
+  echo "FAIL: the guard vetted a PATH entry the spawn did not run; a prefix-resident cosign rubber-stamped the update" >&2
+  exit 1
+else
+  # A harness that will not build is not a verdict on the bug - say so rather
+  # than sending whoever triages this after a vulnerability that may not exist.
+  echo "FAIL: the regression harness did not build or run; this is not a verdict on the bug" >&2
+  printf '%s\n' "$OUT" >&2
+  exit 2
+fi

--- a/src/update/verify.zig
+++ b/src/update/verify.zig
@@ -156,21 +156,24 @@ pub fn resolvedInsidePrefix(resolved: []const u8, prefix: []const u8) bool {
     return resolved[prefix.len] == '/';
 }
 
-/// Locate `bin` on `PATH` and reject it when it resolves inside `prefix`.
-/// A bare name with no match is left to the spawn to fail as CosignNotFound.
-fn rejectPrefixResidentTool(
+/// Resolve `bin` to the path the spawn must use, refusing one that lands
+/// inside `prefix`. Returning the path is what lets the caller pin the spawn:
+/// vetting alone left the kernel free to resolve a different binary.
+fn resolveTrustedCosign(
     io: std.Io,
     bin: []const u8,
     prefix: []const u8,
     environ: std.process.Environ,
-) CosignError!void {
-    if (prefix.len == 0) return;
-    var resolved_buf: [std.fs.max_path_bytes]u8 = undefined;
+    out: []u8,
+) CosignError![]const u8 {
+    // No prefix means no guard (tests only) - spawn the name as given.
+    if (prefix.len == 0) return bin;
 
     // Resolve the prefix too, or the comparison is spelling-sensitive: on
     // macOS `/tmp` is a symlink to `/private/tmp`, so a resolved binary path
     // would never match a prefix given in the other form. Falls back to the
-    // literal when the prefix does not exist yet.
+    // literal when the prefix does not exist yet - nothing can resolve inside
+    // a prefix that is not there.
     var prefix_buf: [std.fs.max_path_bytes]u8 = undefined;
     const prefix_real = if (std.Io.Dir.cwd().realPathFile(io, prefix, &prefix_buf)) |pn|
         prefix_buf[0..pn]
@@ -179,12 +182,12 @@ fn rejectPrefixResidentTool(
 
     // An explicit path is checked as given; a bare name is searched on PATH.
     if (std.mem.indexOfScalar(u8, bin, '/') != null) {
-        const n = std.Io.Dir.cwd().realPathFile(io, bin, &resolved_buf) catch return;
-        if (resolvedInsidePrefix(resolved_buf[0..n], prefix_real)) return error.CosignUntrusted;
-        return;
+        const n = std.Io.Dir.cwd().realPathFile(io, bin, out) catch return error.CosignNotFound;
+        if (resolvedInsidePrefix(out[0..n], prefix_real)) return error.CosignUntrusted;
+        return out[0..n];
     }
 
-    const path_env = std.process.Environ.getPosix(environ, "PATH") orelse return;
+    const path_env = std.process.Environ.getPosix(environ, "PATH") orelse return error.CosignNotFound;
     var it = std.mem.tokenizeScalar(u8, path_env, ':');
     var probe: [std.fs.max_path_bytes]u8 = undefined;
     while (it.next()) |dir| {
@@ -192,25 +195,31 @@ fn rejectPrefixResidentTool(
         // Mere existence is the wrong test: execvp walks past an entry it
         // cannot exec, so a non-executable file (or a directory) named
         // `cosign` earlier on PATH would end the search here while the real
-        // resolution carried on into the prefix. Ask the kernel the same
-        // question execvp asks — can *this* process execute this file.
+        // resolution carried on into the prefix.
         const st = std.Io.Dir.cwd().statFile(io, cand, .{}) catch continue;
         if (st.kind != .file) continue;
         std.Io.Dir.cwd().access(io, cand, .{ .execute = true }) catch continue;
-        // First hit wins, exactly as execvp would resolve it.
-        const n = std.Io.Dir.cwd().realPathFile(io, cand, &resolved_buf) catch return;
-        if (resolvedInsidePrefix(resolved_buf[0..n], prefix_real)) return error.CosignUntrusted;
-        return;
+        // Unresolvable means unvettable, so skip it the way execvp skips one
+        // it cannot exec. Safe because the spawn runs whatever this walk
+        // returns - a skipped candidate can never be the one that executes.
+        const n = std.Io.Dir.cwd().realPathFile(io, cand, out) catch continue;
+        if (resolvedInsidePrefix(out[0..n], prefix_real)) return error.CosignUntrusted;
+        return out[0..n];
     }
+    return error.CosignNotFound;
 }
 
 /// Shell out to `cosign verify-blob` with the same flags `install.sh` uses.
 /// Exit 0 = verified. Any other outcome maps to a CosignError.
 pub fn verifyCosignBlob(io: std.Io, args: CosignBlob) CosignError!void {
-    try rejectPrefixResidentTool(io, args.cosign_bin, args.prefix, args.environ);
+    // A path with a slash makes the spawn skip its own PATH search, so the
+    // vetted binary is the one that runs. The residual TOCTOU is accepted:
+    // closing it needs fexecve, which std.process.spawn does not expose.
+    var resolved_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cosign_bin = try resolveTrustedCosign(io, args.cosign_bin, args.prefix, args.environ, &resolved_buf);
 
     const argv = [_][]const u8{
-        args.cosign_bin,
+        cosign_bin,
         "verify-blob",
         "--bundle",
         args.bundle_path,
@@ -353,4 +362,162 @@ test "an unexecutable PATH entry does not end the search short of the prefix" {
     try std.Io.Dir.cwd().deleteFile(io, decoy);
     try std.Io.Dir.cwd().createDirPath(io, decoy);
     try std.testing.expectError(error.CosignUntrusted, verifyCosignBlob(io, args));
+}
+
+test "the resolver pins the spawn to the candidate it vetted" {
+    const io = std.Options.debug_io;
+    const a = std.testing.allocator;
+
+    // The decoy passes `access(X_OK)` but `execve` rejects it with ENOENT, so
+    // the kernel's own PATH walk would carry on into the prefix. The resolver
+    // must hand back the decoy, which is what pins the spawn away from there.
+    const root = try std.fmt.allocPrint(a, "/tmp/malt_cosign_pin_{d}", .{std.c.getpid()});
+    defer a.free(root);
+    defer std.Io.Dir.cwd().deleteTree(io, root) catch {};
+
+    const decoy_dir = try std.fmt.allocPrint(a, "{s}/decoy", .{root});
+    defer a.free(decoy_dir);
+    const prefix = try std.fmt.allocPrint(a, "{s}/prefix", .{root});
+    defer a.free(prefix);
+    const prefix_bin = try std.fmt.allocPrint(a, "{s}/bin", .{prefix});
+    defer a.free(prefix_bin);
+    try std.Io.Dir.cwd().createDirPath(io, decoy_dir);
+    try std.Io.Dir.cwd().createDirPath(io, prefix_bin);
+
+    for ([_][]const u8{ decoy_dir, prefix_bin }) |dir| {
+        const p = try std.fmt.allocPrint(a, "{s}/cosign", .{dir});
+        defer a.free(p);
+        const f = try std.Io.Dir.createFileAbsolute(io, p, .{ .truncate = true });
+        defer f.close(io);
+        try f.writeStreamingAll(io, "#!/nonexistent/interp\n");
+        try f.setPermissions(io, std.Io.File.Permissions.fromMode(0o755));
+    }
+
+    const path_val = try std.fmt.allocPrintSentinel(a, "PATH={s}:{s}", .{ decoy_dir, prefix_bin }, 0);
+    defer a.free(path_val);
+    const entries = [_:null]?[*:0]const u8{path_val.ptr};
+    const environ: std.process.Environ = .{ .block = .{ .slice = &entries } };
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const got = try resolveTrustedCosign(io, "cosign", prefix, environ, &buf);
+    try std.testing.expect(std.mem.endsWith(u8, got, "/decoy/cosign"));
+    try std.testing.expect(!resolvedInsidePrefix(got, prefix));
+}
+
+test "the resolver reports not-found rather than trusting an unresolvable name" {
+    const io = std.Options.debug_io;
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+
+    // An explicit path that does not exist: the spawn would have failed the
+    // same way, so the error stays CosignNotFound.
+    try std.testing.expectError(error.CosignNotFound, resolveTrustedCosign(
+        io,
+        "/tmp/malt_cosign_absent_xyz",
+        "/opt/malt",
+        .empty,
+        &buf,
+    ));
+    // No PATH to search, and a PATH with no hit: both are a missing cosign.
+    try std.testing.expectError(error.CosignNotFound, resolveTrustedCosign(io, "cosign", "/opt/malt", .empty, &buf));
+    const path_val: [:0]const u8 = "PATH=/tmp/malt_cosign_absent_dir_xyz";
+    const entries = [_:null]?[*:0]const u8{path_val.ptr};
+    try std.testing.expectError(error.CosignNotFound, resolveTrustedCosign(
+        io,
+        "cosign",
+        "/opt/malt",
+        .{ .block = .{ .slice = &entries } },
+        &buf,
+    ));
+}
+
+test "an empty prefix disables the guard and passes the name through" {
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const got = try resolveTrustedCosign(std.Options.debug_io, "cosign", "", .empty, &buf);
+    try std.testing.expectEqualStrings("cosign", got);
+}
+
+test "a PATH entry symlinked into the prefix is refused" {
+    const io = std.Options.debug_io;
+    const a = std.testing.allocator;
+
+    // The link sits outside the prefix but its target does not. Vetting the
+    // resolved path is what catches this; comparing the candidate would not.
+    const root = try std.fmt.allocPrint(a, "/tmp/malt_cosign_link_{d}", .{std.c.getpid()});
+    defer a.free(root);
+    defer std.Io.Dir.cwd().deleteTree(io, root) catch {};
+
+    const outside = try std.fmt.allocPrint(a, "{s}/outside", .{root});
+    defer a.free(outside);
+    const prefix = try std.fmt.allocPrint(a, "{s}/prefix", .{root});
+    defer a.free(prefix);
+    const prefix_bin = try std.fmt.allocPrint(a, "{s}/bin", .{prefix});
+    defer a.free(prefix_bin);
+    try std.Io.Dir.cwd().createDirPath(io, outside);
+    try std.Io.Dir.cwd().createDirPath(io, prefix_bin);
+
+    const target = try std.fmt.allocPrint(a, "{s}/cosign", .{prefix_bin});
+    defer a.free(target);
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, target, .{ .truncate = true });
+        defer f.close(io);
+        try f.writeStreamingAll(io, "#!/nonexistent/interp\n");
+        try f.setPermissions(io, std.Io.File.Permissions.fromMode(0o755));
+    }
+    const link = try std.fmt.allocPrint(a, "{s}/cosign", .{outside});
+    defer a.free(link);
+    try std.Io.Dir.symLinkAbsolute(io, target, link, .{});
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path_val = try std.fmt.allocPrintSentinel(a, "PATH={s}", .{outside}, 0);
+    defer a.free(path_val);
+    const entries = [_:null]?[*:0]const u8{path_val.ptr};
+    try std.testing.expectError(error.CosignUntrusted, resolveTrustedCosign(
+        io,
+        "cosign",
+        prefix,
+        .{ .block = .{ .slice = &entries } },
+        &buf,
+    ));
+
+    // Explicit-path form takes the same route through the symlink.
+    try std.testing.expectError(error.CosignUntrusted, resolveTrustedCosign(io, link, prefix, .empty, &buf));
+}
+
+test "a candidate that cannot be resolved is skipped, never trusted" {
+    const io = std.Options.debug_io;
+    const a = std.testing.allocator;
+
+    // An executable, prefix-external cosign the walk reaches and accepts on
+    // every check but the last: an undersized output buffer makes realpath
+    // fail there. The candidate must be skipped, not handed to the spawn.
+    const root = try std.fmt.allocPrint(a, "/tmp/malt_cosign_unres_{d}", .{std.c.getpid()});
+    defer a.free(root);
+    defer std.Io.Dir.cwd().deleteTree(io, root) catch {};
+
+    const dir = try std.fmt.allocPrint(a, "{s}/bin", .{root});
+    defer a.free(dir);
+    try std.Io.Dir.cwd().createDirPath(io, dir);
+    const cosign = try std.fmt.allocPrint(a, "{s}/cosign", .{dir});
+    defer a.free(cosign);
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, cosign, .{ .truncate = true });
+        defer f.close(io);
+        try f.writeStreamingAll(io, "#!/nonexistent/interp\n");
+        try f.setPermissions(io, std.Io.File.Permissions.fromMode(0o755));
+    }
+
+    const path_val = try std.fmt.allocPrintSentinel(a, "PATH={s}", .{dir}, 0);
+    defer a.free(path_val);
+    const entries = [_:null]?[*:0]const u8{path_val.ptr};
+    const environ: std.process.Environ = .{ .block = .{ .slice = &entries } };
+
+    // Returning any path here would hand the spawn something unvetted.
+    var small: [64]u8 = undefined;
+    try std.testing.expectError(error.CosignNotFound, resolveTrustedCosign(
+        io,
+        "cosign",
+        "/opt/malt",
+        environ,
+        &small,
+    ));
 }

--- a/tests/verify_test.zig
+++ b/tests/verify_test.zig
@@ -458,3 +458,62 @@ test "verifyCosignBlob errors when cosign exits non-zero" {
     args.cosign_bin = path;
     try testing.expectError(error.CosignVerifyFailed, verify.verifyCosignBlob(lio.io(), args));
 }
+
+test "the spawned cosign is the one the guard resolved" {
+    try fs_compat.skipIfNoSubprocess();
+    const a = testing.allocator;
+    const dio = std.Options.debug_io;
+
+    // A decoy that `access(X_OK)` accepts but `execve` rejects with ENOENT:
+    // the kernel's own PATH walk continues past it, so a guard that only
+    // vetted the decoy would let the next hit -- the prefix shim -- run.
+    const root = try fs_compat.uniqueTempPath(a, "verify", "cosign_pin");
+    defer a.free(root);
+    fs_compat.deleteTreeAbsolute(dio, root) catch {};
+    defer fs_compat.deleteTreeAbsolute(dio, root) catch {};
+
+    const decoy_dir = try std.fmt.allocPrint(a, "{s}/decoy", .{root});
+    defer a.free(decoy_dir);
+    const prefix = try std.fmt.allocPrint(a, "{s}/prefix", .{root});
+    defer a.free(prefix);
+    const prefix_bin = try std.fmt.allocPrint(a, "{s}/bin", .{prefix});
+    defer a.free(prefix_bin);
+    try std.Io.Dir.cwd().createDirPath(dio, decoy_dir);
+    try std.Io.Dir.cwd().createDirPath(dio, prefix_bin);
+
+    const decoy = try std.fmt.allocPrint(a, "{s}/cosign", .{decoy_dir});
+    defer a.free(decoy);
+    {
+        const f = try fs_compat.createFileAbsolute(dio, decoy, .{});
+        defer f.close(dio);
+        try f.writeStreamingAll(dio, "#!/nonexistent/interp\n");
+        try f.setPermissions(dio, std.Io.File.Permissions.fromMode(0o755));
+    }
+
+    // The rubber stamp: runnable, exits 0, and inside malt's own prefix.
+    const shim = try std.fmt.allocPrint(a, "{s}/cosign", .{prefix_bin});
+    defer a.free(shim);
+    try writeFakeCosign(shim, 0);
+
+    // The spawn reads PATH from the runtime's environ and the guard from the
+    // injected one; setting only one would prove nothing.
+    var orig_buf: [8192]u8 = undefined;
+    const orig_raw = fs_compat.getenv("PATH") orelse "";
+    if (orig_raw.len >= orig_buf.len) return error.SkipZigTest;
+    @memcpy(orig_buf[0..orig_raw.len], orig_raw);
+    orig_buf[orig_raw.len] = 0;
+
+    var path_buf: [8192]u8 = undefined;
+    const new_path = try std.fmt.bufPrintZ(&path_buf, "{s}:{s}", .{ decoy_dir, prefix_bin });
+    if (setenv("PATH", new_path.ptr, 1) != 0) return error.SetEnvFailed;
+    defer _ = if (orig_raw.len == 0) unsetenv("PATH") else setenv("PATH", @ptrCast(&orig_buf), 1);
+
+    var lio = LiveIo.init();
+    defer lio.deinit();
+    var args = fake_args;
+    args.cosign_bin = "cosign";
+    args.environ = malt.app_ctx.processEnviron();
+    args.prefix = prefix;
+    // The decoy is what the guard resolved, so the decoy is what must fail.
+    try testing.expectError(error.CosignNotFound, verify.verifyCosignBlob(lio.io(), args));
+}


### PR DESCRIPTION
## Description

`mt version update` could check a release signature with a `cosign` the trust guard never approved. The guard vetted one binary and the spawn resolved another, so a shim dropped inside malt's own prefix - a directory every installed package can write to - could rubber-stamp the update. The guard now hands the resolved path straight to the spawn, and a candidate it cannot resolve is skipped rather than trusted.

## Related Issue

- None

## Notes for Reviewers

- A `cosign` reached through a symlink is now executed by its resolved target rather than the link. That is deliberate: the link is what an attacker in the prefix would control.
- The guard walks past a candidate it cannot resolve instead of refusing outright, so a transient filesystem error on one `PATH` entry no longer fails an update that a later entry would have satisfied. Skipping stays safe because the spawn only ever runs a candidate this walk returned and vetted.