### PR TITLE
fix(tap): treat every spelling of a tap as the one tap brew treats it as

### DIFF
--- a/scripts/regressions/tap-resolution-contract.sh
+++ b/scripts/regressions/tap-resolution-contract.sh
@@ -21,6 +21,11 @@
 # Allowed sites:
 #   - src/core/forge.zig        the host-shaped seam (URLs, parse, auth)
 #   - src/core/tap.zig          the row/orchestration caller of the seam
+#   - src/tap_slug.zig          the canonical-identity leaf: strip and
+#                                 re-prefix live together so they cannot
+#                                 drift, and a leaf is the only tier both
+#                                 core/ and db/ (the repair migration) can
+#                                 import
 #   - src/cli/migrate/keg.zig   on-disk Cellar path
 #                                 (<prefix>/Library/Taps/<user>/homebrew-<repo>) —
 #                                 Homebrew's filesystem layout, not a URL
@@ -59,6 +64,7 @@ bs=$'\\'
 filtered=$(printf '%s\n' "$all" |
   grep -v '^src/core/forge\.zig:' |
   grep -v '^src/core/tap\.zig:' |
+  grep -v '^src/tap_slug\.zig:' |
   grep -v '^src/cli/migrate/keg\.zig:' |
   grep -v '^src/net/client\.zig:' |
   grep -vE ":[0-9]+:[[:space:]]*${bs}${bs}" |

--- a/scripts/regressions/tap-slug-canonicalisation-myx-installation-fails.sh
+++ b/scripts/regressions/tap-slug-canonicalisation-myx-installation-fails.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Lock tap-slug canonicalisation: every spelling of a tap is one tap.
+#
+# Homebrew downcases a tap reference and strips a leading `homebrew-`
+# from the repo component before addressing the git repo as
+# `homebrew-<repo>`. malt used to keep the user's spelling verbatim, so
+# a slug that already carried the prefix resolved to
+# `github.com/<user>/homebrew-homebrew-<repo>` (404), and the same
+# missing canonicalisation split one tap's identity across two rows.
+#
+# Pinned behaviour:
+#   1. Resolve — a `homebrew-`-prefixed slug reaches the `.rb` probe
+#      instead of 404ing on the tap repo. Keyed on error *text*, not exit
+#      code: both the broken and fixed runs exit non-zero on a formula
+#      that does not exist; only the broken one blames the repo.
+#   2. Identity — registering one spelling and removing another leaves
+#      no row behind. `untap` is silent about a miss, so the registry
+#      listing is the assertion.
+#
+# Uses a deliberately absent formula, so nothing is installed and a
+# single API round trip covers the whole run. Throwaway MALT_PREFIX,
+# never the live one.
+#
+# Usage: scripts/regressions/tap-slug-canonicalisation-myx-installation-fails.sh
+# Requirements: a built malt binary; one GitHub API call.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+MALT_BIN=${MALT_BIN:-$ROOT/zig-out/bin/malt}
+if [[ ! -x "$MALT_BIN" ]]; then
+  printf 'FAIL: malt binary not found at %s — run "zig build" first.\n' "$MALT_BIN" >&2
+  exit 1
+fi
+
+# The override must name a tap whose slug ALREADY carries `homebrew-`.
+TAP_PREFIXED=${MALT_TAP_REGRESSION:-indaco/homebrew-tap}
+TAP_BARE=${TAP_PREFIXED/\/homebrew-//}
+
+PREFIX=$(mktemp -d)
+trap 'rm -rf "$PREFIX"' EXIT
+export MALT_PREFIX="$PREFIX"
+export MALT_GITHUB_TOKEN=${MALT_GITHUB_TOKEN:-$(gh auth token 2>/dev/null || true)}
+
+# Skip loud rather than fail: the anonymous 60/hr cap makes an untokened
+# run indistinguishable from the bug. Same gate as tap_head_etag_304.sh.
+if [[ -z "$MALT_GITHUB_TOKEN" ]]; then
+  printf 'SKIP: MALT_GITHUB_TOKEN unset — a rate-limited resolve is\n' >&2
+  printf '       indistinguishable from the 404 this test looks for.\n' >&2
+  exit 0
+fi
+
+# (1) resolve
+out=$("$MALT_BIN" install --dry-run "$TAP_PREFIXED/nope-not-a-formula" 2>&1 || true)
+# An environment failure is not a regression — say so and stop.
+if grep -qE 'rate limit reached|Network failure' <<<"$out"; then
+  printf 'SKIP: GitHub unreachable or rate-limited:\n%s\n' "$out" >&2
+  exit 0
+fi
+if grep -q '404 for the tap repo' <<<"$out"; then
+  printf "FAIL: '%s' still resolves to a doubled homebrew- prefix:\n\n" "$TAP_PREFIXED" >&2
+  printf '%s\n' "$out" >&2
+  exit 1
+fi
+if ! grep -q 'Tap formula/cask not found' <<<"$out"; then
+  printf 'FAIL: unexpected resolve output for %s:\n\n' "$TAP_PREFIXED" >&2
+  printf '%s\n' "$out" >&2
+  exit 1
+fi
+
+# (2) identity
+if ! reg_out=$("$MALT_BIN" tap "$TAP_BARE" 2>&1); then
+  printf 'SKIP: could not register %s:\n%s\n' "$TAP_BARE" "$reg_out" >&2
+  exit 0
+fi
+"$MALT_BIN" untap "$TAP_PREFIXED" >/dev/null 2>&1 || true
+listing=$("$MALT_BIN" tap --list 2>&1 || true)
+if grep -qi -- "$TAP_BARE" <<<"$listing"; then
+  printf "FAIL: '%s' survived untap of '%s' — two rows for one tap:\n\n" \
+    "$TAP_BARE" "$TAP_PREFIXED" >&2
+  printf '%s\n' "$listing" >&2
+  exit 1
+fi
+
+echo "OK: prefixed and bare spellings resolve alike and share one tap identity"

--- a/scripts/regressions/tap_no_inline_homebrew_synthesis.sh
+++ b/scripts/regressions/tap_no_inline_homebrew_synthesis.sh
@@ -6,11 +6,11 @@
 # else.
 #
 # Allowed sites:
-#   - src/core/tap.zig          single-point fallback in `effectiveOwnerRepo`
-#                               (the cold path during initial `mt tap`).
-#   - src/db/schema.zig         v8→v9 migration backfill needs the prefix
-#                               literal to derive (owner, "homebrew-" || repo)
-#                               from the existing slug.
+#   - src/tap_slug.zig          the one synthesis, beside the prefix strip
+#                               it has to stay consistent with. Both the
+#                               cold-path fallback in `effectiveOwnerRepo`
+#                               and the repair migration call it, which is
+#                               why it sits in a leaf.
 #   - src/cli/migrate/keg.zig   `<prefix>/Library/Taps/<user>/homebrew-<repo>`
 #                               on-disk path — Homebrew's filesystem layout,
 #                               not a URL.
@@ -29,8 +29,7 @@ cd "$ROOT"
 hits=$(grep -rn --include='*.zig' -F 'homebrew-{' src || true)
 
 filtered=$(printf '%s\n' "$hits" |
-  grep -v '^src/core/tap\.zig:' |
-  grep -v '^src/db/schema\.zig:' |
+  grep -v '^src/tap_slug\.zig:' |
   grep -v '^src/cli/migrate/keg\.zig:' |
   grep -v '^$' || true)
 

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -20,6 +20,7 @@ const plist_mod = @import("../core/services/plist.zig");
 const supervisor_mod = @import("../core/services/supervisor.zig");
 const signals = @import("../core/signals.zig");
 const store_mod = @import("../core/store.zig");
+const tap_slug = @import("../tap_slug.zig");
 const lock_mod = @import("../db/lock.zig");
 const lock_report = @import("lock_report.zig");
 const schema = @import("../db/schema.zig");
@@ -306,8 +307,11 @@ fn caskPresent(ctx: *const AppCtx, prefix: []const u8, token: []const u8) bool {
 fn tapPackagePresent(ctx: *const AppCtx, prefix: []const u8, name: []const u8) bool {
     const parts = args_mod.parseTapName(name) orelse return false;
 
-    var slug_buf: [256]u8 = undefined;
-    const slug = std.fmt.bufPrint(&slug_buf, "{s}/{s}", .{ parts.user, parts.repo }) catch return false;
+    // Must key the probe the same way the install path records the row.
+    var slug_raw_buf: [tap_slug.max_slug_len]u8 = undefined;
+    const slug_raw = std.fmt.bufPrint(&slug_raw_buf, "{s}/{s}", .{ parts.user, parts.repo }) catch return false;
+    var slug_buf: [tap_slug.max_slug_len]u8 = undefined;
+    const slug = tap_slug.canonicalTapSlug(&slug_buf, slug_raw) orelse return false;
 
     var db = openExistingDb(ctx, prefix) orelse return false;
     defer db.close();

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -12,6 +12,7 @@ const cellar_mod = @import("../../core/cellar.zig");
 const hash = @import("../../core/hash.zig");
 const linker_mod = @import("../../core/linker.zig");
 const tap_mod = @import("../../core/tap.zig");
+
 const forge = @import("../../core/forge.zig");
 const tap_cache = @import("../../core/tap_cache.zig");
 const sqlite = @import("../../db/sqlite.zig");
@@ -226,8 +227,14 @@ fn installTapRb(
         return InstallError.FormulaNotFound;
     };
 
-    var tap_slug_buf: [128]u8 = undefined;
-    const tap_slug = std.fmt.bufPrint(&tap_slug_buf, "{s}/{s}", .{ parts.user, parts.repo }) catch
+    // Single construction point for the tap key: the registry row,
+    // `kegs.tap`/`casks.tap` and the resolve URLs all inherit it, so
+    // canonicalizing here is what keeps one tap from splitting in two.
+    var tap_slug_raw_buf: [tap_mod.max_slug_len]u8 = undefined;
+    const tap_slug_raw = std.fmt.bufPrint(&tap_slug_raw_buf, "{s}/{s}", .{ parts.user, parts.repo }) catch
+        return InstallError.FormulaNotFound;
+    var tap_slug_buf: [tap_mod.max_slug_len]u8 = undefined;
+    const tap_slug = tap_mod.canonicalTapSlug(&tap_slug_buf, tap_slug_raw) orelse
         return InstallError.FormulaNotFound;
 
     // An already-recorded package needs no `.rb` at all - the post-parse

--- a/src/cli/list.zig
+++ b/src/cli/list.zig
@@ -9,6 +9,7 @@ const schema = @import("../db/schema.zig");
 const sqlite = @import("../db/sqlite.zig");
 const atomic = @import("../fs/atomic.zig");
 const dirsize = @import("../fs/dirsize.zig");
+const tap_slug = @import("../tap_slug.zig");
 const color = @import("../ui/color.zig");
 const output = @import("../ui/output.zig");
 const help = @import("help.zig");
@@ -53,6 +54,11 @@ pub fn execute(ctx: *const AppCtx, args: []const []const u8) !void {
             tap_filter = arg["--tap=".len..];
         }
     }
+    // Rows are stored canonical; fold the filter so every spelling of a
+    // tap selects the same set.
+    var tap_filter_buf: [tap_slug.max_slug_len]u8 = undefined;
+    if (tap_filter) |raw| tap_filter = tap_slug.canonicalTapSlug(&tap_filter_buf, raw) orelse raw;
+
     const json_mode = output.isJson();
 
     // If neither specified, show both

--- a/src/cli/outdated.zig
+++ b/src/cli/outdated.zig
@@ -8,6 +8,7 @@ const formula_mod = @import("../core/formula.zig");
 const schema = @import("../db/schema.zig");
 const sqlite = @import("../db/sqlite.zig");
 const atomic = @import("../fs/atomic.zig");
+const tap_slug = @import("../tap_slug.zig");
 const api_mod = @import("../net/api.zig");
 const client_mod = @import("../net/client.zig");
 const color = @import("../ui/color.zig");
@@ -248,10 +249,12 @@ pub fn planEmit(
 /// Trim ASCII whitespace from a `--tap` label; return null when the
 /// trimmed result is empty so the caller can fail with a precise
 /// error instead of running the DB lookup against `""`.
-pub fn normalizeTapLabel(label: []const u8) ?[]const u8 {
+pub fn normalizeTapLabel(buf: []u8, label: []const u8) ?[]const u8 {
     const trimmed = std.mem.trim(u8, label, " \t\n\r");
     if (trimmed.len == 0) return null;
-    return trimmed;
+    // Rows are stored canonical; fold the filter so `--tap User/Homebrew-X`
+    // and `--tap user/x` select the same set.
+    return tap_slug.canonicalTapSlug(buf, trimmed) orelse trimmed;
 }
 
 /// "All clear" summary line for the current scope, or null when at
@@ -661,14 +664,34 @@ test "planEmit recomputes when --tap= narrows the scope (equals form)" {
 }
 
 test "normalizeTapLabel returns null for empty and whitespace-only labels" {
-    try std.testing.expectEqual(@as(?[]const u8, null), normalizeTapLabel(""));
-    try std.testing.expectEqual(@as(?[]const u8, null), normalizeTapLabel("   "));
-    try std.testing.expectEqual(@as(?[]const u8, null), normalizeTapLabel("\t\n"));
+    var buf: [160]u8 = undefined;
+    try std.testing.expectEqual(@as(?[]const u8, null), normalizeTapLabel(&buf, ""));
+    try std.testing.expectEqual(@as(?[]const u8, null), normalizeTapLabel(&buf, "   "));
+    try std.testing.expectEqual(@as(?[]const u8, null), normalizeTapLabel(&buf, "\t\n"));
 }
 
 test "normalizeTapLabel trims surrounding whitespace from a valid label" {
-    try std.testing.expectEqualStrings("user/repo", normalizeTapLabel("  user/repo  ").?);
-    try std.testing.expectEqualStrings("user/repo", normalizeTapLabel("user/repo").?);
+    var buf: [160]u8 = undefined;
+    try std.testing.expectEqualStrings("user/repo", normalizeTapLabel(&buf, "  user/repo  ").?);
+    try std.testing.expectEqualStrings("user/repo", normalizeTapLabel(&buf, "user/repo").?);
+}
+
+test "normalizeTapLabel passes through a label it cannot fold" {
+    // No slash means no tap identity to fold onto; the raw value is bound
+    // and simply matches nothing, rather than silently selecting a row.
+    var buf: [160]u8 = undefined;
+    try std.testing.expectEqualStrings("noslash", normalizeTapLabel(&buf, " noslash ").?);
+    // Too long for the buffer — same pass-through, no truncation.
+    var tiny: [4]u8 = undefined;
+    try std.testing.expectEqualStrings("user/repo", normalizeTapLabel(&tiny, "user/repo").?);
+}
+
+test "normalizeTapLabel folds a --tap label onto the stored tap identity" {
+    // `--tap` is matched against rows written in canonical form, so the
+    // user's spelling has to be folded before it is bound.
+    var buf: [160]u8 = undefined;
+    try std.testing.expectEqualStrings("indaco/tap", normalizeTapLabel(&buf, " Indaco/Homebrew-Tap ").?);
+    try std.testing.expectEqualStrings("homebrew/core", normalizeTapLabel(&buf, "Homebrew/homebrew-core").?);
 }
 
 test "summaryMessage suppresses 'all up to date' when any row was printed" {
@@ -866,8 +889,9 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
 
     // Validate --tap before any cache/network I/O so a typo never
     // writes a partial snapshot or warms an API cache for nothing.
+    var tap_label_buf: [tap_slug.max_slug_len]u8 = undefined;
     if (tap_filter) |raw_label| {
-        const label = normalizeTapLabel(raw_label) orelse {
+        const label = normalizeTapLabel(&tap_label_buf, raw_label) orelse {
             output.err("--tap requires a non-empty label (e.g. `--tap user/repo`)", .{});
             return error.Aborted;
         };

--- a/src/cli/outdated/rows.zig
+++ b/src/cli/outdated/rows.zig
@@ -53,7 +53,8 @@ pub fn loadFormulaRows(
     const sql: [:0]const u8 = switch (filter) {
         .all => "SELECT name, version, revision, tap, pinned FROM kegs ORDER BY name;",
         .pinned_only => "SELECT name, version, revision, tap, pinned FROM kegs WHERE pinned = 1 ORDER BY name;",
-        // NOCASE so `--tap User/Repo` resolves a row stored lowercase.
+        // NOCASE: redundant now both sides are canonical, kept for
+        // hand-edited or un-migrated DBs. See `tapExists`.
         .by_tap => "SELECT name, version, revision, tap, pinned FROM kegs WHERE tap = ?1 COLLATE NOCASE ORDER BY name;",
     };
     const bind: ?[]const u8 = switch (filter) {
@@ -77,7 +78,8 @@ pub fn loadCaskRows(
     const sql: [:0]const u8 = switch (filter) {
         .all => "SELECT token, version, 0 AS revision, tap, pinned FROM casks ORDER BY token;",
         .pinned_only => "SELECT token, version, 0 AS revision, tap, pinned FROM casks WHERE pinned = 1 ORDER BY token;",
-        // NOCASE so `--tap User/Repo` resolves a row stored lowercase.
+        // NOCASE: redundant now both sides are canonical, kept for
+        // hand-edited or un-migrated DBs. See `tapExists`.
         .by_tap => "SELECT token, version, 0 AS revision, tap, pinned FROM casks WHERE tap = ?1 COLLATE NOCASE ORDER BY token;",
     };
     const bind: ?[]const u8 = switch (filter) {
@@ -94,10 +96,11 @@ pub fn loadCaskRows(
 /// `untap`ped while keeping their installs.
 pub fn tapExists(db: *sqlite.Database, label: []const u8) !bool {
     // Three sources, single round-trip: `?1` is reused across the
-    // UNION ALL legs; `COLLATE NOCASE` matches `--tap User/Repo`
-    // against a lowercase row; `LIMIT 1` short-circuits after the
-    // first match. Caller propagates `error.PrepareFailed` so a
-    // broken schema is diagnosed distinctly from a typo.
+    // UNION ALL legs; `LIMIT 1` short-circuits after the first match.
+    // `COLLATE NOCASE` predates canonicalization and is now redundant —
+    // kept so hand-edited or un-migrated DBs still match. Caller
+    // propagates `error.PrepareFailed` so a broken schema is diagnosed
+    // distinctly from a typo.
     var stmt = try db.prepare(
         \\SELECT 1 FROM taps  WHERE name = ?1 COLLATE NOCASE
         \\UNION ALL

--- a/src/cli/tap.zig
+++ b/src/cli/tap.zig
@@ -840,11 +840,15 @@ fn run(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u
         return;
     }
 
-    const name = positional.?;
-    validateTapName(name) catch {
-        output.err("Invalid tap '{s}'. Expected: user/repo with [A-Za-z0-9._-]", .{name});
+    const raw_name = positional.?;
+    validateTapName(raw_name) catch {
+        output.err("Invalid tap '{s}'. Expected: user/repo with [A-Za-z0-9._-]", .{raw_name});
         return error.Aborted;
     };
+    // One identity per tap: fold here so add and remove agree on the row
+    // key no matter which spelling the user typed.
+    var name_buf: [tap_mod.max_slug_len]u8 = undefined;
+    const name = tap_mod.canonicalTapSlug(&name_buf, raw_name) orelse raw_name;
 
     switch (action) {
         .add => {

--- a/src/core/tap.zig
+++ b/src/core/tap.zig
@@ -72,7 +72,9 @@ pub fn describeResolveError(buf: []u8, err: TapError, forge_kind: forge.Forge, h
 fn githubResolveError(err: TapError) []const u8 {
     return switch (err) {
         error.RateLimited => "GitHub API rate limit reached. Set MALT_GITHUB_TOKEN to an authorized GitHub token to lift the 60/hr anonymous cap.",
-        error.NotFound => "GitHub returned 404 for the tap repo. If the repo lives at github.com/<user>/<exact-name> instead of github.com/<user>/homebrew-<repo>, rerun with --repo <user>/<exact-name>.",
+        // `--repo` is a `mt tap` flag; this hint is shared with `mt install`,
+        // where the escape hatch is to register the tap first.
+        error.NotFound => "GitHub returned 404 for the tap repo. If the repo lives at github.com/<user>/<exact-name> instead of github.com/<user>/homebrew-<repo>, register it with `mt tap <user>/<repo> --repo <user>/<exact-name>` first.",
         error.NetworkError => "Network failure while reaching api.github.com — check connectivity and retry.",
         error.AuthTokenTooLong => "MALT_GITHUB_TOKEN is too long to fit the auth request buffer — verify the token value.",
         error.MalformedJson => "Unexpected response shape from GitHub — rerun with --debug and attach the log when filing an issue.",
@@ -140,6 +142,15 @@ test "describeResolveError gitlab: NetworkError names the instance host, not api
     try std.testing.expect(std.mem.indexOf(u8, msg, "api.github.com") == null);
     // The skip-guard regex in scripts/regressions/*.sh keys on this phrase.
     try std.testing.expect(std.mem.indexOf(u8, msg, "Network failure") != null);
+}
+
+test "describeResolveError github: NotFound points --repo at the command that accepts it" {
+    // The hint is shared with `mt install`, which has no --repo flag, so a
+    // bare "rerun with --repo" would be unactionable for half its callers.
+    var buf: [512]u8 = undefined;
+    const msg = describeResolveError(&buf, error.NotFound, .github, "github.com");
+    try std.testing.expect(std.mem.indexOf(u8, msg, "mt tap <user>/<repo> --repo") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "rerun with --repo") == null);
 }
 
 test "describeResolveError gitlab: NotFound drops the github-only homebrew-/--repo hint" {

--- a/src/core/tap.zig
+++ b/src/core/tap.zig
@@ -3,6 +3,11 @@ const std = @import("std");
 const sqlite = @import("../db/sqlite.zig");
 const client_mod = @import("../net/client.zig");
 const forge = @import("forge.zig");
+const tap_slug = @import("../tap_slug.zig");
+
+/// Re-exported so every tap-facing caller folds a slug the same way.
+pub const canonicalTapSlug = tap_slug.canonicalTapSlug;
+pub const max_slug_len = tap_slug.max_slug_len;
 
 pub const TapInfo = struct {
     name: []const u8,
@@ -562,12 +567,19 @@ pub fn effectiveOwnerRepo(
     // a GitHub-community convention — it does not hold on other forges, so
     // a non-github registration must name its repo explicitly.
     if (!std.mem.eql(u8, host, "github.com")) return error.ExplicitRepoRequired;
-    const slash = std.mem.indexOfScalar(u8, slug, '/') orelse unreachable;
-    const user = slug[0..slash];
-    const repo_part = slug[slash + 1 ..];
+    // Synthesize from the canonical identity, not the typed spelling: an
+    // input that already carries `homebrew-` would otherwise be addressed
+    // as `homebrew-homebrew-<repo>`, which no tap repo answers to.
+    var canon_buf: [160]u8 = undefined;
+    const canon = tap_slug.canonicalTapSlug(&canon_buf, slug) orelse return error.ExplicitRepoRequired;
+    const slash = std.mem.indexOfScalar(u8, canon, '/').?;
+    const user = canon[0..slash];
+    const repo_part = canon[slash + 1 ..];
     const owner_owned = try allocator.dupe(u8, user);
     errdefer allocator.free(owner_owned);
-    const repo_owned = try std.fmt.allocPrint(allocator, "homebrew-{s}", .{repo_part});
+    var repo_buf: [192]u8 = undefined;
+    const repo_synth = tap_slug.synthRepo(&repo_buf, repo_part) orelse return error.ExplicitRepoRequired;
+    const repo_owned = try allocator.dupe(u8, repo_synth);
     errdefer allocator.free(repo_owned);
     const host_owned = try allocator.dupe(u8, "github.com");
     return .{ .owner = owner_owned, .repo = repo_owned, .host = host_owned };
@@ -1012,6 +1024,31 @@ test "effectiveOwnerRepo cold path synthesizes homebrew- for github.com" {
     defer pair.deinit(std.testing.allocator);
     try std.testing.expectEqualStrings("github.com", pair.host);
     try std.testing.expectEqualStrings("aeroxy", pair.owner);
+    try std.testing.expectEqualStrings("homebrew-tap", pair.repo);
+}
+
+test "effectiveOwnerRepo synthesizes from the canonical slug, never a doubled prefix" {
+    // A slug that already carries `homebrew-` used to become
+    // `homebrew-homebrew-<repo>`, which 404s on every real tap.
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    const schema = @import("../db/schema.zig");
+    try schema.initSchema(&db);
+
+    const pair = try effectiveOwnerRepo(std.testing.allocator, &db, "Aeroxy/Homebrew-Tap", "github.com");
+    defer pair.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("aeroxy", pair.owner);
+    try std.testing.expectEqualStrings("homebrew-tap", pair.repo);
+}
+
+test "effectiveOwnerRepo re-prefixes a linuxbrew- slug as homebrew-, like brew" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    const schema = @import("../db/schema.zig");
+    try schema.initSchema(&db);
+
+    const pair = try effectiveOwnerRepo(std.testing.allocator, &db, "aeroxy/linuxbrew-tap", "github.com");
+    defer pair.deinit(std.testing.allocator);
     try std.testing.expectEqualStrings("homebrew-tap", pair.repo);
 }
 

--- a/src/db/schema.zig
+++ b/src/db/schema.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const testing = std.testing;
 
 const sqlite = @import("sqlite.zig");
+const tap_slug = @import("../tap_slug.zig");
 
 /// Initialize the database schema (CREATE TABLE IF NOT EXISTS).
 /// Idempotent — safe to call on an existing database.
@@ -127,7 +128,7 @@ pub fn initSchema(db: *sqlite.Database) MigrateError!void {
 /// Highest schema version this binary knows how to operate on. Bump in
 /// lockstep with the last `migrateVNtoVN+1` step so a future binary's
 /// DB doesn't get silently used against older SQL.
-pub const known_schema_version: i64 = 13;
+pub const known_schema_version: i64 = 14;
 
 pub const MigrateError = sqlite.SqliteError || error{SchemaTooNew};
 
@@ -150,6 +151,7 @@ pub fn migrate(db: *sqlite.Database) MigrateError!void {
     if (ver < 11) try migrateV10toV11(db);
     if (ver < 12) try migrateV11toV12(db);
     if (ver < 13) try migrateV12toV13(db);
+    if (ver < 14) try migrateV13toV14(db);
 }
 
 fn migrateV1toV2(db: *sqlite.Database) sqlite.SqliteError!void {
@@ -678,13 +680,11 @@ fn migrateV12toV13(db: *sqlite.Database) sqlite.SqliteError!void {
     try db.commit();
 }
 
-/// Return true iff every column in `wanted` is present on the `casks`
-/// table. Mirrors the PRAGMA-guarded probes used by v2→v3 / v3→v4 /
-/// v5→v6; centralised here because the v6→v7 backfill needs five
-/// columns, not one.
-fn caskColumnsPresent(db: *sqlite.Database, wanted: []const []const u8) sqlite.SqliteError!bool {
+/// True iff `pragma` reports every column in `wanted`. Generalises the
+/// per-table probes above; the v14 repair spans three tables.
+fn columnsPresent(db: *sqlite.Database, comptime pragma: [:0]const u8, wanted: []const []const u8) sqlite.SqliteError!bool {
     var seen: u32 = 0;
-    var stmt = try db.prepare("PRAGMA table_info(casks);");
+    var stmt = try db.prepare(pragma);
     defer stmt.finalize();
     while (try stmt.step()) {
         const name_ptr = stmt.columnText(1) orelse continue;
@@ -695,6 +695,240 @@ fn caskColumnsPresent(db: *sqlite.Database, wanted: []const []const u8) sqlite.S
     }
     const all: u32 = (@as(u32, 1) << @intCast(wanted.len)) - 1;
     return seen == all;
+}
+
+/// Rows longer than a slug can legally be are left untouched rather
+/// than truncated.
+const tap_slug_cap = tap_slug.max_slug_len;
+
+/// v14 — one identity per tap. Slugs used to be stored exactly as typed,
+/// so `user/homebrew-tap`, `user/tap` and `User/Tap` were three rows for
+/// one tap, and the v9 backfill baked a doubled `homebrew-homebrew-<x>`
+/// repo into any row registered with the prefix.
+///
+/// Written in Zig, not SQL, and driven by the same `tap_slug` helper the
+/// runtime uses: v9's defect got baked in precisely because the backfill
+/// re-implemented the rule in SQL, and sharing the helper is what stops
+/// the stored form and the live form drifting apart again.
+///
+/// `github_repo`/`github_owner`/`url` are repaired only where the stored
+/// value provably came from that backfill — an explicit `--repo`/`--url`
+/// registration survives byte-for-byte.
+///
+/// PRAGMA-guarded like the migrations above so forensic and partial
+/// fixture DBs bump the marker instead of aborting the chain.
+fn migrateV13toV14(db: *sqlite.Database) sqlite.SqliteError!void {
+    try db.beginTransaction();
+    errdefer db.rollback();
+
+    if (try columnsPresent(db, "PRAGMA table_info(taps);", &.{ "id", "name", "url", "github_owner", "github_repo", "commit_sha", "host" })) {
+        try canonicalizeTaps(db);
+    }
+    if (try columnsPresent(db, "PRAGMA table_info(kegs);", &.{ "id", "tap", "full_name" })) {
+        try canonicalizeKegs(db);
+    }
+    if (try columnsPresent(db, "PRAGMA table_info(casks);", &.{ "token", "tap" })) {
+        try canonicalizeCasks(db);
+    }
+
+    try db.exec("INSERT OR IGNORE INTO schema_version (version) VALUES (14);");
+
+    try db.commit();
+}
+
+/// Stage the canonical form of every tap row in a temp table, then let
+/// SQL do the set work. Staging first keeps us from mutating `taps`
+/// while stepping a cursor over it.
+fn canonicalizeTaps(db: *sqlite.Database) sqlite.SqliteError!void {
+    try db.exec("DROP TABLE IF EXISTS temp._tap_v14;");
+    try db.exec(
+        \\CREATE TEMP TABLE _tap_v14 (
+        \\    id     INTEGER PRIMARY KEY,
+        \\    canon  TEXT NOT NULL,
+        \\    can_fetch INTEGER NOT NULL,
+        \\    owner  TEXT,
+        \\    repo   TEXT,
+        \\    url    TEXT
+        \\);
+    );
+
+    {
+        var read = try db.prepare("SELECT id, name, github_owner, github_repo, url FROM taps;");
+        defer read.finalize();
+        var write = try db.prepare(
+            "INSERT INTO temp._tap_v14 (id, canon, can_fetch, owner, repo, url) VALUES (?1, ?2, ?3, ?4, ?5, ?6);",
+        );
+        defer write.finalize();
+
+        while (try read.step()) {
+            const id = read.columnInt(0);
+            const name = std.mem.sliceTo(read.columnText(1) orelse continue, 0);
+            const owner = std.mem.sliceTo(read.columnText(2) orelse "", 0);
+            const repo = std.mem.sliceTo(read.columnText(3) orelse "", 0);
+            const url = std.mem.sliceTo(read.columnText(4) orelse "", 0);
+
+            var canon_buf: [tap_slug_cap]u8 = undefined;
+            const canon = tap_slug.canonicalTapSlug(&canon_buf, name) orelse continue;
+            const slash = std.mem.indexOfScalar(u8, canon, '/').?;
+
+            // The row that can actually fetch wins a collision.
+            var want_buf: [tap_slug_cap]u8 = undefined;
+            const want_repo = tap_slug.synthRepo(&want_buf, canon[slash + 1 ..]) orelse continue;
+            const can_fetch: i64 = if (std.mem.eql(u8, repo, want_repo)) 1 else 0;
+
+            // Damage test: the stored repo equals what the v9 backfill
+            // would have produced from this row's own spelling. Anything
+            // else is an explicit registration and stays as it is.
+            // Folding only downcases and strips a prefix, so `canon`'s slash
+            // sits at the same index as `name`'s.
+            var damaged_buf: [tap_slug_cap]u8 = undefined;
+            const backfilled = tap_slug.synthRepo(&damaged_buf, name[slash + 1 ..]);
+            const damaged = backfilled != null and std.mem.eql(u8, repo, backfilled.?);
+
+            try write.reset();
+            try write.bindInt(1, id);
+            try write.bindText(2, canon);
+            try write.bindInt(3, can_fetch);
+            if (damaged) {
+                try write.bindText(4, canon[0..slash]);
+                try write.bindText(5, want_repo);
+                // Rewrite only the trailing `/<owner>/<repo>`: no URL
+                // shape is assumed beyond the repo being the last segment.
+                var tail_buf: [tap_slug_cap * 2]u8 = undefined;
+                const tail = std.fmt.bufPrint(&tail_buf, "/{s}/{s}", .{ owner, repo }) catch "";
+                var new_buf: [1024]u8 = undefined;
+                if (tail.len != 0 and std.mem.endsWith(u8, url, tail)) {
+                    const fixed = std.fmt.bufPrint(&new_buf, "{s}/{s}/{s}", .{
+                        url[0 .. url.len - tail.len], canon[0..slash], want_repo,
+                    }) catch "";
+                    if (fixed.len != 0) try write.bindText(6, fixed) else try write.bindNull(6);
+                } else {
+                    try write.bindNull(6);
+                }
+            } else {
+                try write.bindNull(4);
+                try write.bindNull(5);
+                try write.bindNull(6);
+            }
+            _ = try write.step();
+        }
+    }
+
+    // Rows that fold together but live on different forges are two real
+    // taps, not one spelled twice — `homebrew-` is a GitHub convention and
+    // says nothing about a repo of that name elsewhere. Folding would make
+    // one of them unrepresentable under UNIQUE(name), so leave the whole
+    // group exactly as registered rather than delete a tap the user still
+    // uses.
+    try db.exec(
+        \\DELETE FROM temp._tap_v14 WHERE canon IN (
+        \\  SELECT k.canon FROM temp._tap_v14 k JOIN taps t ON t.id = k.id
+        \\  GROUP BY k.canon HAVING COUNT(DISTINCT t.host) > 1
+        \\);
+    );
+
+    // `name` is UNIQUE, so canonicalizing can collide. Keep the row that
+    // can fetch, else the one carrying a real pin, else the oldest.
+    try db.exec(
+        \\DELETE FROM taps WHERE id IN (
+        \\  SELECT c.id FROM temp._tap_v14 c
+        \\  WHERE c.id <> (
+        \\    SELECT k.id FROM temp._tap_v14 k JOIN taps t ON t.id = k.id
+        \\    WHERE k.canon = c.canon
+        \\    ORDER BY k.can_fetch DESC, (t.commit_sha IS NOT NULL) DESC, k.id ASC
+        \\    LIMIT 1)
+        \\);
+    );
+    try db.exec("DELETE FROM temp._tap_v14 WHERE id NOT IN (SELECT id FROM taps);");
+
+    try db.exec(
+        \\UPDATE taps SET
+        \\  name         = (SELECT c.canon FROM temp._tap_v14 c WHERE c.id = taps.id),
+        \\  github_owner = COALESCE((SELECT c.owner FROM temp._tap_v14 c WHERE c.id = taps.id), github_owner),
+        \\  github_repo  = COALESCE((SELECT c.repo  FROM temp._tap_v14 c WHERE c.id = taps.id), github_repo),
+        \\  url          = COALESCE((SELECT c.url   FROM temp._tap_v14 c WHERE c.id = taps.id), url)
+        \\WHERE id IN (SELECT id FROM temp._tap_v14);
+    );
+    try db.exec("DROP TABLE temp._tap_v14;");
+}
+
+/// `kegs.tap` plus the tap half of `kegs.full_name` (`<tap>/<name>`),
+/// which `mt info` and uninstall-by-full-name match on. Canonical slugs
+/// are never longer than what they replace, so the width budget the
+/// migrate path works to can only shrink.
+fn canonicalizeKegs(db: *sqlite.Database) sqlite.SqliteError!void {
+    try db.exec("DROP TABLE IF EXISTS temp._keg_v14;");
+    try db.exec("CREATE TEMP TABLE _keg_v14 (id INTEGER PRIMARY KEY, tap TEXT NOT NULL, full_name TEXT);");
+    {
+        var read = try db.prepare("SELECT id, tap, full_name FROM kegs WHERE tap IS NOT NULL AND tap <> '';");
+        defer read.finalize();
+        var stage = try db.prepare("INSERT INTO temp._keg_v14 (id, tap, full_name) VALUES (?1, ?2, ?3);");
+        defer stage.finalize();
+        while (try read.step()) {
+            const id = read.columnInt(0);
+            const tap = std.mem.sliceTo(read.columnText(1) orelse continue, 0);
+            var canon_buf: [tap_slug_cap]u8 = undefined;
+            const canon = tap_slug.canonicalTapSlug(&canon_buf, tap) orelse continue;
+
+            try stage.reset();
+            try stage.bindInt(1, id);
+            try stage.bindText(2, canon);
+            // NULL full_name means "leave it"; the UPDATE coalesces.
+            const full = if (read.columnText(2)) |f| std.mem.sliceTo(f, 0) else "";
+            var full_buf: [1024]u8 = undefined;
+            const rewritable = full.len > tap.len and
+                std.mem.startsWith(u8, full, tap) and full[tap.len] == '/';
+            const fixed = if (rewritable)
+                std.fmt.bufPrint(&full_buf, "{s}{s}", .{ canon, full[tap.len..] }) catch ""
+            else
+                "";
+            if (fixed.len != 0) try stage.bindText(3, fixed) else try stage.bindNull(3);
+            _ = try stage.step();
+        }
+    }
+    try db.exec(
+        \\UPDATE kegs SET
+        \\  tap       = (SELECT k.tap FROM temp._keg_v14 k WHERE k.id = kegs.id),
+        \\  full_name = COALESCE((SELECT k.full_name FROM temp._keg_v14 k WHERE k.id = kegs.id), full_name)
+        \\WHERE id IN (SELECT id FROM temp._keg_v14);
+    );
+    try db.exec("DROP TABLE temp._keg_v14;");
+}
+
+/// `casks.tap` has no UNIQUE constraint, so every non-empty value folds
+/// with no collision handling.
+fn canonicalizeCasks(db: *sqlite.Database) sqlite.SqliteError!void {
+    try db.exec("DROP TABLE IF EXISTS temp._cask_v14;");
+    try db.exec("CREATE TEMP TABLE _cask_v14 (token TEXT PRIMARY KEY, tap TEXT NOT NULL);");
+    {
+        var read = try db.prepare("SELECT token, tap FROM casks WHERE tap IS NOT NULL AND tap <> '';");
+        defer read.finalize();
+        var stage = try db.prepare("INSERT OR REPLACE INTO temp._cask_v14 (token, tap) VALUES (?1, ?2);");
+        defer stage.finalize();
+        while (try read.step()) {
+            const token = std.mem.sliceTo(read.columnText(0) orelse continue, 0);
+            const tap = std.mem.sliceTo(read.columnText(1) orelse continue, 0);
+            var canon_buf: [tap_slug_cap]u8 = undefined;
+            const canon = tap_slug.canonicalTapSlug(&canon_buf, tap) orelse continue;
+            try stage.reset();
+            try stage.bindText(1, token);
+            try stage.bindText(2, canon);
+            _ = try stage.step();
+        }
+    }
+    try db.exec(
+        \\UPDATE casks SET tap = (SELECT c.tap FROM temp._cask_v14 c WHERE c.token = casks.token)
+        \\WHERE token IN (SELECT token FROM temp._cask_v14);
+    );
+    try db.exec("DROP TABLE temp._cask_v14;");
+}
+
+/// Return true iff every column in `wanted` is present on the `casks`
+/// table. Mirrors the PRAGMA-guarded probes used by v2→v3 / v3→v4 /
+/// v5→v6; centralised here because the v6→v7 backfill needs five
+/// columns, not one.
+fn caskColumnsPresent(db: *sqlite.Database, wanted: []const []const u8) sqlite.SqliteError!bool {
+    return columnsPresent(db, "PRAGMA table_info(casks);", wanted);
 }
 
 /// Query the current schema version.
@@ -788,6 +1022,326 @@ test "fresh DB ships kegs at the v5 UNIQUE without a rebuild (v5 shape)" {
     // The short-circuit still has to bump the marker and let the rest of
     // the ladder run.
     try testing.expectEqual(known_schema_version, try currentVersion(&db));
+}
+
+fn seedV13Taps(db: *sqlite.Database) sqlite.SqliteError!void {
+    try db.exec("DELETE FROM schema_version WHERE version >= 14;");
+}
+
+fn tapField(db: *sqlite.Database, comptime sql: [:0]const u8, key: []const u8, buf: []u8) sqlite.SqliteError!?[]const u8 {
+    var stmt = try db.prepare(sql);
+    defer stmt.finalize();
+    try stmt.bindText(1, key);
+    if (!(try stmt.step())) return null;
+    const v = stmt.columnText(0) orelse return null;
+    const t = std.mem.sliceTo(v, 0);
+    @memcpy(buf[0..t.len], t);
+    return buf[0..t.len];
+}
+
+test "v13→v14 canonicalizes a prefixed tap row and repairs its synthesised repo" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO taps (name, url, github_owner, github_repo)
+        \\VALUES ('Indaco/Homebrew-Tap', 'https://github.com/Indaco/homebrew-Homebrew-Tap',
+        \\        'Indaco', 'homebrew-Homebrew-Tap');
+    );
+    try seedV13Taps(&db);
+    try migrate(&db);
+
+    var buf: [128]u8 = undefined;
+    try testing.expectEqualStrings("homebrew-tap", (try tapField(&db, "SELECT github_repo FROM taps WHERE name = ?1;", "indaco/tap", &buf)).?);
+    var buf2: [256]u8 = undefined;
+    try testing.expectEqualStrings(
+        "https://github.com/indaco/homebrew-tap",
+        (try tapField(&db, "SELECT url FROM taps WHERE name = ?1;", "indaco/tap", &buf2)).?,
+    );
+    try testing.expectEqual(known_schema_version, try currentVersion(&db));
+}
+
+test "v13→v14 leaves an explicitly registered repo and url byte-for-byte" {
+    // An explicit `--repo`/`--url` pair is intent, not v9 damage: only a
+    // value equal to the synthesised one may be rewritten.
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO taps (name, url, github_owner, github_repo)
+        \\VALUES ('Grp/Homebrew-Tap', 'https://gitlab.com/grp/exact-name', 'grp', 'exact-name');
+    );
+    try seedV13Taps(&db);
+    try migrate(&db);
+
+    var buf: [128]u8 = undefined;
+    try testing.expectEqualStrings("exact-name", (try tapField(&db, "SELECT github_repo FROM taps WHERE name = ?1;", "grp/tap", &buf)).?);
+    var buf2: [256]u8 = undefined;
+    try testing.expectEqualStrings(
+        "https://gitlab.com/grp/exact-name",
+        (try tapField(&db, "SELECT url FROM taps WHERE name = ?1;", "grp/tap", &buf2)).?,
+    );
+}
+
+test "v13→v14 collapses colliding spellings onto the row that can actually fetch" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    // The prefixed row carries the doubled repo (never fetched); the bare
+    // row is the one whose repo resolves, so it must be the survivor.
+    try db.exec(
+        \\INSERT INTO taps (name, url, commit_sha, github_owner, github_repo) VALUES
+        \\  ('u/homebrew-tap', 'https://github.com/u/homebrew-homebrew-tap', 'a', 'u', 'homebrew-homebrew-tap'),
+        \\  ('u/tap',          'https://github.com/u/homebrew-tap',          NULL, 'u', 'homebrew-tap');
+    );
+    try seedV13Taps(&db);
+    try migrate(&db);
+
+    var count = try db.prepare("SELECT COUNT(*) FROM taps;");
+    defer count.finalize();
+    try testing.expect(try count.step());
+    try testing.expectEqual(@as(i64, 1), count.columnInt(0));
+
+    var buf: [128]u8 = undefined;
+    try testing.expectEqualStrings("homebrew-tap", (try tapField(&db, "SELECT github_repo FROM taps WHERE name = ?1;", "u/tap", &buf)).?);
+}
+
+test "v13→v14 keeps the pinned row when neither collision side has a fetchable repo" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO taps (name, url, commit_sha, github_owner, github_repo) VALUES
+        \\  ('u/homebrew-tap', 'https://x/a', NULL, 'u', 'zzz'),
+        \\  ('u/Tap',          'https://x/b', 'deadbeef', 'u', 'yyy');
+    );
+    try seedV13Taps(&db);
+    try migrate(&db);
+
+    var buf: [128]u8 = undefined;
+    try testing.expectEqualStrings("deadbeef", (try tapField(&db, "SELECT commit_sha FROM taps WHERE name = ?1;", "u/tap", &buf)).?);
+}
+
+test "v13→v14 keeps two same-named taps that live on different forges" {
+    // `homebrew-` is a GitHub convention; a repo of that name on another
+    // forge is a different tap. Folding these together would delete a
+    // registration the user still uses.
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO taps (name, url, commit_sha, github_owner, github_repo, host) VALUES
+        \\  ('Acme/Homebrew-Tap', 'https://github.com/Acme/homebrew-Homebrew-Tap', NULL,
+        \\   'Acme', 'homebrew-Homebrew-Tap', 'github.com'),
+        \\  ('acme/tap', 'https://gitlab.example.com/acme/tap', 'deadbeef', 'acme', 'tap',
+        \\   'gitlab.example.com');
+    );
+    try seedV13Taps(&db);
+    try migrate(&db);
+
+    var count = try db.prepare("SELECT COUNT(*) FROM taps;");
+    defer count.finalize();
+    try testing.expect(try count.step());
+    try testing.expectEqual(@as(i64, 2), count.columnInt(0));
+
+    // Both keep the name they were registered under.
+    var buf: [128]u8 = undefined;
+    try testing.expectEqualStrings(
+        "gitlab.example.com",
+        (try tapField(&db, "SELECT host FROM taps WHERE name = ?1;", "acme/tap", &buf)).?,
+    );
+    var buf2: [128]u8 = undefined;
+    try testing.expectEqualStrings(
+        "github.com",
+        (try tapField(&db, "SELECT host FROM taps WHERE name = ?1;", "Acme/Homebrew-Tap", &buf2)).?,
+    );
+}
+
+test "v13→v14 carries the surviving row's untouched columns through a collision" {
+    // The repair rewrites name/owner/repo/url; everything else on the
+    // winning row must come through byte-for-byte.
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO taps (name, url, commit_sha, head_etag, github_owner, github_repo, host, forge, added_at) VALUES
+        \\  ('u/homebrew-tap', 'https://x/a', NULL, NULL, 'u', 'homebrew-homebrew-tap', 'github.com', NULL, '2020-01-01 00:00:00'),
+        \\  ('U/Tap', 'https://github.com/u/homebrew-tap', 'sha', 'etag-keep', 'u', 'homebrew-tap', 'github.com', 'github', '2021-02-03 04:05:06');
+    );
+    try seedV13Taps(&db);
+    try migrate(&db);
+
+    var stmt = try db.prepare("SELECT commit_sha, head_etag, host, forge, added_at FROM taps WHERE name='u/tap';");
+    defer stmt.finalize();
+    try testing.expect(try stmt.step());
+    try testing.expectEqualStrings("sha", std.mem.sliceTo(stmt.columnText(0).?, 0));
+    try testing.expectEqualStrings("etag-keep", std.mem.sliceTo(stmt.columnText(1).?, 0));
+    try testing.expectEqualStrings("github.com", std.mem.sliceTo(stmt.columnText(2).?, 0));
+    try testing.expectEqualStrings("github", std.mem.sliceTo(stmt.columnText(3).?, 0));
+    try testing.expectEqualStrings("2021-02-03 04:05:06", std.mem.sliceTo(stmt.columnText(4).?, 0));
+    try testing.expect(!try stmt.step());
+}
+
+test "v13→v14 resolves a three-way collision down to a single row" {
+    // Two rows deleted in one statement whose subquery reads the same
+    // table it deletes from — the arity the two-row case cannot expose.
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO taps (name, url, commit_sha, github_owner, github_repo) VALUES
+        \\  ('U/Homebrew-Tap',   'https://x/a', NULL, 'U', 'homebrew-Homebrew-Tap'),
+        \\  ('u/linuxbrew-tap',  'https://x/b', NULL, 'u', 'homebrew-linuxbrew-tap'),
+        \\  ('u/tap',            'https://x/c', 'sha', 'u', 'homebrew-tap');
+    );
+    try seedV13Taps(&db);
+    try migrate(&db);
+
+    var count = try db.prepare("SELECT COUNT(*) FROM taps;");
+    defer count.finalize();
+    try testing.expect(try count.step());
+    try testing.expectEqual(@as(i64, 1), count.columnInt(0));
+
+    var buf: [128]u8 = undefined;
+    try testing.expectEqualStrings("sha", (try tapField(&db, "SELECT commit_sha FROM taps WHERE name = ?1;", "u/tap", &buf)).?);
+}
+
+test "v13→v14 is idempotent when re-run over already-canonical rows" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO taps (name, url, github_owner, github_repo)
+        \\VALUES ('Indaco/Homebrew-Tap', 'https://github.com/Indaco/homebrew-Homebrew-Tap',
+        \\        'Indaco', 'homebrew-Homebrew-Tap');
+    );
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, tap)
+        \\VALUES ('a', 'Indaco/Homebrew-Tap/a', '1.0', 'sha-a', '/c/a/1.0', 'Indaco/Homebrew-Tap');
+    );
+    try seedV13Taps(&db);
+    try migrate(&db);
+    try seedV13Taps(&db);
+    try migrate(&db);
+
+    var buf: [256]u8 = undefined;
+    try testing.expectEqualStrings(
+        "https://github.com/indaco/homebrew-tap",
+        (try tapField(&db, "SELECT url FROM taps WHERE name = ?1;", "indaco/tap", &buf)).?,
+    );
+    var buf2: [128]u8 = undefined;
+    try testing.expectEqualStrings(
+        "indaco/tap/a",
+        (try tapField(&db, "SELECT full_name FROM kegs WHERE name = ?1;", "a", &buf2)).?,
+    );
+}
+
+test "v13→v14 leaves a full_name that does not carry its tap prefix alone" {
+    // Pre-full_name rows store the bare leaf; rewriting blindly would
+    // corrupt what `mt info` and uninstall-by-full-name match on.
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, tap)
+        \\VALUES ('a', 'a', '1.0', 'sha-a', '/c/a/1.0', 'U/Homebrew-Tap');
+    );
+    try seedV13Taps(&db);
+    try migrate(&db);
+
+    var buf: [128]u8 = undefined;
+    try testing.expectEqualStrings("a", (try tapField(&db, "SELECT full_name FROM kegs WHERE name = ?1;", "a", &buf)).?);
+    var buf2: [128]u8 = undefined;
+    try testing.expectEqualStrings("u/tap", (try tapField(&db, "SELECT tap FROM kegs WHERE name = ?1;", "a", &buf2)).?);
+}
+
+test "v13→v14 bumps the marker past a degenerate slug it cannot canonicalize" {
+    // Forensic fixtures must not abort the migration chain.
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO taps (name, url, github_owner, github_repo)
+        \\VALUES ('noslash', 'https://x/a', 'noslash', 'noslash');
+    );
+    try seedV13Taps(&db);
+    try migrate(&db);
+
+    var buf: [128]u8 = undefined;
+    try testing.expectEqualStrings("noslash", (try tapField(&db, "SELECT name FROM taps WHERE name = ?1;", "noslash", &buf)).?);
+    try testing.expectEqual(known_schema_version, try currentVersion(&db));
+}
+
+test "v13→v14 bumps the marker even when every table is empty" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+    try seedV13Taps(&db);
+    try migrate(&db);
+    try testing.expectEqual(known_schema_version, try currentVersion(&db));
+}
+
+test "v13→v14 canonicalizes kegs.tap, casks.tap and the tap half of full_name" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, tap)
+        \\VALUES ('myx', 'HaseebKhalid1507/homebrew-tap/myx', '0.4.0', 'sha-myx', '/c/myx/0.4.0',
+        \\        'HaseebKhalid1507/homebrew-tap');
+    );
+    try db.exec(
+        \\INSERT INTO casks (token, name, version, url, tap)
+        \\VALUES ('font-x', 'Font X', '1.0', 'https://x/f.zip', 'U/Homebrew-Fonts');
+    );
+    try seedV13Taps(&db);
+    try migrate(&db);
+
+    var buf: [128]u8 = undefined;
+    try testing.expectEqualStrings(
+        "haseebkhalid1507/tap",
+        (try tapField(&db, "SELECT tap FROM kegs WHERE name = ?1;", "myx", &buf)).?,
+    );
+    var buf2: [128]u8 = undefined;
+    try testing.expectEqualStrings(
+        "haseebkhalid1507/tap/myx",
+        (try tapField(&db, "SELECT full_name FROM kegs WHERE name = ?1;", "myx", &buf2)).?,
+    );
+    var buf3: [128]u8 = undefined;
+    try testing.expectEqualStrings(
+        "u/fonts",
+        (try tapField(&db, "SELECT tap FROM casks WHERE token = ?1;", "font-x", &buf3)).?,
+    );
+}
+
+test "v13→v14 leaves a core-tap keg and a NULL tap alone" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, tap)
+        \\VALUES ('jq', 'jq', '1.7', 'sha-jq', '/c/jq/1.7', NULL);
+    );
+    try seedV13Taps(&db);
+    try migrate(&db);
+
+    var stmt = try db.prepare("SELECT full_name, tap FROM kegs WHERE name='jq';");
+    defer stmt.finalize();
+    try testing.expect(try stmt.step());
+    try testing.expectEqualStrings("jq", std.mem.sliceTo(stmt.columnText(0).?, 0));
+    try testing.expect(stmt.columnText(1) == null);
 }
 
 test "v4→v5 migration is idempotent when kegs already carries the v5 UNIQUE" {
@@ -1025,7 +1579,7 @@ test "v6→v7 migration backfills cask_versions from existing casks rows" {
     const token1 = stmt.columnText(0) orelse return error.TestUnexpectedResult;
     try testing.expectEqualStrings("flux-markdown", std.mem.sliceTo(token1, 0));
 
-    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
+    try testing.expectEqual(known_schema_version, try currentVersion(&db));
 }
 
 test "v6→v7 migration is idempotent when cask_versions already carries the rows" {
@@ -1074,7 +1628,7 @@ test "fresh DB ships with taps.head_etag (v8 shape)" {
         }
     }
     try testing.expect(found);
-    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
+    try testing.expectEqual(known_schema_version, try currentVersion(&db));
 }
 
 test "v7→v8 migration adds head_etag and preserves existing tap rows" {
@@ -1105,7 +1659,7 @@ test "v7→v8 migration adds head_etag and preserves existing tap rows" {
     );
     // Pre-v8 rows must carry NULL until a conditional GET populates it.
     try testing.expect(probe.columnText(1) == null);
-    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
+    try testing.expectEqual(known_schema_version, try currentVersion(&db));
 }
 
 test "v7→v8 migration is idempotent when head_etag is already present" {
@@ -1154,7 +1708,7 @@ test "fresh DB ships with taps.github_owner and taps.github_repo (v9 shape)" {
     }
     try testing.expect(owner_seen);
     try testing.expect(repo_seen);
-    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
+    try testing.expectEqual(known_schema_version, try currentVersion(&db));
 }
 
 test "v8→v9 migration backfills (user, \"homebrew-\" || repo) from existing slugs" {
@@ -1174,7 +1728,7 @@ test "v8→v9 migration backfills (user, \"homebrew-\" || repo) from existing sl
 
     try migrate(&db);
 
-    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
+    try testing.expectEqual(known_schema_version, try currentVersion(&db));
 
     var probe = try db.prepare(
         "SELECT name, github_owner, github_repo FROM taps ORDER BY name;",
@@ -1236,7 +1790,7 @@ test "v8→v9 migration bumps the marker even when taps is empty" {
     try db.exec("DELETE FROM schema_version WHERE version >= 9;");
     try migrate(&db);
 
-    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
+    try testing.expectEqual(known_schema_version, try currentVersion(&db));
 }
 
 // Pre-v3 rows could in theory have escaped slug validation. The CASE
@@ -1263,7 +1817,7 @@ test "v8→v9 migration tolerates a slug starting with a slash (degenerate fixtu
 
     // We don't pin the specific (owner, repo) values for degenerate
     // input — only that the migration completes and the marker bumps.
-    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
+    try testing.expectEqual(known_schema_version, try currentVersion(&db));
 }
 
 test "v8→v9 migration falls back to verbatim name on a slug missing the slash" {
@@ -1308,7 +1862,7 @@ test "fresh DB ships with kegs.bin_isolated (v10 shape)" {
         }
     }
     try testing.expect(found);
-    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
+    try testing.expectEqual(known_schema_version, try currentVersion(&db));
 }
 
 test "v9→v10 migration adds bin_isolated and defaults existing rows to 0" {
@@ -1327,7 +1881,7 @@ test "v9→v10 migration adds bin_isolated and defaults existing rows to 0" {
 
     try migrate(&db);
 
-    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
+    try testing.expectEqual(known_schema_version, try currentVersion(&db));
 
     var probe = try db.prepare("SELECT name, bin_isolated FROM kegs ORDER BY name;");
     defer probe.finalize();
@@ -1401,7 +1955,7 @@ test "fresh DB ships with taps.host defaulting to github.com (v11 shape)" {
     try testing.expect(try probe.step());
     try testing.expectEqualStrings("github.com", std.mem.sliceTo(probe.columnText(0) orelse "", 0));
 
-    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
+    try testing.expectEqual(known_schema_version, try currentVersion(&db));
 }
 
 test "v10→v11 migration backfills host=github.com on existing tap rows" {
@@ -1419,7 +1973,7 @@ test "v10→v11 migration backfills host=github.com on existing tap rows" {
 
     try migrate(&db);
 
-    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
+    try testing.expectEqual(known_schema_version, try currentVersion(&db));
 
     var probe = try db.prepare("SELECT host FROM taps WHERE name='aeroxy/tap';");
     defer probe.finalize();
@@ -1460,7 +2014,7 @@ test "v10→v11 migration bumps the marker even when taps is empty" {
     try db.exec("DELETE FROM schema_version WHERE version >= 11;");
     try migrate(&db);
 
-    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
+    try testing.expectEqual(known_schema_version, try currentVersion(&db));
 }
 
 // v11→v12 adds taps.forge so a tap can name its provider explicitly when
@@ -1496,7 +2050,7 @@ test "fresh DB ships with a nullable taps.forge column (v12 shape)" {
     try testing.expect(try probe.step());
     try testing.expect(probe.columnText(0) == null);
 
-    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
+    try testing.expectEqual(known_schema_version, try currentVersion(&db));
 }
 
 test "v11→v12 migration adds taps.forge as NULL on existing rows" {
@@ -1512,7 +2066,7 @@ test "v11→v12 migration adds taps.forge as NULL on existing rows" {
 
     try migrate(&db);
 
-    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
+    try testing.expectEqual(known_schema_version, try currentVersion(&db));
 
     var probe = try db.prepare("SELECT forge FROM taps WHERE name='aeroxy/tap';");
     defer probe.finalize();
@@ -1573,7 +2127,7 @@ test "fresh DB ships with a nullable services.schedule column (v13 shape)" {
     try testing.expect(try probe.step());
     try testing.expect(probe.columnText(0) == null);
 
-    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
+    try testing.expectEqual(known_schema_version, try currentVersion(&db));
 }
 
 test "v12→v13 migration adds services.schedule as NULL on existing rows" {
@@ -1591,7 +2145,7 @@ test "v12→v13 migration adds services.schedule as NULL on existing rows" {
 
     try migrate(&db);
 
-    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
+    try testing.expectEqual(known_schema_version, try currentVersion(&db));
 
     var probe = try db.prepare("SELECT schedule FROM services WHERE name='redis';");
     defer probe.finalize();

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -97,6 +97,7 @@ pub const client_pool = @import("net/client_pool.zig");
 pub const ghcr = @import("net/ghcr.zig");
 pub const mirror = @import("net/mirror.zig");
 pub const offline = @import("net/offline.zig");
+pub const tap_slug = @import("tap_slug.zig");
 pub const text_replace = @import("text_replace.zig");
 pub const color = @import("ui/color.zig");
 pub const custom_theme = @import("ui/custom_theme.zig");

--- a/src/tap_slug.zig
+++ b/src/tap_slug.zig
@@ -1,0 +1,109 @@
+//! Canonical tap identity — the one place a `user/repo` tap slug is
+//! folded to the single form every layer keys on.
+//!
+//! A leaf on purpose: both `core/tap.zig` (URL synthesis, registry
+//! writes) and `db/schema.zig` (the migration that repairs stored rows)
+//! need it, and a leaf cannot import `core`. Sharing the runtime helper
+//! is what keeps the migration from drifting away from the live rule.
+
+const std = @import("std");
+
+/// Buffer size every caller should use for a slug. `validateTapName`
+/// caps a component at 64, but `parseTapName` on the install path does
+/// not validate length at all, and GitHub itself allows 39 + 100 — so
+/// size to the forge's limit, not malt's.
+pub const max_slug_len = 256;
+
+/// Fold a validated `user/repo` slug to Homebrew's canonical identity:
+/// both components ASCII-downcased, and one anchored `homebrew-` /
+/// `linuxbrew-` stripped from the repo component. The stripped form is
+/// the *identity*; the git repo is addressed as `homebrew-<repo>` on top
+/// of it, which is why `linuxbrew-x` and `homebrew-x` collapse together.
+///
+/// Returns `null` on a slug with no `/` or a `buf` too small — callers
+/// already validate the shape and fail on their own terms.
+///
+/// The strip is not looped: `user/homebrew-homebrew-x` canonicalizes to
+/// `user/homebrew-x`, matching brew's anchored regex.
+pub fn canonicalTapSlug(buf: []u8, slug: []const u8) ?[]const u8 {
+    const slash = std.mem.indexOfScalar(u8, slug, '/') orelse return null;
+    const user = slug[0..slash];
+    var repo = slug[slash + 1 ..];
+
+    // Compare case-insensitively: the downcase happens on the way out,
+    // so `Homebrew-Tap` must strip too.
+    for ([_][]const u8{ "homebrew-", "linuxbrew-" }) |prefix| {
+        if (repo.len > prefix.len and std.ascii.eqlIgnoreCase(repo[0..prefix.len], prefix)) {
+            repo = repo[prefix.len..];
+            break;
+        }
+    }
+
+    if (user.len + 1 + repo.len > buf.len) return null;
+    _ = std.ascii.lowerString(buf[0..user.len], user);
+    buf[user.len] = '/';
+    _ = std.ascii.lowerString(buf[user.len + 1 ..][0..repo.len], repo);
+    return buf[0 .. user.len + 1 + repo.len];
+}
+
+/// The git repo a canonical slug's `repo` component addresses. Homebrew
+/// always re-prefixes the stripped identity, which is why a `linuxbrew-`
+/// input still ends up at a `homebrew-` repo. Kept beside
+/// `canonicalTapSlug` so the strip and the re-prefix can never drift.
+///
+/// Returns `null` when `buf` cannot hold the result.
+pub fn synthRepo(buf: []u8, canonical_repo: []const u8) ?[]const u8 {
+    return std.fmt.bufPrint(buf, "homebrew-{s}", .{canonical_repo}) catch null;
+}
+
+test "synthRepo re-prefixes the stripped identity" {
+    var buf: [64]u8 = undefined;
+    try std.testing.expectEqualStrings("homebrew-tap", synthRepo(&buf, "tap").?);
+    var tiny: [4]u8 = undefined;
+    try std.testing.expect(synthRepo(&tiny, "tap") == null);
+}
+
+test "canonicalTapSlug strips one homebrew- prefix from the repo component" {
+    var buf: [128]u8 = undefined;
+    try std.testing.expectEqualStrings("indaco/tap", canonicalTapSlug(&buf, "indaco/homebrew-tap").?);
+    try std.testing.expectEqualStrings("indaco/tap", canonicalTapSlug(&buf, "indaco/tap").?);
+    // Anchored, not looped — brew leaves the inner prefix in place.
+    try std.testing.expectEqualStrings("indaco/homebrew-tap", canonicalTapSlug(&buf, "indaco/homebrew-homebrew-tap").?);
+}
+
+test "canonicalTapSlug folds linuxbrew- onto the same identity as homebrew-" {
+    var buf: [128]u8 = undefined;
+    try std.testing.expectEqualStrings("u/x", canonicalTapSlug(&buf, "u/linuxbrew-x").?);
+    try std.testing.expectEqualStrings("u/x", canonicalTapSlug(&buf, "u/homebrew-x").?);
+}
+
+test "canonicalTapSlug downcases both components" {
+    var buf: [128]u8 = undefined;
+    try std.testing.expectEqualStrings(
+        "haseebkhalid1507/tap",
+        canonicalTapSlug(&buf, "HaseebKhalid1507/Homebrew-Tap").?,
+    );
+    try std.testing.expectEqualStrings("homebrew/core", canonicalTapSlug(&buf, "Homebrew/homebrew-core").?);
+}
+
+test "canonicalTapSlug leaves a prefix that is the whole repo component alone" {
+    var buf: [128]u8 = undefined;
+    // Stripping would leave an empty repo, which is not a tap identity.
+    try std.testing.expectEqualStrings("u/homebrew-", canonicalTapSlug(&buf, "u/homebrew-").?);
+    try std.testing.expectEqualStrings("u/homebrew", canonicalTapSlug(&buf, "u/homebrew").?);
+}
+
+test "canonicalTapSlug rejects a slug with no slash and a buffer that cannot hold the result" {
+    var buf: [128]u8 = undefined;
+    try std.testing.expect(canonicalTapSlug(&buf, "noslash") == null);
+    var tiny: [4]u8 = undefined;
+    try std.testing.expect(canonicalTapSlug(&tiny, "user/repo") == null);
+    // Exactly-fitting buffers are accepted.
+    var exact: [9]u8 = undefined;
+    try std.testing.expectEqualStrings("user/repo", canonicalTapSlug(&exact, "user/repo").?);
+}
+
+test "canonicalTapSlug preserves the dots, underscores and dashes validateComponent allows" {
+    var buf: [128]u8 = undefined;
+    try std.testing.expectEqualStrings("my.user_1/my-tap.rb", canonicalTapSlug(&buf, "My.User_1/Homebrew-My-Tap.RB").?);
+}

--- a/tests/cask_test.zig
+++ b/tests/cask_test.zig
@@ -1289,7 +1289,7 @@ test "v6→v7 migration leaves cask_versions empty when casks has a broken shape
     _ = try stmt.step();
     try testing.expectEqual(@as(i64, 0), stmt.columnInt(0));
     // Migration still bumps the schema marker so a future run skips this path.
-    try testing.expectEqual(@as(i64, 13), try schema.currentVersion(&db));
+    try testing.expectEqual(schema.known_schema_version, try schema.currentVersion(&db));
 }
 
 // v7→v8 / v8→v9 ALTERs must skip when `taps` is missing entirely
@@ -1310,7 +1310,7 @@ test "v7→v8 migration tolerates a missing taps table" {
 
     try schema.migrate(&db);
 
-    try testing.expectEqual(@as(i64, 13), try schema.currentVersion(&db));
+    try testing.expectEqual(schema.known_schema_version, try schema.currentVersion(&db));
 }
 
 // --- coverage: lookupCaskVersion refuses a malformed row ----------------

--- a/tests/db_schema_v2_test.zig
+++ b/tests/db_schema_v2_test.zig
@@ -60,7 +60,7 @@ test "initSchema runs v1 then migrates to the current known version" {
     try testing.expect(try tableExists(&tdb.db, "bundle_members"));
 
     const ver = try schema.currentVersion(&tdb.db);
-    try testing.expectEqual(@as(i64, 13), ver);
+    try testing.expectEqual(schema.known_schema_version, ver);
 }
 
 test "migrate is idempotent on re-run" {
@@ -72,7 +72,7 @@ test "migrate is idempotent on re-run" {
     try schema.migrate(&tdb.db);
 
     const ver = try schema.currentVersion(&tdb.db);
-    try testing.expectEqual(@as(i64, 13), ver);
+    try testing.expectEqual(schema.known_schema_version, ver);
 }
 
 test "v4 migration adds pinned column to casks" {
@@ -102,7 +102,7 @@ test "v4 migration is idempotent on re-run" {
     try schema.migrate(&tdb.db);
 
     const ver = try schema.currentVersion(&tdb.db);
-    try testing.expectEqual(@as(i64, 13), ver);
+    try testing.expectEqual(schema.known_schema_version, ver);
 }
 
 test "v6 migration adds tap column to casks" {
@@ -232,4 +232,55 @@ test "bundle_members cascade-deletes with bundle" {
     defer stmt.finalize();
     _ = try stmt.step();
     try testing.expectEqual(@as(i64, 0), stmt.columnInt(0));
+}
+
+test "v14 leaves one identity per tap across taps, kegs and casks" {
+    // Whole-registry view the per-table unit tests cannot give: three
+    // spellings of one tap, spread over three tables, must join again
+    // after the repair.
+    var t = try TempDb.init("v14_identity");
+    defer t.deinit();
+    try schema.initSchema(&t.db);
+
+    try t.db.exec(
+        \\INSERT INTO taps (name, url, commit_sha, github_owner, github_repo) VALUES
+        \\  ('Indaco/Homebrew-Tap', 'https://github.com/Indaco/homebrew-Homebrew-Tap', NULL,
+        \\   'Indaco', 'homebrew-Homebrew-Tap'),
+        \\  ('indaco/tap', 'https://github.com/indaco/homebrew-tap', 'abc123', 'indaco', 'homebrew-tap');
+    );
+    try t.db.exec(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, tap) VALUES
+        \\  ('a', 'Indaco/Homebrew-Tap/a', '1.0', 'sha-a', '/c/a/1.0', 'Indaco/Homebrew-Tap'),
+        \\  ('b', 'indaco/tap/b',          '2.0', 'sha-b', '/c/b/2.0', 'indaco/tap');
+    );
+    try t.db.exec(
+        \\INSERT INTO casks (token, name, version, url, tap)
+        \\VALUES ('c', 'C', '3.0', 'https://x/c.zip', 'INDACO/linuxbrew-tap');
+    );
+
+    try t.db.exec("DELETE FROM schema_version WHERE version >= 14;");
+    try schema.migrate(&t.db);
+
+    // One surviving tap row, and it is the one carrying the real pin.
+    var taps = try t.db.prepare("SELECT name, commit_sha FROM taps;");
+    defer taps.finalize();
+    try testing.expect(try taps.step());
+    try testing.expectEqualStrings("indaco/tap", std.mem.sliceTo(taps.columnText(0).?, 0));
+    try testing.expectEqualStrings("abc123", std.mem.sliceTo(taps.columnText(1).?, 0));
+    try testing.expect(!try taps.step());
+
+    // Every keg and cask now points at that one row.
+    var joined = try t.db.prepare(
+        \\SELECT COUNT(*) FROM (
+        \\  SELECT tap FROM kegs UNION ALL SELECT tap FROM casks
+        \\) WHERE tap = 'indaco/tap';
+    );
+    defer joined.finalize();
+    try testing.expect(try joined.step());
+    try testing.expectEqual(@as(i64, 3), joined.columnInt(0));
+
+    var full = try t.db.prepare("SELECT full_name FROM kegs WHERE name='a';");
+    defer full.finalize();
+    try testing.expect(try full.step());
+    try testing.expectEqualStrings("indaco/tap/a", std.mem.sliceTo(full.columnText(0).?, 0));
 }


### PR DESCRIPTION
## Description

`mt install user/homebrew-tap/formula` failed on a tap that `brew install` handles fine, and two spellings of one tap produced two registry rows with independent pins - so `mt untap` missed across spellings, and `mt list --tap` and `mt outdated --tap` disagreed on the same data.

Tap slugs now fold to the same identity brew uses, wherever one enters, and a migration reunites rows already stored as typed. Explicit `--repo`/`--url` registrations are left alone.

## Related Issue

- None

## Notes for Reviewers

- The migration is the risky half: `taps.name` is UNIQUE, so folding can genuinely collide. Within one forge it keeps the row that can fetch, else the one carrying a real pin, else the oldest. Across forges it keeps both untouched - `homebrew-` is a GitHub convention and says nothing about a repo of that name elsewhere, so those are two taps, not one.