### PR TITLE
ci(bench): stop reporting an unconfigured peer as a benchmark failure

### DIFF
--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -368,11 +368,14 @@ ensure_nb_short_prefix() {
   cur=$(readlink /opt/nb 2>/dev/null || true)
   [ "$cur" = "$target" ] && return 0
   if [ -n "$cur" ] || [ -e /opt/nb ]; then
-    warn "/opt/nb exists (-> ${cur:-not a symlink}) - leaving it alone; nanobrew installs will fail"
+    warn "/opt/nb exists (-> ${cur:-not a symlink}) - leaving it alone"
+    set_result skip_nb "n/a (/opt/nb points elsewhere)"
     return 0
   fi
-  sudo -n ln -s "$target" /opt/nb 2>/dev/null ||
-    warn "could not create /opt/nb -> $target (needs sudo) - nanobrew installs will fail"
+  sudo -n ln -s "$target" /opt/nb 2>/dev/null || {
+    warn "could not create /opt/nb -> $target (needs sudo)"
+    set_result skip_nb "n/a (/opt/nb missing, needs sudo)"
+  }
 }
 
 build_nanobrew() {
@@ -906,17 +909,34 @@ finalize_results() {
 # published table never lies. Active peers (binary present) are left to
 # finalize_results; this only fills the holes it leaves behind.
 emit_skipped_peers() {
-  local pkg="$1" tool bin reason
+  local pkg="$1" tool reason
   for tool in nb zb; do
-    case "$tool" in
-    nb) bin="$NB_BIN" ;;
-    zb) bin="$ZB_BIN" ;;
-    esac
-    [ -x "$bin" ] && continue
+    peer_usable "$tool" && continue
     reason=$(get_result "skip_$tool")
     emit_output "${tool}_cold_disp=⚠️ ${reason:-n/a}"
     emit_output "${tool}_warm=⚠️ ${reason:-n/a}"
   done
+}
+
+# peer_usable <nb|zb>
+#
+# A peer counts as measurable only when its binary exists *and* nothing has
+# recorded a reason to skip it. Presence alone is not enough: nanobrew installs
+# relocate through `/opt/nb`, and without that symlink every install exits
+# non-zero. Running them anyway spent 24 rounds proving a precondition we had
+# already checked, dumped each failure's output into the log — enough `✗` lines
+# to make any wrapper scanning for failure markers report the bench as broken —
+# and published a column of FAIL cells that read like a peer regression rather
+# than an unconfigured host.
+peer_usable() {
+  local bin
+  case "$1" in
+  nb) bin="$NB_BIN" ;;
+  zb) bin="$ZB_BIN" ;;
+  *) return 1 ;;
+  esac
+  [ -x "$bin" ] || return 1
+  [ -z "$(get_result "skip_$1")" ]
 }
 
 # --- orchestration -----------------------------------------------------------
@@ -927,8 +947,8 @@ run_bench_for() {
   # warmup order; measured rounds rotate from it.
   local tools=(mt)
   if [ "$SKIP_OTHERS" != "1" ]; then
-    [ -x "$NB_BIN" ] && tools+=(nb)
-    [ -x "$ZB_BIN" ] && tools+=(zb)
+    peer_usable nb && tools+=(nb)
+    peer_usable zb && tools+=(zb)
   fi
   if [ "$SKIP_BREW" != "1" ] && command -v brew >/dev/null 2>&1; then
     tools+=(brew)

--- a/scripts/test/bench_release_resolution_test.sh
+++ b/scripts/test/bench_release_resolution_test.sh
@@ -117,6 +117,20 @@ set_result skip_nb ""
 emit_skipped_peers tree
 check "no-reason skip falls back to n/a" "⚠️ n/a" "$(emitted nb_cold_disp)"
 
+# Present binary + recorded reason -> still a marker. nanobrew relocates
+# through /opt/nb and cannot install without it, so a built-but-unusable peer
+# has to be skipped like a missing one; measuring it anyway published a column
+# of FAIL cells that read as a peer regression rather than an unconfigured host.
+: >"$GITHUB_OUTPUT"
+# shellcheck disable=SC2034
+NB_BIN=$(command -v sh)
+set_result skip_nb "n/a (/opt/nb missing, needs sudo)"
+emit_skipped_peers tree
+check "built-but-unusable peer cold cell is a marker" "⚠️ n/a (/opt/nb missing, needs sudo)" "$(emitted nb_cold_disp)"
+check "built-but-unusable peer warm cell is a marker" "⚠️ n/a (/opt/nb missing, needs sudo)" "$(emitted nb_warm)"
+check "built-but-unusable peer is not measurable" "no" "$(peer_usable nb && echo yes || echo no)"
+check "built-and-clean peer is measurable" "yes" "$(set_result skip_nb "" && peer_usable nb && echo yes || echo no)"
+
 echo "fail-fast scope:"
 # BENCH_FAIL_FAST guards malt only. A peer's broken install records FAIL and
 # lets the run continue (its cell gets marked below); malt's aborts, so a


### PR DESCRIPTION
## Description

nanobrew ≥v0.1.208 relocates through a `/opt/nb` symlink and fails every install without it. `ensure_nb_short_prefix` already detects that and warns - then the bench measures the peer anyway, so each round runs an install we knew would fail, dumps the tool's output into the log, and publishes a column of `FAIL` cells. On a host where the symlink cannot be created that is ~480 failure lines and a table that reads like a peer regression rather than an unconfigured machine.

A peer is now measured only when its binary exists *and* nothing has recorded a reason to skip it, reusing the marker the bench already stamps for a peer that failed to build. The cell says why the comparison is missing instead of claiming the tool is broken. Where the symlink can be created - CI - nothing changes.

## Related Issue

- None

## Notes for Reviewers

- The behaviour this adds is "binary present but unusable", which neither the old code nor its tests covered: presence alone gated measurement, so an unusable peer produced a blank cell - the exact silent-hole case the helper's own comment warns about. Four cases added to `scripts/test/bench_release_resolution_test.sh`, including the CI path.