### PR TITLE
docs: add security policy for private vulnerability reports

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Report privately through GitHub: [open a draft security advisory](https://github.com/indaco/malt/security/advisories/new).
+
+Please do not open a public issue, pull request, or discussion for a suspected vulnerability.
+
+Helpful details, when you have them:
+
+- affected version (`mt version`) and macOS version
+- steps to reproduce, or a proof of concept
+- what an attacker gains
+
+## What to Expect
+
+- acknowledgement within 7 days
+- a fix or a decision on the report before the advisory is published
+- credit in the advisory, unless you prefer to stay anonymous

--- a/README.md
+++ b/README.md
@@ -909,6 +909,10 @@ To reproduce locally, `./scripts/local-bench.sh` runs the four CI phases (tree, 
 
 Contributions are welcome. Please open an issue to discuss before submitting large changes. See [CONTRIBUTING](CONTRIBUTING.md).
 
+## Security
+
+Found a vulnerability? Report it privately - do not open a public issue. See [SECURITY](.github/SECURITY.md).
+
 ## License
 
 malt is licensed under the [MIT License](LICENSE). Third-party components and upstream projects - including Homebrew (BSD-2-Clause) and homebrew-core (BSD-2-Clause) - are acknowledged in the [LICENSE](LICENSE) file.


### PR DESCRIPTION
## Description

Adds a security policy so vulnerability reports have an obvious private channel instead of landing in public issues. Private vulnerability reporting is enabled on the repo, so the policy points at GitHub's draft advisory flow and states what a reporter can expect: latest release only, acknowledgement within 7 days, credit in the advisory. The README gets a short Security section carrying the "do not open a public issue" warning where people actually decide where to report.

## Related Issues

- None

## Notes for Reviewers

- None