### PR TITLE
fix(post-install): run the declarative steps upstream moved formulas onto

### DIFF
--- a/justfile
+++ b/justfile
@@ -38,6 +38,7 @@ regressions-static:
     @./scripts/regressions/tap-resolution-contract.sh
     @./scripts/regressions/relocated-store-logic-version-pin.sh
     @./scripts/regressions/post-install-native-spawns-inherit-full-environment.sh
+    @MALT_STATIC_ONLY=1 ./scripts/regressions/post-install-steps-live-artefacts.sh
     @./scripts/test/bench_release_resolution_test.sh
 
 # Run unit tests + cheap static regression guards.

--- a/man/malt.1
+++ b/man/malt.1
@@ -366,6 +366,10 @@ Options:
                  stable `{cask_history: {retained_versions,
                  bytes}}` payload on stdout. Empty state still
                  surfaces with zero values.
+  --post-install-status
+                 Report, per installed keg, whether its
+                 post_install work runs natively or needs the
+                 Ruby fallback. Read-only probe; runs no steps.
 .fi
 .SS tap/untap
 .nf

--- a/scripts/regressions/native-step-coverage-llvm-post-install.sh
+++ b/scripts/regressions/native-step-coverage-llvm-post-install.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Regression: declarative post_install steps upstream ships but malt could not
+# run.
+#
+# Homebrew is migrating formulas off Ruby `def post_install` onto a declarative
+# `post_install_steps` array. Every step type outside `step_map` — and every
+# guard condition outside `guard_condition_map` — routed to `logUnsupported`,
+# so the declared work was silently never done and the install warned with a
+# `--use-system-ruby` hint that cannot work for a formula with no Ruby body.
+# llvm's `configure_clang_system` was the reported case: no
+# `<prefix>/etc/clang/*.cfg`, so a malt-installed clang had no `-isysroot`.
+#
+# The `on` guard is the other half: it carries a `value` and no path at all, so
+# it failed twice over — unknown condition, and nothing for the unconditional
+# spec resolution to resolve.
+#
+# These steps cannot be driven offline through the `mt` binary without standing
+# up a live tap, so behaviour is pinned by the colocated inline unit tests and
+# this script asserts the load-bearing code plus its tests are present, then
+# builds and runs `lib_tests`. A step type registered without a test would let a
+# "register the tag, stub the body" change pass silently, so registration and
+# test are judged together. ~45s, matching its post_install_steps siblings; no
+# network.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+STEPS="$ROOT/src/core/post_install_steps.zig"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+# 1. Every newly covered type must be in the single-source-of-truth table, and
+#    must have at least one inline test naming it. `step_map` also drives
+#    `supportedStepType`, `allStepsSupported` and the doctor probe row, so a
+#    missing entry silently reinstates the partial-skip envelope.
+for t in configure_clang_system configure_gcc_runtime warn move \
+  set_permissions install_gzipped_executable change_dylib_id \
+  terminate_process; do
+  grep -qE "\"$t\", \." "$STEPS" || fail "$t missing from step_map — its formulas will partial-skip"
+  grep -qE "^test \".*$t" "$STEPS" || fail "$t registered but untested — stub risk"
+done
+
+# 2. The `on` guard, and the restructure that lets it be evaluated at all: the
+#    condition must be dispatched before any spec resolution, because an `on`
+#    guard has no path to resolve.
+grep -qE '\{ "on", \.on \}' "$STEPS" || fail "the on guard is no longer registered — its formulas stay blocked"
+grep -qE '^test "the on guard' "$STEPS" || fail "the on guard is registered but untested"
+
+# 3. Landmines that silently produce wrong output rather than failing.
+#    The clang config filenames carry the Darwin kernel major, not the macOS
+#    product major — reading the wrong sysctl writes six plausibly-named but
+#    wrong files.
+grep -q 'kern.osrelease' "$STEPS" || fail "no kern.osrelease read — darwin<N>.cfg would be named from the macOS major"
+#    set_permissions recurses by default; the key opts OUT. Ignoring it inverts
+#    the default and silently under-applies the mode.
+grep -q 'non_recursive' "$STEPS" || fail "set_permissions ignores non_recursive — recursion default inverted"
+
+# 4. Types deliberately left as loud skips must stay unregistered, so a later
+#    drive-by cannot quietly stub them into a no-op that reports success.
+for t in configure_glibc_runtime set_ownership configure_php \
+  bootstrap_cpython bootstrap_pypy move_children move_contents; do
+  if grep -qE "\"$t\", \." "$STEPS"; then
+    fail "$t registered — it is a deliberate loud skip, not a native step"
+  fi
+done
+
+# 5. Behavioural guards. If a test block is deleted the run below goes green
+#    vacuously, so assert each is present first.
+TESTS=(
+  "configure_clang_system writes one isysroot config per arch and target"
+  "configure_clang_system writes nothing when every config file already exists"
+  "configure_clang_system refuses rather than naming files from an unknown version"
+  "configure_gcc_runtime is a no-op on macOS rather than an unsupported step"
+  "warn surfaces the formula's message instead of downgrading the install"
+  "move relocates a tree and refuses an occupied target without overwrite"
+  "move refuses a source that escapes the keg and prefix"
+  "set_permissions recurses by default and honours non_recursive"
+  "set_permissions applies symbolic modes and skips paths that do not exist"
+  "set_permissions refuses a symbolic mode it cannot parse"
+  "install_gzipped_executable unpacks, marks executable, and unlinks the source"
+  "install_gzipped_executable leaves no temp file behind on a corrupt source"
+  "change_dylib_id sets the install name on the real file behind a resolved source"
+  "terminate_process treats an absent process as success"
+  "the on guard admits a macOS step and skips a Linux one silently"
+  "the on guard routes an unknown platform value loudly"
+)
+
+for t in "${TESTS[@]}"; do
+  grep -Rqs -- "$t" "$STEPS" || fail "guard test missing from post_install_steps.zig: $t"
+done
+
+if ! zig build test-bin >/dev/null 2>&1; then
+  fail "could not build the test binaries (zig build test-bin)"
+fi
+
+# One run of the suite, judged per guard line: a pass ends in "OK".
+out=$("$ROOT/zig-out/test-bin/lib_tests" 2>&1 || true)
+for t in "${TESTS[@]}"; do
+  line=$(printf '%s\n' "$out" | grep -F -- "$t" || true)
+  [[ -n "$line" ]] || fail "guard test did not run: $t"
+  [[ "$line" == *OK ]] || fail "$t: $line"
+done
+
+echo "OK: the migrated step types and the platform guard run natively"

--- a/scripts/regressions/post-install-steps-live-artefacts.sh
+++ b/scripts/regressions/post-install-steps-live-artefacts.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Regression guard for the native `post_install_steps` executor, driven by real
+# installs.
+#
+# Its sibling `native-step-coverage-llvm-post-install.sh` is a static guard: it
+# proves the step types are registered and their unit tests run. That cannot see
+# what only a live keg has. The bug that motivated this script is the example —
+# redis declares `set_permissions` on `<prefix>/lib/redis/modules/*`, and in a
+# linked prefix those are symlinks into the Cellar. Unit fixtures are plain
+# files, so every test passed while a real `mt install redis` failed with a
+# sandbox violation. `chmod(1)` follows a symlink it is handed; the executor now
+# does too, and this script is what proves it against the real layout.
+#
+# One formula per step type, each asserted on the artefact the step is supposed
+# to leave behind — never merely on "install exited 0", because the pre-fix
+# failure mode was a clean exit with the work skipped.
+#
+#   redis  set_permissions  modes applied through the prefix's own symlinks
+#   nginx  move             docroot relocated out of the keg, source consumed
+#   ruby   change_dylib_id  install name rewritten (+ the `on: macos` guard)
+#
+# Formulas whose bottles run to hundreds of megabytes (llvm, gcc, bazel) are
+# behind MALT_REGRESSION_SLOW=1 so the default path stays a few minutes.
+#
+# Usage: scripts/regressions/post-install-steps-live-artefacts.sh
+#        MALT_REGRESSION_SLOW=1 scripts/regressions/post-install-steps-live-artefacts.sh
+# Requirements: built `mt` binary, network access to formulae.brew.sh + ghcr.io.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/mt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+if [[ -z "${MALT_GITHUB_TOKEN:-}" ]] && command -v gh >/dev/null 2>&1; then
+  MALT_GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
+  export MALT_GITHUB_TOKEN
+fi
+
+# Short on purpose: a long prefix exceeds the Mach-O patch budget and every
+# install emits a relocation warning that has nothing to do with these steps.
+PREFIX="/tmp/mt_pis"
+export MALT_PREFIX="$PREFIX"
+# Overridable so a warm cache can be reused; it lives outside PREFIX and
+# therefore survives the cleanup trap.
+export MALT_CACHE="${MALT_CACHE:-$PREFIX/cache}"
+export NO_COLOR=1 MALT_NO_EMOJI=1
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX/bin"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  ✓ %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+LOG="$PREFIX/install.log"
+
+# install <formula> — refuses the partial-skip envelope as well as a non-zero
+# exit. The pre-fix bug exited 0 and printed a warning; both must be gone.
+install_clean() {
+  local formula="$1"
+  printf '▸ mt install %s\n' "$formula"
+  "$BIN" install "$formula" >"$LOG" 2>&1 || {
+    tail -20 "$LOG" >&2
+    fail "$formula: install failed"
+  }
+  # Scoped to the formula under test. A transitive dependency can fail its own
+  # post_install for reasons that have nothing to do with these step types —
+  # fontconfig's `run` step is a known one, its fc-cache spawning before
+  # gettext is linked — and swallowing that silently is as wrong as failing on
+  # it, so it is reported and stepped over.
+  if grep -qE "($formula: post_install partially skipped|post_install DSL failed for $formula|use --use-system-ruby=$formula)" "$LOG"; then
+    grep -B2 -A4 -E "($formula: post_install partially skipped|post_install DSL failed for $formula)" "$LOG" >&2
+    fail "$formula: post_install did not run natively"
+  fi
+  if grep -qE 'partially skipped|post_install DSL failed' "$LOG"; then
+    printf '  ! a dependency of %s failed its own post_install (not one of the step types under test):\n' "$formula" >&2
+    grep -E 'partially skipped|post_install DSL failed|\[system_command_failed\]' "$LOG" | sed 's/^/      /' >&2
+  fi
+  grep -q "post_install completed for $formula" "$LOG" ||
+    fail "$formula: no post_install completion line"
+  pass "$formula: post_install completed natively, no fallback envelope"
+}
+
+# ── set_permissions, applied through the prefix's link farm ──────────
+install_clean redis
+modules="$PREFIX/lib/redis/modules"
+[[ -d "$modules" ]] || fail "redis: $modules missing"
+found=0
+for link in "$modules"/*.so; do
+  [[ -e "$link" ]] || continue
+  found=1
+  # The declared mode is 0755 and the file behind the link is what must carry
+  # it; asserting on the link itself would pass without the step running.
+  [[ -L "$link" ]] || fail "redis: $link is not the expected prefix symlink"
+  mode=$(stat -f '%Lp' "$(readlink "$link")")
+  [[ "$mode" == "755" ]] || fail "redis: $(basename "$link") is $mode, expected 755"
+done
+[[ "$found" == "1" ]] || fail "redis: no modules found to check"
+pass "redis: 0755 applied to the real files behind the prefix symlinks"
+
+# ── move ─────────────────────────────────────────────────────────────
+install_clean nginx
+[[ -f "$PREFIX/var/www/index.html" ]] || fail "nginx: docroot not relocated to <prefix>/var/www"
+pass "nginx: docroot relocated into the prefix"
+if compgen -G "$PREFIX/Cellar/nginx/*/libexec/html" >/dev/null; then
+  fail "nginx: source survived the move — it was copied, not moved"
+fi
+pass "nginx: source consumed by the move"
+if compgen -G "$PREFIX/var/www.malt-replaced" >/dev/null; then
+  fail "nginx: swap-aside scaffolding left behind in the prefix"
+fi
+pass "nginx: no swap-aside scaffolding left behind"
+
+# ── change_dylib_id, and the `on: macos` guard that gates it ─────────
+install_clean ruby
+dylib=$(find "$PREFIX/Cellar/ruby" -name 'libruby.*.dylib' -type f 2>/dev/null | head -1)
+[[ -n "$dylib" ]] || fail "ruby: no libruby dylib in the keg"
+id=$(otool -D "$dylib" 2>/dev/null | tail -1)
+[[ "$id" == "$PREFIX/opt/ruby"*/lib/libruby.*.dylib ]] ||
+  fail "ruby: install name is '$id', expected the prefix's opt path"
+pass "ruby: install name rewritten to the opt path"
+
+# ── heavyweight bottles, opt-in ──────────────────────────────────────
+if [[ -n "${MALT_REGRESSION_SLOW:-}" ]]; then
+  # configure_clang_system — the originally reported failure. Six files, each
+  # one line naming the SDK; the Darwin major and the macOS major differ, and
+  # reading one sysctl for both is the mistake this pins.
+  install_clean llvm
+  kernel=$(uname -r | cut -d. -f1)
+  macos=$(sw_vers -productVersion | cut -d. -f1)
+  want="-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX${macos}.sdk"
+  for arch in arm64 x86_64 aarch64; do
+    for target in "darwin${kernel}" "macosx${macos}"; do
+      cfg="$PREFIX/etc/clang/${arch}-apple-${target}.cfg"
+      [[ -f "$cfg" ]] || fail "llvm: $cfg missing"
+      [[ "$(cat "$cfg")" == "$want" ]] || fail "llvm: $cfg reads '$(cat "$cfg")', expected '$want'"
+    done
+  done
+  pass "llvm: six clang configs written, named from both the kernel and macOS majors"
+
+  # install_gzipped_executable — the archive must be consumed and the unpacked
+  # binary left executable.
+  install_clean bazel
+  real=$(find "$PREFIX/Cellar/bazel" -name 'bazel-real' -type f 2>/dev/null | head -1)
+  [[ -n "$real" ]] || fail "bazel: bazel-real was never unpacked"
+  [[ "$(stat -f '%Lp' "$real")" == "755" ]] || fail "bazel: bazel-real is not 0755"
+  if find "$PREFIX/Cellar/bazel" -name 'bazel-real.gz' | grep -q .; then
+    fail "bazel: the gzipped source survived — it must be unlinked"
+  fi
+  pass "bazel: executable unpacked 0755 and the archive consumed"
+
+  # configure_gcc_runtime — a correct macOS no-op, which must still not route
+  # the formula into the partial-skip envelope.
+  install_clean gcc
+  pass "gcc: the Linux-only step stayed a clean no-op"
+fi
+
+echo "OK: every implemented post_install step left its artefact behind"

--- a/scripts/regressions/post-install-steps-live-artefacts.sh
+++ b/scripts/regressions/post-install-steps-live-artefacts.sh
@@ -87,6 +87,42 @@ install_clean() {
   pass "$formula: post_install completed natively, no fallback envelope"
 }
 
+# ── the hook phase must stay deferred ────────────────────────────────
+# A `run` step executes a binary out of its own keg, and that binary resolves
+# its dependencies through `<prefix>/opt/...`. Dependency resolution walks the
+# graph breadth-first, which is not a topological order, so a hook run inline
+# with linking can start before a dependency it needs is linked — dyld then
+# kills the child (fontconfig's fc-cache against gettext's libintl). This is
+# graph-shaped, not timing-dependent, so it hides on small dependency sets;
+# assert the structure rather than hope a live case reproduces it.
+INSTALL="$ROOT/src/cli/install.zig"
+drive_calls=$(grep -c 'drive(ctx, allocator' "$INSTALL")
+[[ "$drive_calls" == "1" ]] ||
+  fail "expected exactly one drive() call site, found $drive_calls — a hook may have moved back inline"
+# Judge the CALL's position, not the comments': a rename or a reworded banner
+# must not be able to leave this passing while the hook runs inline again.
+awk '
+  /Serial link \+ record phase/      { link = NR }
+  /Deferred post-install phase/      { deferred = NR }
+  /drive\(ctx, allocator/            { call = NR }
+  /provisionShippedCaBundle/         { bundle = NR }
+  END {
+    if (!link || !deferred || !call || !bundle) exit 1
+    if (deferred <= link) exit 1     # phase must come after the link loop
+    if (call <= deferred) exit 1     # the call must live inside that phase
+    if (bundle <= call) exit 1       # the CA fallback must follow the hook
+  }' "$INSTALL" ||
+  fail "post_install no longer runs after the link phase, or the CA-bundle fallback no longer follows it"
+pass "post_install hooks stay deferred until every keg in the transaction is linked"
+
+# Static-only mode: the checks above need no network or built binary, so
+# `just test` can run them on every commit while the install cases below stay
+# in the network-bound pool.
+if [[ -n "${MALT_STATIC_ONLY:-}" ]]; then
+  echo "OK: post_install ordering guards hold (static-only)"
+  exit 0
+fi
+
 # ── set_permissions, applied through the prefix's link farm ──────────
 install_clean redis
 modules="$PREFIX/lib/redis/modules"

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -318,6 +318,10 @@ const doctor_help =
     \\                 stable `{cask_history: {retained_versions,
     \\                 bytes}}` payload on stdout. Empty state still
     \\                 surfaces with zero values.
+    \\  --post-install-status
+    \\                 Report, per installed keg, whether its
+    \\                 post_install work runs natively or needs the
+    \\                 Ruby fallback. Read-only probe; runs no steps.
     \\
 ;
 

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -1049,10 +1049,16 @@ fn runInstall(
     }
 
     // ── Serial link + record phase ──────────────────────────────────
-    // Runs in dep order so `findFailedDep` propagates failures down the
-    // graph; linker + SQLite writes cannot be parallelised.
+    // linker + SQLite writes cannot be parallelised. Post-install hooks are
+    // deliberately NOT run here — see the deferred phase below. Wording is
+    // asserted by scripts/regressions/post-install-steps-live-artefacts.sh.
     var failed_kegs = std.StringHashMap(void).init(allocator);
     defer failed_kegs.deinit();
+
+    // Jobs that linked cleanly, in link order. Their post-install work runs
+    // only once the whole transaction is linked — see the deferred phase.
+    var linked_jobs: std.ArrayList(usize) = .empty;
+    defer linked_jobs.deinit(allocator);
 
     for (all_jobs.items, 0..) |*job, i| {
         if (signals.isInterrupted()) {
@@ -1124,13 +1130,41 @@ fn runInstall(
             pruneOtherCellarVersionsForReinstall(ctx, allocator, prefix, job.name, job.version_str);
         }
 
+        // Post-install work is deferred, not run here: a hook may execute a
+        // binary out of its own keg, and that binary links against its
+        // dependencies through `<prefix>/opt/...`. Dependency resolution walks
+        // the graph breadth-first, which is not a topological order, so a
+        // dependency can still be unlinked at this point and dyld kills the
+        // child.
+        linked_jobs.append(allocator, i) catch {
+            // Deliberately not `failed_kegs`: the keg is linked, recorded and
+            // usable, so dependents must not be skipped. Only its follow-up
+            // work is lost, and the exit code says so.
+            sink.err("Out of memory scheduling post_install for {s}", .{job.name});
+            failed_count += 1;
+        };
+    }
+
+    // ── Deferred post-install phase ─────────────────────────────────
+    // Safe here for the reason given at `linked_jobs` above: everything the
+    // transaction installs is linked. Wording is asserted by
+    // scripts/regressions/post-install-steps-live-artefacts.sh.
+    //
+    // Deliberately not gated on the interrupt flag. `signals.isInterrupted()`
+    // latches for the rest of the process, so checking it here would abandon
+    // the hooks of every keg linked *before* the Ctrl-C too — and a keg that is
+    // linked and recorded but never provisioned is not something a later
+    // `mt install` retries, since that takes the already-installed path.
+    for (linked_jobs.items) |idx| {
+        const job = all_jobs.items[idx];
         if (job.wants_post_install) {
             drive(ctx, allocator, job.name, job.version_str, job.formula_json, prefix, flags.system_ruby, &formula_cache, sink);
         }
-
         // ca-certificates' macOS post_install can't run natively, so the
         // shipped Mozilla bundle is linked into etc/<name>/cert.pem here.
-        // No-op for every keg that ships no CA bundle.
+        // After the keg's own hook, never before: the helper stands down when a
+        // bundle is already present, so running it first would shadow one the
+        // hook meant to write.
         post_install_mod.provisionShippedCaBundle(ctx.io, prefix, job.name);
     }
 

--- a/src/core/dsl/builtins/process.zig
+++ b/src/core/dsl/builtins/process.zig
@@ -241,6 +241,20 @@ pub fn macosVersion(ctx: ExecCtx, _: ?Value, _: []const Value) BuiltinError!Valu
     return Value{ .string = trimmed };
 }
 
+/// `OS.kernel_version` — the Darwin release (`25.6.0`), NOT the macOS product
+/// version. Formulas chain `.major` on it to name toolchain config files, so
+/// answering `26` where Darwin says `25` writes plausible, wrong filenames.
+pub fn kernelVersion(ctx: ExecCtx, _: ?Value, _: []const Value) BuiltinError!Value {
+    var buf: [64]u8 = undefined;
+    var len: usize = buf.len;
+    // A guess here is worse than a loud refusal, so there is no fallback.
+    if (std.c.sysctlbyname("kern.osrelease", &buf, &len, null, 0) != 0)
+        return BuiltinError.UnknownMethod;
+    const text = std.mem.sliceTo(buf[0..len], 0);
+    return Value{ .string = std.fmt.allocPrint(ctx.allocator, "{s}", .{text}) catch
+        return BuiltinError.OutOfMemory };
+}
+
 /// MacOS::CLT.PKG_PATH — Homebrew's canonical Command Line Tools prefix.
 /// Hard-coded because Apple's installer places CLT here on every macOS
 /// version our DSL could plausibly run on; resolving it lets formulas
@@ -854,4 +868,20 @@ test "suppressed child stdout stays off the json document" {
     const got = try cap.finish(alloc);
 
     try std.testing.expectEqual(@as(usize, 0), got.len);
+}
+
+test "OS.kernel_version answers the Darwin release, not the macOS product version" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    var lio: std.Io.Threaded = .init(alloc, .{});
+    defer lio.deinit();
+    const ctx = sanitizeTestCtx(alloc, lio.io());
+
+    const kernel = (try kernelVersion(ctx, null, &.{})).string;
+    const product = (try macosVersion(ctx, null, &.{})).string;
+    try std.testing.expect(kernel.len > 0);
+    // The two majors differ on every current release, which is exactly why a
+    // formula naming `darwin#{OS.kernel_version.major}.cfg` needs this one.
+    try std.testing.expect(!std.mem.eql(u8, kernel, product));
 }

--- a/src/core/dsl/builtins/root.zig
+++ b/src/core/dsl/builtins/root.zig
@@ -67,7 +67,7 @@ pub const bare_builtins = std.StaticStringMap(BuiltinFn).initComptime(.{
     .{ "Hardware::CPU.arch", process.cpuArch },
     .{ "Hardware::CPU.arm?", process.osMac }, // arm? = true on Apple Silicon
     .{ "Hardware::CPU.intel?", process.osLinux }, // intel? = false on Apple Silicon
-    .{ "OS.kernel_version", process.macosVersion },
+    .{ "OS.kernel_version", process.kernelVersion },
 
     // Module constants. The parser lowers `A::B::C` and `A::B.C` to the
     // same chained method_call shape, so one key covers both syntaxes.

--- a/src/core/post_install_steps.zig
+++ b/src/core/post_install_steps.zig
@@ -17,6 +17,9 @@ const atomic = @import("../fs/atomic.zig");
 const clonefile = @import("../fs/clonefile.zig");
 const fs_read = @import("../fs/read.zig");
 const text_replace = @import("../text_replace.zig");
+const patch = @import("patch.zig");
+const codesign = @import("../macho/codesign.zig");
+const system_tools = @import("../system_tools.zig");
 
 pub const FallbackLog = fallback_log.FallbackLog;
 
@@ -64,6 +67,14 @@ const StepTag = enum {
     update_desktop_database,
     init_data_dir,
     run,
+    move,
+    warn,
+    set_permissions,
+    install_gzipped_executable,
+    change_dylib_id,
+    terminate_process,
+    configure_clang_system,
+    configure_gcc_runtime,
 };
 
 /// Single source of truth for the native step set: `runStep` dispatch and
@@ -86,6 +97,14 @@ const step_map = std.StaticStringMap(StepTag).initComptime(.{
     .{ "update_desktop_database", .update_desktop_database },
     .{ "init_data_dir", .init_data_dir },
     .{ "run", .run },
+    .{ "move", .move },
+    .{ "warn", .warn },
+    .{ "set_permissions", .set_permissions },
+    .{ "install_gzipped_executable", .install_gzipped_executable },
+    .{ "change_dylib_id", .change_dylib_id },
+    .{ "terminate_process", .terminate_process },
+    .{ "configure_clang_system", .configure_clang_system },
+    .{ "configure_gcc_runtime", .configure_gcc_runtime },
 });
 
 /// Bookkeeping every step may carry: routing, gating, and audit hints that
@@ -115,6 +134,16 @@ fn honouredKeys(tag: StepTag) []const []const u8 {
         .inreplace => &.{ "path", "before", "after", "regexp" },
         .init_data_dir => &.{ "path", "using", "locale" },
         .run => &.{ "command", "args", "sudo" },
+        // `force` is upstream's alias for `overwrite` on this step.
+        .move => &.{ "source", "target", "overwrite", "force" },
+        .warn => &.{"message"},
+        .set_permissions => &.{ "paths", "permissions", "non_recursive" },
+        .install_gzipped_executable => &.{ "source", "target" },
+        .change_dylib_id => &.{ "source", "id", "resolve_source" },
+        // Deliberately narrow: `sudo`/`must_succeed` would change what the
+        // step is allowed to do, so they must refuse rather than be dropped.
+        .terminate_process => &.{"name"},
+        .configure_clang_system, .configure_gcc_runtime => &.{},
     };
 }
 
@@ -204,8 +233,9 @@ fn runStep(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
         return false;
     };
 
-    // mkdir/move/move_children are defined upstream but unused in
-    // homebrew-core today — routed loudly until a formula ships one.
+    // Types with no entry above are refused here on purpose: php and the
+    // legacy python/pypy bootstrappers are whole subsystems, and the glibc
+    // runtime never reaches a macOS bottle. A loud skip beats a stub.
     const tag = step_map.get(step_type) orelse {
         logUnsupported(ctx, step_type);
         return false;
@@ -241,6 +271,14 @@ fn runStep(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
         .gtk_update_icon_cache => stepGtkUpdateIconCache(ctx, obj),
         .init_data_dir => stepInitDataDir(ctx, obj),
         .run => stepRun(ctx, obj),
+        .move => stepMove(ctx, obj),
+        .warn => stepWarn(ctx, obj),
+        .set_permissions => stepSetPermissions(ctx, obj),
+        .install_gzipped_executable => stepInstallGzippedExecutable(ctx, obj),
+        .change_dylib_id => stepChangeDylibId(ctx, obj),
+        .terminate_process => stepTerminateProcess(ctx, obj),
+        .configure_clang_system => stepConfigureClangSystem(ctx),
+        .configure_gcc_runtime => stepConfigureGccRuntime(ctx),
     };
 }
 
@@ -364,6 +402,7 @@ const BaseTag = enum {
     pkgetc,
     pkgshare,
     opt_pkgshare,
+    frameworks,
     formula_pkgetc,
     formula_opt_prefix,
 };
@@ -382,6 +421,8 @@ const base_map = std.StaticStringMap(BaseTag).initComptime(.{
     .{ "pkgetc", .pkgetc },
     .{ "pkgshare", .pkgshare },
     .{ "opt_pkgshare", .opt_pkgshare },
+    // Keg-relative, like `libexec`: upstream's `frameworks` is `prefix/Frameworks`.
+    .{ "frameworks", .frameworks },
     .{ "formula_pkgetc", .formula_pkgetc },
     .{ "formula_opt_prefix", .formula_opt_prefix },
 });
@@ -404,6 +445,7 @@ pub fn resolveBase(ctx: StepsCtx, base: []const u8, formula_ref: ?[]const u8) ?[
         .pkgetc => std.fmt.allocPrint(a, "{s}/etc/{s}", .{ ctx.prefix, ctx.name }) catch null,
         .pkgshare => std.fmt.allocPrint(a, "{s}/share/{s}", .{ ctx.prefix, ctx.name }) catch null,
         .opt_pkgshare => std.fmt.allocPrint(a, "{s}/opt/{s}/share/{s}", .{ ctx.prefix, ctx.name, ctx.name }) catch null,
+        .frameworks => std.fmt.allocPrint(a, "{s}/Frameworks", .{ctx.keg_path}) catch null,
         .formula_pkgetc => {
             const f = formula_ref orelse return null;
             return std.fmt.allocPrint(a, "{s}/etc/{s}", .{ ctx.prefix, f }) catch null;
@@ -820,13 +862,18 @@ fn stepRemove(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
 fn removeTrees(ctx: StepsCtx, items: []const std.json.Value) bool {
     for (items) |item| {
         if (item != .object) continue;
-        const path = resolveSpec(ctx, item.object, "paths") orelse continue;
-        if (!confined(ctx, path)) return false;
-        if (sharedPrefixDir(ctx, path)) {
-            logUnsupported(ctx, "recursive remove of a shared prefix directory");
-            return false;
+        const spec = resolveSpec(ctx, item.object, "paths") orelse continue;
+        // ruby names the tree to retire as `gems/bundler-*`; a literal path
+        // matches nothing, so the stale copy would survive every upgrade.
+        const paths = expandGlob(ctx, spec) orelse return false;
+        for (paths) |path| {
+            if (!confined(ctx, path)) return false;
+            if (sharedPrefixDir(ctx, path)) {
+                logUnsupported(ctx, "recursive remove of a shared prefix directory");
+                return false;
+            }
+            std.Io.Dir.cwd().deleteTree(ctx.io, path) catch {};
         }
-        std.Io.Dir.cwd().deleteTree(ctx.io, path) catch {};
     }
     return true;
 }
@@ -907,6 +954,567 @@ fn linkDirRecursive(ctx: StepsCtx, src: []const u8, dst: []const u8) void {
             std.Io.Dir.symLinkAbsolute(ctx.io, src_child, dst_child, .{}) catch {};
         }
     }
+}
+
+/// `move`: relocate a tree the formula shipped — nginx lifts its default
+/// docroot out of the keg into `<prefix>/var`. Both ends are confined like
+/// every other write.
+fn stepMove(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
+    const source = resolvePathSpec(ctx, obj, "source") orelse return false;
+    const target = resolvePathSpec(ctx, obj, "target") orelse return false;
+    // Checked before confinement so a bottle that shipped no source reports as
+    // the mismatch it is, rather than as a fatal confinement violation.
+    if (!pathExists(ctx.io, source)) {
+        logUnsupported(ctx, "move whose source the bottle did not ship");
+        return false;
+    }
+    if (!confinedSource(ctx, source)) return false;
+    if (!confined(ctx, target)) return false;
+
+    if (pathExists(ctx.io, target)) {
+        // Refused rather than skipped: the declared relocation did not happen
+        // and the source is still sitting where the formula left it.
+        if (!getFlag(obj, "overwrite") and !getFlag(obj, "force")) {
+            logUnsupported(ctx, "move onto an existing target without overwrite");
+            return false;
+        }
+        // Swapped aside rather than deleted: if the relocation below fails,
+        // whatever the user had there is still recoverable.
+        const aside = asidePath(ctx, target) orelse return false;
+        std.Io.Dir.cwd().deleteTree(ctx.io, aside) catch {};
+        std.Io.Dir.renameAbsolute(target, aside, ctx.io) catch {
+            logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "could not clear {s}", .{target}) catch target);
+            return false;
+        };
+        mkParent(ctx, target);
+        if (atomic.atomicRename(ctx.io, ctx.allocator, source, target)) |_| {
+            std.Io.Dir.cwd().deleteTree(ctx.io, aside) catch {};
+            return true;
+        } else |_| {
+            std.Io.Dir.renameAbsolute(aside, target, ctx.io) catch {};
+            logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "could not relocate {s}", .{source}) catch source);
+            return false;
+        }
+    }
+    mkParent(ctx, target);
+    // An aside can outlive a crash between the two renames below; drop it here
+    // too, or it lingers in the prefix with nothing to reclaim it.
+    std.Io.Dir.cwd().deleteTree(ctx.io, asidePath(ctx, target) orelse "") catch {};
+    atomic.atomicRename(ctx.io, ctx.allocator, source, target) catch {
+        logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "could not relocate {s}", .{source}) catch source);
+        return false;
+    };
+    return true;
+}
+
+fn asidePath(ctx: StepsCtx, target: []const u8) ?[]const u8 {
+    return std.fmt.allocPrint(ctx.allocator, "{s}.malt-replaced", .{target}) catch null;
+}
+
+/// `warn`: upstream's `opoo`. Printing IS the step, so it must never reach
+/// `logUnsupported` — that would downgrade a whole install over a message.
+fn stepWarn(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
+    const raw = getString(obj, "message") orelse {
+        logUnsupported(ctx, "warn without a message");
+        return false;
+    };
+    const message = expandTemplates(ctx, raw) catch raw;
+    // The renderer writes notes verbatim, so the line ending is the caller's.
+    ctx.flog.note(std.fmt.allocPrint(ctx.allocator, "{s}\n", .{message}) catch message);
+    return true;
+}
+
+// --- permissions -----------------------------------------------------------
+
+/// A `permissions` value: an absolute octal mode, or a symbolic clause applied
+/// against whatever the file already carries.
+const Mode = union(enum) {
+    absolute: std.posix.mode_t,
+    symbolic: struct {
+        who: std.posix.mode_t,
+        bits: std.posix.mode_t,
+        op: enum { add, remove, set },
+    },
+};
+
+/// Parse the two shapes homebrew-core ships: `0755` and `[ugoa]+[+-=][rwx]+`.
+/// Null for anything else — approximating a mode is how a private key ends up
+/// world-readable.
+fn parseMode(spec: []const u8) ?Mode {
+    if (spec.len == 0) return null;
+    if (spec[0] >= '0' and spec[0] <= '7') {
+        const parsed = std.fmt.parseInt(std.posix.mode_t, spec, 8) catch return null;
+        // chmod(2) only consults the low bits; mask so a wide literal cannot
+        // overflow the cast, matching the DSL chmod builtin.
+        return .{ .absolute = parsed & 0o7777 };
+    }
+
+    var who: std.posix.mode_t = 0;
+    var i: usize = 0;
+    while (i < spec.len) : (i += 1) switch (spec[i]) {
+        'u' => who |= 0o700,
+        'g' => who |= 0o070,
+        'o' => who |= 0o007,
+        'a' => who |= 0o777,
+        else => break,
+    };
+    if (who == 0 or i == spec.len) return null;
+
+    const op: @FieldType(@FieldType(Mode, "symbolic"), "op") = switch (spec[i]) {
+        '+' => .add,
+        '-' => .remove,
+        '=' => .set,
+        else => return null,
+    };
+    i += 1;
+    if (i == spec.len) return null;
+
+    // r/w/x replicate across all three classes, then the who mask selects.
+    var perm: std.posix.mode_t = 0;
+    while (i < spec.len) : (i += 1) perm |= switch (spec[i]) {
+        'r' => 0o444,
+        'w' => 0o222,
+        'x' => 0o111,
+        else => return null,
+    };
+    return .{ .symbolic = .{ .who = who, .bits = perm & who, .op = op } };
+}
+
+fn applyMode(current: std.posix.mode_t, mode: Mode) std.posix.mode_t {
+    return switch (mode) {
+        .absolute => |m| m,
+        .symbolic => |s| switch (s.op) {
+            .add => current | s.bits,
+            .remove => current & ~s.bits,
+            .set => (current & ~s.who) | s.bits,
+        },
+    };
+}
+
+/// Follow a symlink the step named, the way `chmod(1)` does for an argument —
+/// a linked prefix points `<prefix>/lib/...` at the Cellar, so refusing links
+/// here would refuse the ordinary layout. (`-R` traversal is the opposite and
+/// leaves links alone; `chmodTree` skips them.) Confinement lands on the
+/// resolved file, so a link out of the keg is still refused.
+fn resolveLink(ctx: StepsCtx, path: []const u8) []const u8 {
+    var current = path;
+    // Homebrew plants one hop; the bound just stops a cycle.
+    for (0..8) |_| {
+        var buf: [std.fs.max_path_bytes]u8 = undefined;
+        const n = std.Io.Dir.readLinkAbsolute(ctx.io, current, &buf) catch return current;
+        const target = buf[0..n];
+        // Duped off the stack buffer before it goes out of scope.
+        current = if (std.fs.path.isAbsolute(target))
+            ctx.allocator.dupe(u8, target) catch return current
+        else
+            std.fs.path.join(ctx.allocator, &.{ std.fs.path.dirname(current) orelse "/", target }) catch return current;
+    }
+    return current;
+}
+
+fn chmodConfined(ctx: StepsCtx, named: []const u8, mode: Mode) bool {
+    const path = resolveLink(ctx, named);
+    const file = sandbox.openTargetNoFollow(ctx.io, path, ctx.keg_path, ctx.prefix, .{ .write = false }) catch |e| {
+        if (e == error.PathSandboxViolation) {
+            logViolation(ctx, path);
+            return false;
+        }
+        // A leaf that vanished between the walk and the open is a race, not a
+        // refusal — `chmod -R` reports and keeps going rather than abandoning
+        // the remaining paths. Visible, but it does not downgrade the install.
+        ctx.flog.note(chmodDetail(ctx, "post_install: skipped, could not open", path));
+        return true;
+    };
+    defer file.close(ctx.io);
+    const current: std.posix.mode_t = switch (mode) {
+        .absolute => 0,
+        .symbolic => blk: {
+            // A symbolic clause modifies what is already there, so an
+            // unreadable mode would silently widen or narrow the result.
+            const s = file.stat(ctx.io) catch {
+                logUnsupported(ctx, chmodDetail(ctx, "could not read the current mode of", path));
+                return false;
+            };
+            break :blk s.permissions.toMode() & 0o7777;
+        },
+    };
+    file.setPermissions(ctx.io, .fromMode(applyMode(current, mode))) catch {
+        // Reporting success here is how a private keg directory stays
+        // world-readable with nothing in the log to say so.
+        logUnsupported(ctx, chmodDetail(ctx, "could not chmod", path));
+        return false;
+    };
+    return true;
+}
+
+fn chmodDetail(ctx: StepsCtx, what: []const u8, path: []const u8) []const u8 {
+    return std.fmt.allocPrint(ctx.allocator, "{s} {s}\n", .{ what, path }) catch what;
+}
+
+fn chmodTree(ctx: StepsCtx, path: []const u8, mode: Mode) bool {
+    if (!chmodConfined(ctx, path, mode)) return false;
+    var dir = std.Io.Dir.openDirAbsolute(ctx.io, path, .{ .iterate = true }) catch return true;
+    defer dir.close(ctx.io);
+    // Per-level guard, like the link_dir walk: a directory symlink must not
+    // redirect the descent outside the prefix.
+    sandbox.validateDirTarget(ctx.io, path, ctx.keg_path, ctx.prefix) catch {
+        logViolation(ctx, path);
+        return false;
+    };
+    var iter = dir.iterate();
+    while (iter.next(ctx.io) catch null) |entry| {
+        // `chmod -R` walks past anything that is not a file or a directory;
+        // refusing a symlink here would fail the step over a keg's own links.
+        if (entry.kind != .directory and entry.kind != .file) continue;
+        const child = std.fs.path.join(ctx.allocator, &.{ path, entry.name }) catch continue;
+        const ok = if (entry.kind == .directory) chmodTree(ctx, child, mode) else chmodConfined(ctx, child, mode);
+        if (!ok) return false;
+    }
+    return true;
+}
+
+/// `set_permissions`: chmod every path in the step's array that the formula
+/// actually shipped. Upstream passes `-R` *unless* `non_recursive` is set, so
+/// recursion is the default — inverting it silently under-applies the mode.
+fn stepSetPermissions(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
+    const paths_val = obj.get("paths") orelse {
+        logUnsupported(ctx, "set_permissions without paths");
+        return false;
+    };
+    if (paths_val != .array) {
+        logUnsupported(ctx, "set_permissions with non-array paths");
+        return false;
+    }
+    const permissions = getString(obj, "permissions") orelse {
+        logUnsupported(ctx, "set_permissions without permissions");
+        return false;
+    };
+    const mode = parseMode(permissions) orelse {
+        logUnsupported(ctx, std.fmt.allocPrint(ctx.allocator, "set_permissions mode {s}", .{permissions}) catch "set_permissions mode");
+        return false;
+    };
+    const recursive = !getFlag(obj, "non_recursive");
+
+    for (paths_val.array.items) |item| {
+        if (item != .object) continue;
+        const spec = resolveSpec(ctx, item.object, "paths") orelse return false;
+        const matches = expandGlob(ctx, spec) orelse return false;
+        for (matches) |path| {
+            // A path the formula declared but did not ship is a skip upstream
+            // too: `existing_step_paths` filters before chmod runs.
+            if (!pathExists(ctx.io, path)) continue;
+            if (!confined(ctx, path)) return false;
+            const ok = if (recursive) chmodTree(ctx, path, mode) else chmodConfined(ctx, path, mode);
+            if (!ok) return false;
+        }
+    }
+    return true;
+}
+
+/// Expand the pattern shapes upstream's path specs actually use: a `*` leaf,
+/// optionally behind a `**/` descent. Null for anything else — an approximated
+/// pattern chmods the wrong files rather than failing.
+fn expandGlob(ctx: StepsCtx, spec: []const u8) ?[]const []const u8 {
+    if (std.mem.indexOfScalar(u8, spec, '*') == null) {
+        const one = ctx.allocator.alloc([]const u8, 1) catch return null;
+        one[0] = spec;
+        return one;
+    }
+    const dir_path = std.fs.path.dirname(spec) orelse return logUnexpandable(ctx, spec);
+    const pattern = std.fs.path.basename(spec);
+    if (std.mem.indexOfScalar(u8, pattern, '*') == null) return logUnexpandable(ctx, spec);
+
+    const root, const descend = if (std.mem.indexOfScalar(u8, dir_path, '*') == null)
+        .{ dir_path, false }
+    else if (std.mem.endsWith(u8, dir_path, "/**"))
+        .{ dir_path[0 .. dir_path.len - "/**".len], true }
+    else
+        return logUnexpandable(ctx, spec);
+
+    // Every other step is confined at the point it mutates, which is enough
+    // because it touches exactly the path it was given. Expansion is different:
+    // it *reads* a whole subtree to discover paths, so an unchecked root would
+    // hand a tap recursive enumeration of anywhere this user can read. Bound it
+    // before the first opendir, not after.
+    if (!withinBounds(ctx, root)) {
+        logViolation(ctx, root);
+        return null;
+    }
+
+    var out: std.ArrayList([]const u8) = .empty;
+    collectMatches(ctx, root, pattern, descend, &out);
+    return out.toOwnedSlice(ctx.allocator) catch null;
+}
+
+/// One entry per refusal: the callers cannot tell the shapes apart, so logging
+/// is owned here rather than duplicated at each site.
+fn logUnexpandable(ctx: StepsCtx, spec: []const u8) ?[]const []const u8 {
+    logUnsupported(ctx, std.fmt.allocPrint(ctx.allocator, "a path pattern this executor cannot expand: {s}", .{spec}) catch "a path pattern this executor cannot expand");
+    return null;
+}
+
+/// Boundary test with no I/O — the variant usable *before* a path has been
+/// touched. Siblings: `confined` checks a write's parent chain, `confinedSource`
+/// resolves and checks a read's own leaf; both hit the filesystem.
+///
+/// Defers to the same `validatePath` those two reach eventually, rather than
+/// re-deriving the prefix test: nothing here normalises a path, so a bare
+/// prefix comparison would accept `<prefix>/../../elsewhere`.
+fn withinBounds(ctx: StepsCtx, path: []const u8) bool {
+    sandbox.validatePath(path, ctx.keg_path, ctx.prefix) catch return false;
+    return true;
+}
+
+fn collectMatches(
+    ctx: StepsCtx,
+    dir_path: []const u8,
+    pattern: []const u8,
+    descend: bool,
+    out: *std.ArrayList([]const u8),
+) void {
+    var dir = std.Io.Dir.openDirAbsolute(ctx.io, dir_path, .{ .iterate = true }) catch return;
+    defer dir.close(ctx.io);
+    var iter = dir.iterate();
+    while (iter.next(ctx.io) catch null) |entry| {
+        const child = std.fs.path.join(ctx.allocator, &.{ dir_path, entry.name }) catch continue;
+        if (globMatch(ctx.allocator, pattern, entry.name)) out.append(ctx.allocator, child) catch return;
+        if (descend and entry.kind == .directory) collectMatches(ctx, child, pattern, true, out);
+    }
+}
+
+// --- gzipped executables ---------------------------------------------------
+
+/// `install_gzipped_executable`: bazel and friends ship the real binary
+/// gzipped so the bottle stays small. The archive is unlinked once unpacked,
+/// or it ships in the keg.
+fn stepInstallGzippedExecutable(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
+    const source = resolvePathSpec(ctx, obj, "source") orelse return false;
+    const target = resolvePathSpec(ctx, obj, "target") orelse return false;
+    // A source the bottle did not ship is upstream's silent early return.
+    if (!fileExists(ctx.io, source)) return true;
+    if (!confinedSource(ctx, source)) return false;
+    if (!confined(ctx, target)) return false;
+
+    const dir = std.fs.path.dirname(target) orelse return false;
+    std.Io.Dir.cwd().createDirPath(ctx.io, dir) catch {};
+    const tmp = std.fmt.allocPrint(ctx.allocator, "{s}/.{s}.install-step", .{
+        dir,
+        std.fs.path.basename(target),
+    }) catch return false;
+
+    gunzipConfined(ctx, source, tmp) catch {
+        std.Io.Dir.cwd().deleteFile(ctx.io, tmp) catch {};
+        logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "could not decompress {s}", .{source}) catch source);
+        return false;
+    };
+    // Mode goes on before the rename publishes the file: the archive is gone
+    // by the end, so a chmod that failed afterwards could never be retried —
+    // every re-run would take the "source not shipped" exit and report success
+    // over a binary nobody can execute.
+    if (!chmodConfined(ctx, tmp, .{ .absolute = 0o755 })) {
+        std.Io.Dir.cwd().deleteFile(ctx.io, tmp) catch {};
+        return false;
+    }
+    // No unlink first: rename replaces the destination atomically, so there is
+    // never a moment where the executable is missing.
+    atomic.atomicRename(ctx.io, ctx.allocator, tmp, target) catch {
+        std.Io.Dir.cwd().deleteFile(ctx.io, tmp) catch {};
+        logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "could not place {s}", .{target}) catch target);
+        return false;
+    };
+    std.Io.Dir.cwd().deleteFile(ctx.io, source) catch {};
+    return true;
+}
+
+/// Ceiling on one unpacked executable. The archive is tap-supplied and a few
+/// compressed KiB can expand without bound; the largest real payload
+/// (bazel-real) is under a gigabyte, so this only ever catches a bomb.
+const max_unpacked_bytes: u64 = 4 << 30;
+
+fn gunzipConfined(ctx: StepsCtx, source: []const u8, dest: []const u8) !void {
+    const in = try sandbox.openSourceNoFollow(ctx.io, source, ctx.keg_path, ctx.prefix);
+    defer in.close(ctx.io);
+    var in_buf: [16 * 1024]u8 = undefined;
+    var in_reader = in.reader(ctx.io, &in_buf);
+    var window: [std.compress.flate.max_window_len]u8 = undefined;
+    var decompress = std.compress.flate.Decompress.init(&in_reader.interface, .gzip, &window);
+
+    const out = try sandbox.openTargetNoFollow(ctx.io, dest, ctx.keg_path, ctx.prefix, .{
+        .write = true,
+        .create = true,
+        .truncate = true,
+    });
+    defer out.close(ctx.io);
+    var out_buf: [16 * 1024]u8 = undefined;
+    var out_writer = out.writerStreaming(ctx.io, &out_buf);
+    var written: u64 = 0;
+    while (true) {
+        const n = decompress.reader.stream(&out_writer.interface, .limited(64 * 1024)) catch |e| switch (e) {
+            error.EndOfStream => break,
+            else => return e,
+        };
+        written += n;
+        if (written > max_unpacked_bytes) return error.StreamTooLong;
+    }
+    try out_writer.interface.flush();
+}
+
+// --- Mach-O and process tier -----------------------------------------------
+
+/// `change_dylib_id`: ruby republishes its dylib under the versioned opt path
+/// so dependents link against a stable name. The rewrite invalidates the
+/// signature on arm64, so it is re-signed exactly as relocation does.
+fn stepChangeDylibId(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
+    const source = resolvePathSpec(ctx, obj, "source") orelse return false;
+    const raw_id = getString(obj, "id") orelse {
+        logUnsupported(ctx, "change_dylib_id without an id");
+        return false;
+    };
+    const id = expandTemplates(ctx, raw_id) catch return false;
+
+    // Bounded before the realpath probe, not after: resolving an arbitrary
+    // path is itself a filesystem read a tap should not get.
+    if (!withinBounds(ctx, source)) {
+        logViolation(ctx, source);
+        return false;
+    }
+    // The keg publishes the dylib as a symlink to its versioned twin, and the
+    // install name belongs on the real file. Copied onto the arena because the
+    // FallbackLog borrows every detail it is handed — a stack slice would be
+    // reclaimed before the router renders it.
+    const target = if (getFlag(obj, "resolve_source")) blk: {
+        break :blk std.Io.Dir.realPathFileAbsoluteAlloc(ctx.io, source, ctx.allocator) catch source;
+    } else source;
+    if (!confined(ctx, target)) return false;
+
+    const entries = [_]patch.OverflowEntry{dylibIdEntry(id)};
+    patch.flushOverflow(ctx.io, ctx.allocator, target, &entries) catch {
+        logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "could not set the install name of {s}", .{target}) catch target);
+        return false;
+    };
+    if (codesign.isArm64()) codesign.adHocSign(ctx.io, ctx.allocator, target) catch {
+        logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "could not re-sign {s}", .{target}) catch target);
+        return false;
+    };
+    return true;
+}
+
+/// `-id` carries only the new name: LC_ID_DYLIB has a single slot, so the old
+/// value is implicit.
+fn dylibIdEntry(id: []const u8) patch.OverflowEntry {
+    return .{ .cmd = @intFromEnum(std.macho.LC.ID_DYLIB), .old_path = "", .new_path = id };
+}
+
+/// `terminate_process`: stop a daemon the previous version left running.
+/// Spawned directly rather than through `spawnFenced`: the fence governs
+/// filesystem reach, and this sends a signal without touching the filesystem,
+/// so it would constrain nothing. The argv is malt's own but for `name`, which
+/// is validated below.
+fn stepTerminateProcess(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
+    const name = getString(obj, "name") orelse {
+        logUnsupported(ctx, "terminate_process without a name");
+        return false;
+    };
+    // The name is tap-controlled and killall has no `--` terminator, so a
+    // leading dash would arrive as an option rather than a process name.
+    if (name.len == 0 or name[0] == '-') {
+        logUnsupported(ctx, "terminate_process with a name killall would read as an option");
+        return false;
+    }
+    var child = std.process.spawn(ctx.io, .{
+        .argv = &.{ system_tools.killall, name },
+        .stdout = .ignore,
+        .stderr = .ignore,
+    }) catch {
+        logCmdFail(ctx, "killall failed to spawn");
+        return false;
+    };
+    // A non-zero exit means nothing matched, which is the normal case on a
+    // first install; only failing to spawn is a real failure.
+    _ = child.wait(ctx.io) catch {};
+    return true;
+}
+
+// --- toolchain configuration -----------------------------------------------
+
+/// Toolchain root a malt-installed clang reads its SDK from. Duplicated from
+/// the DSL process builtin on purpose: importing it would buy a dependency
+/// edge for one string.
+const command_line_tools = "/Library/Developer/CommandLineTools";
+
+/// Upstream's set is `[:arm64, :x86_64, :aarch64, arch]`, and the host arch is
+/// always already in it on macOS.
+const clang_arches = [_][]const u8{ "arm64", "x86_64", "aarch64" };
+
+/// `configure_clang_system`: without these a malt-installed clang has no
+/// `-isysroot` and cannot find the macOS SDK.
+fn stepConfigureClangSystem(ctx: StepsCtx) bool {
+    const macos_major = sysctlMajor("kern.osproductversion") orelse {
+        logUnsupported(ctx, "configure_clang_system without a readable macOS version");
+        return false;
+    };
+    // Darwin's own major, not the product major: clang looks for
+    // `<arch>-apple-darwin25.cfg` on macOS 26.
+    const kernel_major = sysctlMajor("kern.osrelease") orelse {
+        logUnsupported(ctx, "configure_clang_system without a readable kernel version");
+        return false;
+    };
+    return writeClangConfigs(ctx, macos_major, kernel_major);
+}
+
+fn writeClangConfigs(ctx: StepsCtx, macos_major: u32, kernel_major: u32) bool {
+    const a = ctx.allocator;
+    // Prefix-scoped `etc`, not the keg's — clang reads one shared config dir.
+    const etc = resolveBase(ctx, "etc", null) orelse return false;
+    const config_dir = std.fs.path.join(a, &.{ etc, "clang" }) catch return false;
+
+    var paths: [clang_arches.len * 2][]const u8 = undefined;
+    for (clang_arches, 0..) |arch, i| {
+        paths[i * 2] = std.fmt.allocPrint(a, "{s}/{s}-apple-darwin{d}.cfg", .{ config_dir, arch, kernel_major }) catch return false;
+        paths[i * 2 + 1] = std.fmt.allocPrint(a, "{s}/{s}-apple-macosx{d}.cfg", .{ config_dir, arch, macos_major }) catch return false;
+    }
+
+    // Idempotent: a complete set stays exactly as the user has it. The `else`
+    // runs only when the loop never broke, i.e. all six are already present.
+    for (paths) |path| {
+        if (!fileExists(ctx.io, path)) break;
+    } else return true;
+
+    const content = std.fmt.allocPrint(a, "-isysroot {s}/SDKs/MacOSX{d}.sdk\n", .{ command_line_tools, macos_major }) catch return false;
+    if (!confined(ctx, config_dir)) return false;
+    std.Io.Dir.cwd().createDirPath(ctx.io, config_dir) catch {};
+    for (paths) |path| {
+        // Atomic, like upstream: the only completeness check on the next run
+        // is that all six files exist, so a torn write would be mistaken for
+        // a finished one and leave clang without an SDK for good.
+        atomic.atomicWriteFile(ctx.io, path, content) catch {
+            logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "could not write {s}", .{path}) catch path);
+            return false;
+        };
+    }
+    return true;
+}
+
+/// `configure_gcc_runtime`: upstream's body returns unless it is running on
+/// Linux, so on macOS this is genuinely nothing to do — a correct evaluation,
+/// not a stub waiting to be filled in.
+fn stepConfigureGccRuntime(ctx: StepsCtx) bool {
+    ctx.flog.note("configure_gcc_runtime: Linux-only upstream, nothing to do here\n");
+    return true;
+}
+
+/// Major component of a `kern.*` version sysctl, or null when it cannot be
+/// read — the caller must refuse rather than name files after a guess.
+/// `formula.zig` parses a major the same way; kept separate because it needs a
+/// second sysctl this one does not, and answers with a sentinel rather than
+/// null. Sharing would buy an edge into a large sibling for five lines.
+fn sysctlMajor(name: [*:0]const u8) ?u32 {
+    var buf: [32]u8 = undefined;
+    var len: usize = buf.len;
+    if (std.c.sysctlbyname(name, &buf, &len, null, 0) != 0) return null;
+    const text = std.mem.sliceTo(buf[0..len], 0);
+    const major = text[0 .. std.mem.indexOfScalar(u8, text, '.') orelse text.len];
+    return std.fmt.parseInt(u32, major, 10) catch null;
 }
 
 // --- tool tier -------------------------------------------------------------
@@ -2529,9 +3137,16 @@ test "allStepsSupported classifies migrated formulas for the doctor probe" {
         \\[{"type":"mkdir_p","path":{"base":"var","path":"glow"}},
         \\ {"type":"init_data_dir","path":{"base":"var","path":"glow"},"using":"postgresql_initdb"}]
     )));
+    // Every type this executor gained is classified as native, so the doctor
+    // probe stops reporting these formulas as partially covered.
+    try testing.expect(allStepsSupported(a, try testFormulaJson(&h,
+        \\[{"type":"configure_clang_system"},
+        \\ {"type":"move","source":{"base":"var","path":"a"},"target":{"base":"var","path":"b"}},
+        \\ {"type":"set_permissions","paths":[{"base":"var","path":"a"}],"permissions":"0755"}]
+    )));
     try testing.expect(!allStepsSupported(a, try testFormulaJson(&h,
         \\[{"type":"mkdir_p","path":{"base":"var","path":"glow"}},
-        \\ {"type":"move","source":{"base":"var","path":"a"},"target":{"base":"var","path":"b"}}]
+        \\ {"type":"configure_php"}]
     )));
     // No steps at all → nothing to support.
     try testing.expect(!allStepsSupported(a, try testFormulaJson(&h, "[]")));
@@ -2616,9 +3231,18 @@ test "supportedStepType matches the executable tier and rejects the rest" {
         "link_dir",                 "link_children",         "compile_gsettings_schemas", "gio_querymodules",
         "gdk_pixbuf_query_loaders", "gtk_update_icon_cache", "update_mime_database",      "update_desktop_database",
         "init_data_dir",            "remove",                "inreplace",                 "run",
+        "move",                     "warn",                  "set_permissions",           "install_gzipped_executable",
+        "change_dylib_id",          "terminate_process",     "configure_clang_system",    "configure_gcc_runtime",
     };
     for (native) |t| try testing.expect(supportedStepType(t));
-    const routed = [_][]const u8{ "mkdir", "move", "move_children", "frobnicate" };
+    // Deliberate loud skips: php and the legacy python/pypy bootstrappers are
+    // whole projects, glibc never reaches a macOS bottle, and the rest have no
+    // occurrence in homebrew-core to model against.
+    const routed = [_][]const u8{
+        "mkdir",         "move_children",     "move_contents",  "set_ownership",
+        "configure_php", "bootstrap_cpython", "bootstrap_pypy", "configure_glibc_runtime",
+        "frobnicate",
+    };
     for (routed) |t| try testing.expect(!supportedStepType(t));
 }
 
@@ -3135,4 +3759,978 @@ test "copy replaces a stale destination even without a force flag" {
 
     const got = try readBack(&h, try std.fmt.allocPrint(a, "{s}/version.txt", .{stale}));
     try testing.expectEqualStrings("new\n", got);
+}
+
+// --- migrated step types ---------------------------------------------------
+
+test "configure_clang_system writes one isysroot config per arch and target" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    // Driven with known versions: the point is the filenames and the exact
+    // byte content, not whatever the host happens to report.
+    try testing.expect(writeClangConfigs(h.ctx(), 26, 25));
+    try testing.expect(!h.flog.hasErrors());
+
+    const want = "-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk\n";
+    for ([_][]const u8{ "arm64", "x86_64", "aarch64" }) |arch| {
+        for ([_][]const u8{ "darwin25", "macosx26" }) |target| {
+            const path = try std.fmt.allocPrint(a, "{s}/etc/clang/{s}-apple-{s}.cfg", .{ h.prefix, arch, target });
+            const got = try fs_read.readFileAllAbsolute(h.io, a, path, 4096);
+            try testing.expectEqualStrings(want, got);
+        }
+    }
+}
+
+test "configure_clang_system writes nothing when every config file already exists" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    try testing.expect(writeClangConfigs(h.ctx(), 26, 25));
+    const probe = try std.fmt.allocPrint(a, "{s}/etc/clang/arm64-apple-darwin25.cfg", .{h.prefix});
+    try atomic.atomicWriteFile(h.io, probe, "user edit\n");
+
+    // A second run must leave a complete set exactly as the user has it.
+    try testing.expect(writeClangConfigs(h.ctx(), 26, 25));
+    try testing.expectEqualStrings("user edit\n", try fs_read.readFileAllAbsolute(h.io, a, probe, 4096));
+}
+
+test "configure_clang_system refuses rather than naming files from an unknown version" {
+    // The version reads are the step's only inputs; an unreadable one must
+    // yield null so the caller refuses, not a sentinel that names six files
+    // after a number nothing produced.
+    try testing.expect(sysctlMajor("kern.no_such_sysctl_for_malt") == null);
+    try testing.expect(sysctlMajor("kern.osrelease") != null);
+    try testing.expect(sysctlMajor("kern.osproductversion") != null);
+
+    // The Darwin major and the macOS major are different numbers, which is the
+    // whole reason the step reads two sysctls.
+    try testing.expect(sysctlMajor("kern.osrelease").? != sysctlMajor("kern.osproductversion").?);
+}
+
+test "configure_gcc_runtime is a no-op on macOS rather than an unsupported step" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+
+    const json = try testFormulaJson(&h, "[{\"type\":\"configure_gcc_runtime\"}]");
+    try testing.expect(execute(h.ctx(), json));
+    // Upstream's body is Linux-only, so "handled, nothing to do" is correct —
+    // routing it as unsupported would downgrade every gcc install.
+    try testing.expect(!h.flog.hasErrors());
+    try testing.expectEqual(@as(usize, 1), h.flog.notes().len);
+    // Notes render verbatim; without the newline the next line runs into it.
+    try testing.expect(std.mem.endsWith(u8, h.flog.notes()[0], "\n"));
+}
+
+test "warn surfaces the formula's message instead of downgrading the install" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+
+    const json = try testFormulaJson(&h,
+        \\[{"type":"warn","message":"A system my.cnf may interfere with {{name}}."}]
+    );
+    try testing.expect(execute(h.ctx(), json));
+    try testing.expect(!h.flog.hasErrors());
+    try testing.expectEqual(@as(usize, 1), h.flog.notes().len);
+    try testing.expectEqualStrings("A system my.cnf may interfere with glow.\n", h.flog.notes()[0]);
+}
+
+test "move relocates a tree and refuses an occupied target without overwrite" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    const src = try std.fmt.allocPrint(a, "{s}/libexec/html", .{h.keg});
+    try std.Io.Dir.cwd().createDirPath(h.io, src);
+    try atomic.atomicWriteFile(h.io, try std.fmt.allocPrint(a, "{s}/index.html", .{src}), "hi\n");
+
+    const json = try testFormulaJson(&h,
+        \\[{"type":"move","source":{"base":"libexec","path":"html"},"target":{"base":"var","path":"www"}}]
+    );
+    try testing.expect(execute(h.ctx(), json));
+    try testing.expect(!h.flog.hasErrors());
+    const moved = try std.fmt.allocPrint(a, "{s}/var/www/index.html", .{h.prefix});
+    try testing.expectEqualStrings("hi\n", try fs_read.readFileAllAbsolute(h.io, a, moved, 64));
+    try testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(h.io, src, .{}));
+
+    // Second run: the docroot is the user's now, and the source is still in
+    // the keg, so a silent skip would hide a relocation that did not happen.
+    try std.Io.Dir.cwd().createDirPath(h.io, src);
+    try testing.expect(execute(h.ctx(), json));
+    try testing.expect(h.flog.hasErrors());
+    try testing.expectEqualStrings("hi\n", try fs_read.readFileAllAbsolute(h.io, a, moved, 64));
+}
+
+test "move overwrites an occupied target when the step asks for it" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    const src = try std.fmt.allocPrint(a, "{s}/libexec/html", .{h.keg});
+    try std.Io.Dir.cwd().createDirPath(h.io, src);
+    try atomic.atomicWriteFile(h.io, try std.fmt.allocPrint(a, "{s}/index.html", .{src}), "new\n");
+    const dst = try std.fmt.allocPrint(a, "{s}/var/www", .{h.prefix});
+    try std.Io.Dir.cwd().createDirPath(h.io, dst);
+    try atomic.atomicWriteFile(h.io, try std.fmt.allocPrint(a, "{s}/stale.html", .{dst}), "old\n");
+
+    const json = try testFormulaJson(&h,
+        \\[{"type":"move","source":{"base":"libexec","path":"html"},"target":{"base":"var","path":"www"},"overwrite":true}]
+    );
+    try testing.expect(execute(h.ctx(), json));
+    try testing.expect(!h.flog.hasErrors());
+    try testing.expectEqualStrings("new\n", try fs_read.readFileAllAbsolute(h.io, a, try std.fmt.allocPrint(a, "{s}/index.html", .{dst}), 64));
+    // The whole tree is replaced, not merged.
+    try testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.accessAbsolute(h.io, try std.fmt.allocPrint(a, "{s}/stale.html", .{dst}), .{}),
+    );
+}
+
+test "move refuses a source that escapes the keg and prefix" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    var outside = try Scratch.init("steps_move_outside");
+    defer outside.deinit();
+    try std.Io.Dir.cwd().createDirPath(h.io, outside.base);
+    try atomic.atomicWriteFile(h.io, outside.p("/secret"), "s\n");
+
+    const json = try std.fmt.allocPrint(a,
+        \\[{{"type":"move","source":{{"path":"{s}"}},"target":{{"base":"var","path":"stolen"}}}}]
+    , .{outside.base});
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h, json)));
+    try testing.expect(h.flog.hasErrors());
+    try testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.accessAbsolute(h.io, try std.fmt.allocPrint(a, "{s}/var/stolen", .{h.prefix}), .{}),
+    );
+}
+
+test "set_permissions recurses by default and honours non_recursive" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    // Upstream passes -R unless non_recursive is set. Getting that backwards
+    // leaves the tree under a declared directory at its bottled mode.
+    const nested = try std.fmt.allocPrint(a, "{s}/var/tree/inner", .{h.prefix});
+    try std.Io.Dir.cwd().createDirPath(h.io, nested);
+    const leaf = try std.fmt.allocPrint(a, "{s}/leaf", .{nested});
+    try atomic.atomicWriteFile(h.io, leaf, "x\n");
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"set_permissions","paths":[{"base":"var","path":"tree"}],"permissions":"0700"}]
+    )));
+    try testing.expect(!h.flog.hasErrors());
+    try testing.expectEqual(@as(std.posix.mode_t, 0o700), try fileMode(h.io, leaf));
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"set_permissions","paths":[{"base":"var","path":"tree"}],"permissions":"0755","non_recursive":true}]
+    )));
+    // Only the named directory moved; the leaf kept the recursive run's mode.
+    try testing.expectEqual(@as(std.posix.mode_t, 0o700), try fileMode(h.io, leaf));
+    try testing.expectEqual(
+        @as(std.posix.mode_t, 0o755),
+        try fileMode(h.io, try std.fmt.allocPrint(a, "{s}/var/tree", .{h.prefix})),
+    );
+}
+
+test "set_permissions applies symbolic modes and skips paths that do not exist" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    const file = try std.fmt.allocPrint(a, "{s}/share/glow/save", .{h.prefix});
+    try std.Io.Dir.cwd().createDirPath(h.io, std.fs.path.dirname(file).?);
+    try atomic.atomicWriteFile(h.io, file, "x\n");
+    try chmodPath(h.io, file, 0o644);
+
+    // The second path was never shipped: upstream filters it out rather than
+    // failing the step.
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"set_permissions","non_recursive":true,"permissions":"g+w",
+        \\  "paths":[{"base":"pkgshare","path":"save"},{"base":"pkgshare","path":"absent"}]}]
+    )));
+    try testing.expect(!h.flog.hasErrors());
+    // g+w adds to what the file already carries; it does not replace it.
+    try testing.expectEqual(@as(std.posix.mode_t, 0o664), try fileMode(h.io, file));
+}
+
+test "set_permissions refuses a symbolic mode it cannot parse" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"set_permissions","paths":[{"base":"var","path":"x"}],"permissions":"a+X"}]
+    )));
+    // Silently doing nothing is how a mode ends up wrong; refuse loudly.
+    try testing.expect(h.flog.hasErrors());
+}
+
+test "parseMode covers the octal and symbolic spellings homebrew-core ships" {
+    try testing.expectEqual(@as(std.posix.mode_t, 0o700), parseMode("0700").?.absolute);
+    try testing.expectEqual(@as(std.posix.mode_t, 0o755), parseMode("755").?.absolute);
+    // Masked, not truncated: chmod(2) only consults the low bits.
+    try testing.expectEqual(@as(std.posix.mode_t, 0o7777), parseMode("77777").?.absolute);
+
+    try testing.expectEqual(@as(std.posix.mode_t, 0o644), applyMode(0o644, parseMode("u+r").?));
+    try testing.expectEqual(@as(std.posix.mode_t, 0o664), applyMode(0o644, parseMode("g+w").?));
+    try testing.expectEqual(@as(std.posix.mode_t, 0o755), applyMode(0o555, parseMode("u+w").?));
+    try testing.expectEqual(@as(std.posix.mode_t, 0o600), applyMode(0o660, parseMode("g-rw").?));
+    try testing.expectEqual(@as(std.posix.mode_t, 0o744), applyMode(0o777, parseMode("go=r").?));
+    try testing.expectEqual(@as(std.posix.mode_t, 0o777), applyMode(0o000, parseMode("a+rwx").?));
+
+    // Anything outside that grammar has to refuse rather than approximate.
+    for ([_][]const u8{ "", "+w", "u", "u+", "u?w", "a+X", "9999", "ugo" }) |bad| {
+        try testing.expect(parseMode(bad) == null);
+    }
+}
+
+test "set_permissions expands the glob shapes upstream path specs carry" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    // redis names `modules/*`; python names `venv/scripts/**/*`. A literal
+    // path never matches either, so the step would be a silent no-op.
+    const modules = try std.fmt.allocPrint(a, "{s}/lib/glow/modules", .{h.prefix});
+    const deep = try std.fmt.allocPrint(a, "{s}/lib/glow/scripts/common", .{h.prefix});
+    try std.Io.Dir.cwd().createDirPath(h.io, modules);
+    try std.Io.Dir.cwd().createDirPath(h.io, deep);
+    const mod = try std.fmt.allocPrint(a, "{s}/one.so", .{modules});
+    const activate = try std.fmt.allocPrint(a, "{s}/activate", .{deep});
+    try atomic.atomicWriteFile(h.io, mod, "x\n");
+    try atomic.atomicWriteFile(h.io, activate, "x\n");
+    try chmodPath(h.io, mod, 0o600);
+    try chmodPath(h.io, activate, 0o444);
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"set_permissions","paths":[{"base":"lib","path":"glow/modules/*"}],"permissions":"0755"},
+        \\ {"type":"set_permissions","non_recursive":true,"permissions":"u+w",
+        \\  "paths":[{"base":"lib","path":"glow/scripts/**/*"}]}]
+    )));
+    try testing.expect(!h.flog.hasErrors());
+    try testing.expectEqual(@as(std.posix.mode_t, 0o755), try fileMode(h.io, mod));
+    try testing.expectEqual(@as(std.posix.mode_t, 0o644), try fileMode(h.io, activate));
+}
+
+test "set_permissions refuses a pattern it cannot expand faithfully" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"set_permissions","paths":[{"base":"var","path":"a*/b/c"}],"permissions":"0755"}]
+    )));
+    try testing.expect(h.flog.hasErrors());
+}
+
+test "the frameworks base resolves inside the keg, matching upstream's prefix/Frameworks" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+
+    const resolved = resolveBase(h.ctx(), "frameworks", null).?;
+    const expected = try std.fmt.allocPrint(h.arena.allocator(), "{s}/Frameworks", .{h.keg});
+    try testing.expectEqualStrings(expected, resolved);
+}
+
+test "install_gzipped_executable unpacks, marks executable, and unlinks the source" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    const src = try std.fmt.allocPrint(a, "{s}/libexec/bin/glow-real.gz", .{h.keg});
+    try std.Io.Dir.cwd().createDirPath(h.io, std.fs.path.dirname(src).?);
+    try atomic.atomicWriteFile(h.io, src, try gzipBytes(a, "\x7fELF payload\n"));
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"install_gzipped_executable","source":{"base":"libexec","path":"bin/glow-real.gz"},
+        \\  "target":{"base":"libexec","path":"bin/glow-real"}}]
+    )));
+    try testing.expect(!h.flog.hasErrors());
+
+    const target = try std.fmt.allocPrint(a, "{s}/libexec/bin/glow-real", .{h.keg});
+    try testing.expectEqualStrings("\x7fELF payload\n", try fs_read.readFileAllAbsolute(h.io, a, target, 4096));
+    // Without the exec bit the unpacked binary is unrunnable, and the archive
+    // left behind would ship in the keg.
+    try testing.expectEqual(@as(std.posix.mode_t, 0o755), try fileMode(h.io, target));
+    try testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(h.io, src, .{}));
+}
+
+test "install_gzipped_executable leaves no temp file behind on a corrupt source" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    const src = try std.fmt.allocPrint(a, "{s}/libexec/bin/glow-real.gz", .{h.keg});
+    try std.Io.Dir.cwd().createDirPath(h.io, std.fs.path.dirname(src).?);
+    try atomic.atomicWriteFile(h.io, src, "not gzip at all");
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"install_gzipped_executable","source":{"base":"libexec","path":"bin/glow-real.gz"},
+        \\  "target":{"base":"libexec","path":"bin/glow-real"}}]
+    )));
+    try testing.expect(h.flog.hasErrors());
+    // A half-written dotfile in bin/ would ship in the keg and confuse linking.
+    const tmp = try std.fmt.allocPrint(a, "{s}/libexec/bin/.glow-real.install-step", .{h.keg});
+    try testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(h.io, tmp, .{}));
+    // The archive survives, so a re-run can still succeed.
+    try std.Io.Dir.accessAbsolute(h.io, src, .{});
+}
+
+test "install_gzipped_executable is a silent no-op when the bottle shipped no archive" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"install_gzipped_executable","source":{"base":"libexec","path":"bin/absent.gz"},
+        \\  "target":{"base":"libexec","path":"bin/absent"}}]
+    )));
+    try testing.expect(!h.flog.hasErrors());
+}
+
+test "change_dylib_id sets the install name on the real file behind a resolved source" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    // The keg publishes the dylib as a symlink to its versioned twin. Which
+    // file the rewrite lands on is the whole contract of `resolve_source`, and
+    // the failure detail is the only place that choice is observable without a
+    // real Mach-O to hand to install_name_tool.
+    const real = try std.fmt.allocPrint(a, "{s}/lib/libruby.3.4.dylib", .{h.keg});
+    const link = try std.fmt.allocPrint(a, "{s}/lib/libruby.dylib", .{h.keg});
+    try std.Io.Dir.cwd().createDirPath(h.io, std.fs.path.dirname(real).?);
+    try atomic.atomicWriteFile(h.io, real, "not a mach-o\n");
+    try std.Io.Dir.symLinkAbsolute(h.io, real, link, .{});
+    try std.Io.Dir.accessAbsolute(h.io, real, .{});
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"change_dylib_id","source":{"base":"prefix","path":"lib/libruby.dylib"},
+        \\  "id":"{{HOMEBREW_PREFIX}}/opt/glow/lib/libruby.3.4.dylib","resolve_source":true}]
+    )));
+    try testing.expectEqual(@as(usize, 1), h.flog.entries().len);
+    const detail = h.flog.entries()[0].detail;
+    // Naming the link would mean the realpath step was skipped. (The scratch
+    // prefix lives under /tmp, itself a symlink on macOS, so the resolved path
+    // leaves the harness prefix and is refused — the detail still records which
+    // file the step chose, which is what `resolve_source` decides.)
+    try testing.expect(std.mem.endsWith(u8, detail, "/lib/libruby.3.4.dylib"));
+    try testing.expect(std.mem.indexOf(u8, detail, "Cellar/glow/1.2.3") != null);
+}
+
+test "change_dylib_id without resolve_source rewrites the path it was handed" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    const real = try std.fmt.allocPrint(a, "{s}/lib/libruby.3.4.dylib", .{h.keg});
+    const link = try std.fmt.allocPrint(a, "{s}/lib/libruby.dylib", .{h.keg});
+    try std.Io.Dir.cwd().createDirPath(h.io, std.fs.path.dirname(real).?);
+    try atomic.atomicWriteFile(h.io, real, "not a mach-o\n");
+    try std.Io.Dir.symLinkAbsolute(h.io, real, link, .{});
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"change_dylib_id","source":{"base":"prefix","path":"lib/libruby.dylib"},
+        \\  "id":"{{HOMEBREW_PREFIX}}/opt/glow/lib/libruby.dylib"}]
+    )));
+    try testing.expectEqual(@as(usize, 1), h.flog.entries().len);
+    try testing.expect(std.mem.indexOf(u8, h.flog.entries()[0].detail, link) != null);
+}
+
+test "change_dylib_id refuses a source that resolves outside the keg and prefix" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    var outside = try Scratch.init("steps_dylib_outside");
+    defer outside.deinit();
+    try std.Io.Dir.cwd().createDirPath(h.io, outside.base);
+    try atomic.atomicWriteFile(h.io, outside.p("/libvictim.dylib"), "not macho\n");
+    const link = try std.fmt.allocPrint(a, "{s}/lib/libruby.dylib", .{h.keg});
+    try std.Io.Dir.cwd().createDirPath(h.io, std.fs.path.dirname(link).?);
+    try std.Io.Dir.symLinkAbsolute(h.io, outside.p("/libvictim.dylib"), link, .{});
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"change_dylib_id","source":{"base":"prefix","path":"lib/libruby.dylib"},
+        \\  "id":"{{HOMEBREW_PREFIX}}/opt/glow/lib/libruby.dylib","resolve_source":true}]
+    )));
+    try testing.expectEqual(@as(usize, 1), h.flog.entries().len);
+    try testing.expectEqual(fallback_log.FallbackReason.sandbox_violation, h.flog.entries()[0].reason);
+    try testing.expectEqualStrings(
+        "not macho\n",
+        try fs_read.readFileAllAbsolute(h.io, a, outside.p("/libvictim.dylib"), 64),
+    );
+}
+
+test "change_dylib_id refuses a step that names no id" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"change_dylib_id","source":{"base":"prefix","path":"lib/x.dylib"}}]
+    )));
+    try testing.expect(h.flog.hasErrors());
+}
+
+test "terminate_process treats an absent process as success" {
+    // The debug Io cannot spawn, so this tier needs a real threaded Io.
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    var h = try TestHarness.init();
+    defer h.deinit();
+    h.io = threaded.io();
+
+    // killall exits non-zero when nothing matched, which is the normal case on
+    // a first install — reading that as failure would fail every such install.
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"terminate_process","name":"malt-no-such-daemon"}]
+    )));
+    try testing.expect(!h.flog.hasErrors());
+    try testing.expectEqual(@as(usize, 1), h.flog.handled_top_level);
+}
+
+test "terminate_process refuses the privilege fields malt does not honour" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+
+    // `sudo` and `must_succeed` change what the step is allowed to do; dropping
+    // them silently would be worse than not running the step at all.
+    for ([_][]const u8{
+        \\[{"type":"terminate_process","name":"gpg-agent","sudo":true}]
+        ,
+        \\[{"type":"terminate_process","name":"gpg-agent","must_succeed":true}]
+        ,
+    }) |steps| {
+        var fresh = try TestHarness.init();
+        defer fresh.deinit();
+        try testing.expect(execute(fresh.ctx(), try testFormulaJson(&fresh, steps)));
+        try testing.expect(fresh.flog.hasErrors());
+    }
+    try testing.expect(!h.flog.hasErrors());
+}
+
+// --- helpers for the step tests --------------------------------------------
+
+fn fileMode(io: std.Io, path: []const u8) !std.posix.mode_t {
+    const f = try std.Io.Dir.openFileAbsolute(io, path, .{});
+    defer f.close(io);
+    const s = try f.stat(io);
+    return s.permissions.toMode() & 0o7777;
+}
+
+fn chmodPath(io: std.Io, path: []const u8, mode: std.posix.mode_t) !void {
+    const f = try std.Io.Dir.openFileAbsolute(io, path, .{});
+    defer f.close(io);
+    try f.setPermissions(io, .fromMode(mode));
+}
+
+/// Minimal gzip stream: a single stored deflate block. Enough to exercise the
+/// decompressor without pulling a compressor's 224 KiB of state into a test.
+fn gzipBytes(a: std.mem.Allocator, payload: []const u8) ![]const u8 {
+    var out: std.ArrayList(u8) = .empty;
+    try out.appendSlice(a, &.{ 0x1f, 0x8b, 0x08, 0, 0, 0, 0, 0, 0, 0xff });
+    try out.append(a, 0x01); // BFINAL=1, BTYPE=stored
+    const len: u16 = @intCast(payload.len);
+    try out.appendSlice(a, &std.mem.toBytes(std.mem.nativeToLittle(u16, len)));
+    try out.appendSlice(a, &std.mem.toBytes(std.mem.nativeToLittle(u16, ~len)));
+    try out.appendSlice(a, payload);
+    try out.appendSlice(a, &std.mem.toBytes(std.mem.nativeToLittle(u32, std.hash.Crc32.hash(payload))));
+    try out.appendSlice(a, &std.mem.toBytes(std.mem.nativeToLittle(u32, len)));
+    return out.toOwnedSlice(a);
+}
+
+test "set_permissions walks past a symlink instead of failing the step on it" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    // Kegs are full of their own symlinks. `chmod -R` skips them; treating one
+    // as a confinement violation would fail an install over ordinary layout.
+    const tree = try std.fmt.allocPrint(a, "{s}/var/tree", .{h.prefix});
+    try std.Io.Dir.cwd().createDirPath(h.io, tree);
+    const real = try std.fmt.allocPrint(a, "{s}/real", .{tree});
+    try atomic.atomicWriteFile(h.io, real, "x\n");
+    try std.Io.Dir.symLinkAbsolute(h.io, "/etc/hosts", try std.fmt.allocPrint(a, "{s}/link", .{tree}), .{});
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"set_permissions","paths":[{"base":"var","path":"tree"}],"permissions":"0700"}]
+    )));
+    try testing.expect(!h.flog.hasErrors());
+    try testing.expectEqual(@as(std.posix.mode_t, 0o700), try fileMode(h.io, real));
+}
+
+test "terminate_process refuses a name killall would read as an option" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+
+    // The name is tap-controlled and killall has no `--` terminator.
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"terminate_process","name":"-9"}]
+    )));
+    try testing.expect(h.flog.hasErrors());
+}
+
+test "move reports a source the bottle never shipped as a mismatch, not a violation" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"move","source":{"base":"libexec","path":"absent"},"target":{"base":"var","path":"www"}},
+        \\ {"type":"mkdir_p","path":{"base":"var","path":"after"}}]
+    )));
+    try testing.expectEqual(@as(usize, 1), h.flog.entries().len);
+    // A sandbox_violation is fatal and would abort every following step; a
+    // missing source is a formula/bottle mismatch, not an escape attempt.
+    try testing.expectEqual(fallback_log.FallbackReason.unknown_method, h.flog.entries()[0].reason);
+    try std.Io.Dir.accessAbsolute(h.io, try std.fmt.allocPrint(h.arena.allocator(), "{s}/var/after", .{h.prefix}), .{});
+}
+
+test "a step carrying both a platform and an existence guard evaluates both" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    // ruby's change_dylib_id ships exactly this pair; one guard short-circuits
+    // the other only if both are reached.
+    const json =
+        \\[{"type":"mkdir_p","path":{"base":"var","path":"made"},
+        \\  "guards":[{"condition":"on","value":"macos","id":"1"},
+        \\            {"base":"var","path":"marker","condition":"if_exists","id":"2"}]}]
+    ;
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h, json)));
+    try testing.expect(!h.flog.hasErrors());
+    // The platform matched but the marker is absent, so the step stays unrun.
+    try testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.accessAbsolute(h.io, try std.fmt.allocPrint(a, "{s}/var/made", .{h.prefix}), .{}),
+    );
+
+    try std.Io.Dir.cwd().createDirPath(h.io, try std.fmt.allocPrint(a, "{s}/var", .{h.prefix}));
+    (try std.Io.Dir.createFileAbsolute(h.io, try std.fmt.allocPrint(a, "{s}/var/marker", .{h.prefix}), .{})).close(h.io);
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h, json)));
+    try std.Io.Dir.accessAbsolute(h.io, try std.fmt.allocPrint(a, "{s}/var/made", .{h.prefix}), .{});
+}
+
+test "a recursive remove expands the glob a formula names its stale tree with" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    // ruby retires `gems/bundler-*`; a literal path matches nothing, so the
+    // superseded copy would survive every upgrade.
+    const gems = try std.fmt.allocPrint(a, "{s}/lib/gems", .{h.prefix});
+    try std.Io.Dir.cwd().createDirPath(h.io, try std.fmt.allocPrint(a, "{s}/bundler-2.6.9", .{gems}));
+    const keep = try std.fmt.allocPrint(a, "{s}/rake-13.2.1", .{gems});
+    try std.Io.Dir.cwd().createDirPath(h.io, keep);
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"remove","recursive":true,"paths":[{"base":"lib","path":"gems/bundler-*"}]}]
+    )));
+    try testing.expect(!h.flog.hasErrors());
+    try testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.accessAbsolute(h.io, try std.fmt.allocPrint(a, "{s}/bundler-2.6.9", .{gems}), .{}),
+    );
+    // Neighbours the pattern does not name must survive.
+    try std.Io.Dir.accessAbsolute(h.io, keep, .{});
+}
+
+test "a globbed recursive remove still refuses a shared prefix directory" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    // Expansion happens before the shared-ground guard, so a pattern must not
+    // be a way around it: `<prefix>/*` names every other package's ground.
+    const lib = try std.fmt.allocPrint(a, "{s}/lib", .{h.prefix});
+    try std.Io.Dir.cwd().createDirPath(h.io, lib);
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"remove","recursive":true,"paths":[{"base":"homebrew_prefix","path":"*"}]}]
+    )));
+    try testing.expect(h.flog.hasErrors());
+    try std.Io.Dir.accessAbsolute(h.io, lib, .{});
+}
+
+test "a glob is refused when its root sits outside the keg and prefix" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    // Expansion reads a subtree to discover paths, so an unbounded root would
+    // hand a tap recursive enumeration of anywhere this user can read — even
+    // though the per-match confinement would still refuse the writes.
+    var outside = try Scratch.init("steps_glob_outside");
+    defer outside.deinit();
+    try std.Io.Dir.cwd().createDirPath(h.io, outside.base);
+    try atomic.atomicWriteFile(h.io, outside.p("/secret"), "s\n");
+
+    inline for (.{
+        \\[{{"type":"set_permissions","permissions":"0755","paths":[{{"path":"{s}/*"}}]}}]
+        ,
+        \\[{{"type":"remove","recursive":true,"paths":[{{"path":"{s}/**/*"}}]}}]
+        ,
+    }) |shape| {
+        var fresh = try TestHarness.init();
+        defer fresh.deinit();
+        const json = try std.fmt.allocPrint(a, shape, .{outside.base});
+        try testing.expect(execute(fresh.ctx(), try testFormulaJson(&fresh, json)));
+        try testing.expectEqual(@as(usize, 1), fresh.flog.entries().len);
+        try testing.expectEqual(fallback_log.FallbackReason.sandbox_violation, fresh.flog.entries()[0].reason);
+    }
+    try testing.expectEqualStrings("s\n", try fs_read.readFileAllAbsolute(h.io, a, outside.p("/secret"), 16));
+}
+
+test "configure_clang_system completes a set left half-written by an earlier run" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    // An interrupted run leaves some of the six behind. The early exit only
+    // fires on a complete set, so the rest must still be written.
+    const dir = try std.fmt.allocPrint(a, "{s}/etc/clang", .{h.prefix});
+    try std.Io.Dir.cwd().createDirPath(h.io, dir);
+    const present = try std.fmt.allocPrint(a, "{s}/arm64-apple-darwin25.cfg", .{dir});
+    try atomic.atomicWriteFile(h.io, present, "stale\n");
+
+    try testing.expect(writeClangConfigs(h.ctx(), 26, 25));
+    try testing.expect(!h.flog.hasErrors());
+
+    const want = "-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk\n";
+    const missing = try std.fmt.allocPrint(a, "{s}/x86_64-apple-macosx26.cfg", .{dir});
+    try testing.expectEqualStrings(want, try fs_read.readFileAllAbsolute(h.io, a, missing, 4096));
+    // The incomplete set is rewritten wholesale, matching upstream's all-or-none check.
+    try testing.expectEqualStrings(want, try fs_read.readFileAllAbsolute(h.io, a, present, 4096));
+}
+
+test "configure_clang_system names its files from the host's own two versions" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    // Guards the seam between the sysctl reads and the writer: transposing the
+    // two majors still writes six plausible files, all wrongly named.
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h, "[{\"type\":\"configure_clang_system\"}]")));
+    try testing.expect(!h.flog.hasErrors());
+
+    const kernel = sysctlMajor("kern.osrelease").?;
+    const macos = sysctlMajor("kern.osproductversion").?;
+    try std.Io.Dir.accessAbsolute(h.io, try std.fmt.allocPrint(a, "{s}/etc/clang/arm64-apple-darwin{d}.cfg", .{ h.prefix, kernel }), .{});
+    try std.Io.Dir.accessAbsolute(h.io, try std.fmt.allocPrint(a, "{s}/etc/clang/arm64-apple-macosx{d}.cfg", .{ h.prefix, macos }), .{});
+}
+
+test "install_gzipped_executable refuses a source or target outside the prefix" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    var outside = try Scratch.init("steps_gz_outside");
+    defer outside.deinit();
+    try std.Io.Dir.cwd().createDirPath(h.io, outside.base);
+    try atomic.atomicWriteFile(h.io, outside.p("/payload.gz"), try gzipBytes(a, "payload\n"));
+
+    // The step decompresses tap-controlled bytes and marks the result
+    // executable, so both ends need the same boundary as every other write.
+    const escaping_source = try std.fmt.allocPrint(a,
+        \\[{{"type":"install_gzipped_executable","source":{{"path":"{s}/payload.gz"}},
+        \\  "target":{{"base":"libexec","path":"bin/x"}}}}]
+    , .{outside.base});
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h, escaping_source)));
+    try testing.expect(h.flog.hasErrors());
+    try testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.accessAbsolute(h.io, try std.fmt.allocPrint(a, "{s}/libexec/bin/x", .{h.keg}), .{}),
+    );
+
+    var h2 = try TestHarness.init();
+    defer h2.deinit();
+    const src = try std.fmt.allocPrint(h2.arena.allocator(), "{s}/libexec/payload.gz", .{h2.keg});
+    try std.Io.Dir.cwd().createDirPath(h2.io, std.fs.path.dirname(src).?);
+    try atomic.atomicWriteFile(h2.io, src, try gzipBytes(h2.arena.allocator(), "payload\n"));
+    const escaping_target = try std.fmt.allocPrint(h2.arena.allocator(),
+        \\[{{"type":"install_gzipped_executable","source":{{"base":"libexec","path":"payload.gz"}},
+        \\  "target":{{"path":"{s}/planted"}}}}]
+    , .{outside.base});
+    try testing.expect(execute(h2.ctx(), try testFormulaJson(&h2, escaping_target)));
+    try testing.expect(h2.flog.hasErrors());
+    try testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.accessAbsolute(h2.io, outside.p("/planted"), .{}),
+    );
+}
+
+test "move honours force as upstream's alias for overwrite" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    const src = try std.fmt.allocPrint(a, "{s}/libexec/html", .{h.keg});
+    try std.Io.Dir.cwd().createDirPath(h.io, src);
+    try atomic.atomicWriteFile(h.io, try std.fmt.allocPrint(a, "{s}/index.html", .{src}), "new\n");
+    const dst = try std.fmt.allocPrint(a, "{s}/var/www", .{h.prefix});
+    try std.Io.Dir.cwd().createDirPath(h.io, dst);
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"move","source":{"base":"libexec","path":"html"},"target":{"base":"var","path":"www"},"force":true}]
+    )));
+    try testing.expect(!h.flog.hasErrors());
+    try testing.expectEqualStrings(
+        "new\n",
+        try fs_read.readFileAllAbsolute(h.io, a, try std.fmt.allocPrint(a, "{s}/index.html", .{dst}), 64),
+    );
+    // Nothing of the swap-aside scaffolding may survive in the prefix.
+    try testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.accessAbsolute(h.io, try std.fmt.allocPrint(a, "{s}.malt-replaced", .{dst}), .{}),
+    );
+}
+
+test "steps that lose a field they cannot invent refuse instead of guessing" {
+    // Each of these drops the one key that carries the step's whole intent.
+    const shapes = [_][]const u8{
+        \\[{"type":"warn"}]
+        ,
+        \\[{"type":"set_permissions","paths":[{"base":"var","path":"x"}]}]
+        ,
+        \\[{"type":"set_permissions","permissions":"0755"}]
+        ,
+        \\[{"type":"set_permissions","permissions":"0755","paths":{"base":"var","path":"x"}}]
+        ,
+        \\[{"type":"terminate_process"}]
+        ,
+    };
+    for (shapes) |shape| {
+        var h = try TestHarness.init();
+        defer h.deinit();
+        try testing.expect(execute(h.ctx(), try testFormulaJson(&h, shape)));
+        try testing.expect(h.flog.hasErrors());
+    }
+}
+
+test "set_permissions tolerates the empty and unmatched shapes upstream compacts to" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+
+    // An empty array, a non-object entry, and a glob that matches nothing are
+    // all "nothing to do" upstream — none of them is an error.
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"set_permissions","paths":[],"permissions":"0755"},
+        \\ {"type":"set_permissions","paths":["oops"],"permissions":"0755"},
+        \\ {"type":"set_permissions","paths":[{"base":"var","path":"nothing/here/*"}],"permissions":"0755"}]
+    )));
+    try testing.expect(!h.flog.hasErrors());
+}
+
+test "a glob root cannot walk out of the prefix through a parent reference" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    // Textually inside the prefix, actually outside it. Nothing between the
+    // spec and `openDirAbsolute` normalises a path, so a bare prefix compare
+    // would admit this and hand a tap recursive enumeration of the disk.
+    var outside = try Scratch.init("steps_dotdot");
+    defer outside.deinit();
+    try std.Io.Dir.cwd().createDirPath(h.io, outside.base);
+    try atomic.atomicWriteFile(h.io, outside.p("/secret"), "s\n");
+
+    const escape = try std.fmt.allocPrint(a, "{s}/..{s}", .{ h.prefix, outside.base });
+    inline for (.{
+        \\[{{"type":"set_permissions","permissions":"0777","paths":[{{"path":"{s}/*"}}]}}]
+        ,
+        \\[{{"type":"remove","recursive":true,"paths":[{{"path":"{s}/**/*"}}]}}]
+        ,
+        \\[{{"type":"change_dylib_id","source":{{"path":"{s}/secret"}},"id":"/x","resolve_source":true}}]
+        ,
+    }) |shape| {
+        var fresh = try TestHarness.init();
+        defer fresh.deinit();
+        const json = try std.fmt.allocPrint(a, shape, .{escape});
+        try testing.expect(execute(fresh.ctx(), try testFormulaJson(&fresh, json)));
+        try testing.expectEqual(@as(usize, 1), fresh.flog.entries().len);
+        try testing.expectEqual(fallback_log.FallbackReason.sandbox_violation, fresh.flog.entries()[0].reason);
+    }
+    try testing.expectEqualStrings("s\n", try fs_read.readFileAllAbsolute(h.io, a, outside.p("/secret"), 16));
+}
+
+test "withinBounds refuses what validatePath refuses" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+    const c = h.ctx();
+
+    try testing.expect(withinBounds(c, try std.fmt.allocPrint(a, "{s}/lib", .{h.prefix})));
+    try testing.expect(withinBounds(c, try std.fmt.allocPrint(a, "{s}/bin", .{h.keg})));
+    // A parent reference, a relative path, and a sibling whose name merely
+    // starts with the prefix all have to be refused.
+    try testing.expect(!withinBounds(c, try std.fmt.allocPrint(a, "{s}/../etc", .{h.prefix})));
+    try testing.expect(!withinBounds(c, "relative/path"));
+    try testing.expect(!withinBounds(c, try std.fmt.allocPrint(a, "{s}evil/lib", .{h.prefix})));
+    try testing.expect(!withinBounds(c, "/etc"));
+}
+
+test "resolveLink follows a chain, a relative hop, and gives up on a cycle" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+    const c = h.ctx();
+
+    const dir = try std.fmt.allocPrint(a, "{s}/lib", .{h.keg});
+    try std.Io.Dir.cwd().createDirPath(h.io, dir);
+    const real = try std.fmt.allocPrint(a, "{s}/real", .{dir});
+    try atomic.atomicWriteFile(h.io, real, "x\n");
+
+    // Two hops, the second one relative — a keg's own link farm uses both.
+    const mid = try std.fmt.allocPrint(a, "{s}/mid", .{dir});
+    const top = try std.fmt.allocPrint(a, "{s}/top", .{dir});
+    // Relative target, so not `symLinkAbsolute` — it asserts an absolute one.
+    {
+        var d = try std.Io.Dir.openDirAbsolute(h.io, dir, .{});
+        defer d.close(h.io);
+        try std.Io.Dir.symLink(d, h.io, "real", "mid", .{});
+    }
+    try std.Io.Dir.symLinkAbsolute(h.io, mid, top, .{});
+    try testing.expectEqualStrings(real, resolveLink(c, top));
+
+    // A cycle must terminate rather than spin; the caller then refuses it
+    // because what comes back is still a symlink.
+    const loop_a = try std.fmt.allocPrint(a, "{s}/loop_a", .{dir});
+    const loop_b = try std.fmt.allocPrint(a, "{s}/loop_b", .{dir});
+    try std.Io.Dir.symLinkAbsolute(h.io, loop_b, loop_a, .{});
+    try std.Io.Dir.symLinkAbsolute(h.io, loop_a, loop_b, .{});
+    const settled = resolveLink(c, loop_a);
+    try testing.expect(std.mem.indexOf(u8, settled, "loop_") != null);
+
+    // A plain file resolves to itself.
+    try testing.expectEqualStrings(real, resolveLink(c, real));
+}
+
+test "a glob descent does not cross a symlinked directory boundary" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    // A linked prefix is full of directory symlinks pointing back at the
+    // Cellar. Descending through one would apply a mode to a tree the pattern
+    // never named, so `**` stops at the boundary — same rule `chmod -R` uses.
+    const root = try std.fmt.allocPrint(a, "{s}/var/tree", .{h.prefix});
+    const elsewhere = try std.fmt.allocPrint(a, "{s}/var/elsewhere", .{h.prefix});
+    try std.Io.Dir.cwd().createDirPath(h.io, root);
+    try std.Io.Dir.cwd().createDirPath(h.io, elsewhere);
+    const hidden = try std.fmt.allocPrint(a, "{s}/hidden", .{elsewhere});
+    try atomic.atomicWriteFile(h.io, hidden, "x\n");
+    try chmodPath(h.io, hidden, 0o600);
+    try std.Io.Dir.symLinkAbsolute(h.io, elsewhere, try std.fmt.allocPrint(a, "{s}/link", .{root}), .{});
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"set_permissions","non_recursive":true,"permissions":"0755",
+        \\  "paths":[{"base":"var","path":"tree/**/*"}]}]
+    )));
+    try testing.expect(!h.flog.hasErrors());
+    try testing.expectEqual(@as(std.posix.mode_t, 0o600), try fileMode(h.io, hidden));
+}
+
+test "parseMode refuses an octal literal too wide for a file mode" {
+    // parseInt overflows before the mask can run, so the refusal comes from the
+    // parse, not from truncation.
+    try testing.expect(parseMode("7777777777777777777777") == null);
+    try testing.expect(parseMode("0700") != null);
+}
+
+/// Minimal Mach-O dylib carrying one `LC_ID_DYLIB`. `install_name_tool`
+/// accepts this shape, so the rewrite can be driven for real without a
+/// compiler or a bottle. The embedded name is padded so a longer replacement
+/// still fits its slot.
+fn writeSynthDylib(io: std.Io, path: []const u8, id: []const u8) !void {
+    const macho = std.macho;
+    const lc_size = @sizeOf(macho.dylib_command);
+    const slot = 256;
+    const cmdsize: u32 = @intCast((lc_size + slot + 7) & ~@as(usize, 7));
+    const header_size = @sizeOf(macho.mach_header_64);
+
+    var buf: [header_size + 512]u8 = undefined;
+    const total = header_size + cmdsize;
+    @memset(buf[0..total], 0);
+
+    const header = std.mem.bytesAsValue(macho.mach_header_64, buf[0..header_size]);
+    header.* = .{
+        .magic = macho.MH_MAGIC_64,
+        // arm64 + MH_DYLIB: install_name_tool refuses anything it cannot
+        // recognise as a dylib for this host.
+        .cputype = macho.CPU_TYPE_ARM64,
+        .filetype = macho.MH_DYLIB,
+        .ncmds = 1,
+        .sizeofcmds = cmdsize,
+    };
+    const dy = std.mem.bytesAsValue(macho.dylib_command, buf[header_size..][0..lc_size]);
+    dy.* = .{
+        .cmd = .ID_DYLIB,
+        .cmdsize = cmdsize,
+        .dylib = .{ .name = @intCast(lc_size), .timestamp = 0, .current_version = 0, .compatibility_version = 0 },
+    };
+    @memcpy(buf[header_size + lc_size ..][0..id.len], id);
+
+    const f = try std.Io.Dir.createFileAbsolute(io, path, .{ .truncate = true });
+    defer f.close(io);
+    try f.writeStreamingAll(io, buf[0..total]);
+}
+
+/// The `LC_ID_DYLIB` name currently on disk. Read straight out of the file so
+/// the assertion is the byte the linker would see, not malt's idea of it —
+/// `patch.fileLinksPath` deliberately skips this load command.
+fn readDylibId(io: std.Io, a: std.mem.Allocator, path: []const u8) !?[]const u8 {
+    const f = try std.Io.Dir.openFileAbsolute(io, path, .{});
+    defer f.close(io);
+    const data = try fs_read.readFileAll(io, a, f, 1 << 20);
+    const header = std.mem.bytesAsValue(std.macho.mach_header_64, data[0..@sizeOf(std.macho.mach_header_64)]);
+    var off: usize = @sizeOf(std.macho.mach_header_64);
+    for (0..header.ncmds) |_| {
+        const lc = std.mem.bytesAsValue(std.macho.load_command, data[off..][0..@sizeOf(std.macho.load_command)]);
+        if (lc.cmd == .ID_DYLIB) {
+            const dy = std.mem.bytesAsValue(std.macho.dylib_command, data[off..][0..@sizeOf(std.macho.dylib_command)]);
+            return std.mem.sliceTo(data[off + dy.dylib.name ..], 0);
+        }
+        off += lc.cmdsize;
+    }
+    return null;
+}
+
+test "change_dylib_id rewrites the install name on a real Mach-O" {
+    // Needs a threaded Io: the rewrite spawns the platform tool.
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    var h = try TestHarness.init();
+    defer h.deinit();
+    h.io = threaded.io();
+    const a = h.arena.allocator();
+
+    const dylib = try std.fmt.allocPrint(a, "{s}/lib/libsynth.dylib", .{h.keg});
+    try std.Io.Dir.cwd().createDirPath(h.io, std.fs.path.dirname(dylib).?);
+    try writeSynthDylib(h.io, dylib, "/placeholder/lib/libsynth.dylib");
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"change_dylib_id","source":{"base":"prefix","path":"lib/libsynth.dylib"},
+        \\  "id":"{{HOMEBREW_PREFIX}}/opt/glow/lib/libsynth.dylib"}]
+    )));
+
+    // The substantive half: the new install name is on disk and the old one
+    // is gone. Reading it back through malt's own Mach-O reader means a
+    // wrong LC constant or a swapped argument cannot pass.
+    const want = try std.fmt.allocPrint(a, "{s}/opt/glow/lib/libsynth.dylib", .{h.prefix});
+    try testing.expectEqualStrings(want, (try readDylibId(h.io, a, dylib)).?);
+
+    // The other half: on arm64 the rewrite invalidates the signature, so the
+    // step re-signs. A hand-built dylib cannot satisfy codesign's strict
+    // validation, so what this pins is that the failure is reported rather
+    // than swallowed — a silent one would ship an unrunnable dylib.
+    if (codesign.isArm64()) {
+        try testing.expectEqual(@as(usize, 1), h.flog.entries().len);
+        try testing.expectEqual(fallback_log.FallbackReason.system_command_failed, h.flog.entries()[0].reason);
+        try testing.expect(std.mem.indexOf(u8, h.flog.entries()[0].detail, "libsynth.dylib") != null);
+    } else {
+        try testing.expect(!h.flog.hasErrors());
+    }
 }

--- a/src/core/post_install_steps.zig
+++ b/src/core/post_install_steps.zig
@@ -651,11 +651,12 @@ fn starMatch(pattern: []const u8, name: []const u8) bool {
 /// hold, so a caller can refuse loudly instead of reading it as a skip.
 const GuardOutcome = enum { met, unmet, unsupported };
 
-const GuardCondition = enum { if_exists, unless_exists };
+const GuardCondition = enum { if_exists, unless_exists, on };
 
 const guard_condition_map = std.StaticStringMap(GuardCondition).initComptime(.{
     .{ "if_exists", .if_exists },
     .{ "unless_exists", .unless_exists },
+    .{ "on", .on },
 });
 
 fn evalGuards(ctx: StepsCtx, obj: std.json.ObjectMap) GuardOutcome {
@@ -665,16 +666,40 @@ fn evalGuards(ctx: StepsCtx, obj: std.json.ObjectMap) GuardOutcome {
         if (item != .object) continue;
         const raw = getString(item.object, "condition") orelse return .unsupported;
         const condition = guard_condition_map.get(raw) orelse return .unsupported;
-        // A guard carries the same `{base, path}` spec as the step it gates,
-        // so it must resolve the same way or it tests the wrong location.
-        const path = resolveSpec(ctx, item.object, null) orelse return .unsupported;
-        const exists = if (std.Io.Dir.accessAbsolute(ctx.io, path, .{})) |_| true else |_| false;
-        switch (condition) {
-            .if_exists => if (!exists) return .unmet,
-            .unless_exists => if (exists) return .unmet,
-        }
+        // Dispatched before any spec resolution: an `on` guard carries a
+        // platform value and no path at all.
+        const outcome = switch (condition) {
+            .on => platformGuard(item.object),
+            .if_exists => existsGuard(ctx, item.object, true),
+            .unless_exists => existsGuard(ctx, item.object, false),
+        };
+        if (outcome != .met) return outcome;
     }
     return .met;
+}
+
+const Platform = enum { macos, linux };
+
+const platform_map = std.StaticStringMap(Platform).initComptime(.{
+    .{ "macos", .macos },
+    .{ "linux", .linux },
+});
+
+/// malt builds macOS-only, so the platform is known at compile time — this is a
+/// real evaluation, not a stub standing in for one.
+fn platformGuard(spec: std.json.ObjectMap) GuardOutcome {
+    const value = getString(spec, "value") orelse return .unsupported;
+    return switch (platform_map.get(value) orelse return .unsupported) {
+        .macos => .met,
+        .linux => .unmet,
+    };
+}
+
+fn existsGuard(ctx: StepsCtx, spec: std.json.ObjectMap, want_exists: bool) GuardOutcome {
+    // A guard carries the same `{base, path}` spec as the step it gates, so it
+    // must resolve the same way or it tests the wrong location.
+    const path = resolveSpec(ctx, spec, null) orelse return .unsupported;
+    return if (pathExists(ctx.io, path) == want_exists) .met else .unmet;
 }
 
 /// Replace every line beginning with `literal` wholesale. Caller must have
@@ -1223,6 +1248,11 @@ fn fileExists(io: std.Io, path: []const u8) bool {
     const f = std.Io.Dir.openFileAbsolute(io, path, .{}) catch return false;
     f.close(io);
     return true;
+}
+
+/// Unlike `fileExists`, true for directories too.
+fn pathExists(io: std.Io, path: []const u8) bool {
+    return if (std.Io.Dir.accessAbsolute(io, path, .{})) |_| true else |_| false;
 }
 
 fn getString(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
@@ -1890,6 +1920,59 @@ test "a guard resolves its base like the step it gates" {
     );
     try testing.expect(execute(h.ctx(), json));
     try std.Io.Dir.accessAbsolute(io, try std.fmt.allocPrint(a, "{s}/var/made", .{h.prefix}), .{});
+}
+
+test "the on guard admits a macOS step and skips a Linux one silently" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    // Upstream gates platform-specific steps with a guard carrying a value and
+    // no path — a Linux-only step is a normal skip here, never a failure.
+    const json = try testFormulaJson(&h,
+        \\[{"type":"mkdir_p","path":{"base":"var","path":"mac"},
+        \\  "guards":[{"condition":"on","value":"macos","id":"1"}]},
+        \\ {"type":"mkdir_p","path":{"base":"var","path":"linux"},
+        \\  "guards":[{"condition":"on","value":"linux","id":"2"}]}]
+    );
+    try testing.expect(execute(h.ctx(), json));
+    try testing.expect(!h.flog.hasErrors());
+    try std.Io.Dir.accessAbsolute(h.io, try std.fmt.allocPrint(a, "{s}/var/mac", .{h.prefix}), .{});
+    try testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.accessAbsolute(h.io, try std.fmt.allocPrint(a, "{s}/var/linux", .{h.prefix}), .{}),
+    );
+}
+
+test "the on guard routes an unknown platform value loudly" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    // A platform malt cannot reason about must not read as "skip": the step's
+    // work may still be required here.
+    const json = try testFormulaJson(&h,
+        \\[{"type":"mkdir_p","path":{"base":"var","path":"made"},
+        \\  "guards":[{"condition":"on","value":"haiku","id":"1"}]}]
+    );
+    try testing.expect(execute(h.ctx(), json));
+    try testing.expect(h.flog.hasErrors());
+    try testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.accessAbsolute(h.io, try std.fmt.allocPrint(a, "{s}/var/made", .{h.prefix}), .{}),
+    );
+}
+
+test "the on guard refuses a step whose platform value is missing entirely" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+
+    const json = try testFormulaJson(&h,
+        \\[{"type":"mkdir_p","path":{"base":"var","path":"made"},
+        \\  "guards":[{"condition":"on","id":"1"}]}]
+    );
+    try testing.expect(execute(h.ctx(), json));
+    try testing.expect(h.flog.hasErrors());
 }
 
 test "the libexec base resolves inside the keg, matching a run command's libexec" {
@@ -2779,12 +2862,13 @@ test "run refuses the execution fields malt does not honour" {
 }
 
 test "run refuses a guard it cannot evaluate rather than reading it as a skip" {
-    // Platform guards ship on real formulas. Treating an unevaluable condition
-    // as "declined to run" would turn a missing feature into a silent no-op —
-    // the exact failure the loud envelope exists for.
+    // Treating an unevaluable condition as "declined to run" would turn a
+    // missing feature into a silent no-op — the exact failure the loud
+    // envelope exists for. A platform malt knows is evaluated instead; see the
+    // on-guard tests.
     const unevaluable = [_][]const u8{
         \\[{"type":"run","command":{"base":"bin","path":"t"},
-        \\  "guards":[{"condition":"on","value":"macos","id":"1"}]}]
+        \\  "guards":[{"condition":"on","value":"haiku","id":"1"}]}]
         ,
         \\[{"type":"run","command":{"base":"bin","path":"t"},
         \\  "guards":[{"condition":"if_exists","id":"1"}]}]

--- a/src/system_tools.zig
+++ b/src/system_tools.zig
@@ -16,12 +16,13 @@ pub const install = "/usr/bin/install";
 pub const ln = "/bin/ln";
 pub const launchctl = "/bin/launchctl";
 pub const pgrep = "/usr/bin/pgrep";
+pub const killall = "/usr/bin/killall";
 pub const sw_vers = "/usr/bin/sw_vers";
 
 test "every trusted system tool uses an absolute path" {
     const paths = [_][]const u8{
         codesign,  install_name_tool, unzip, tar,       ditto, hdiutil, sudo,
-        installer, install,           ln,    launchctl, pgrep, sw_vers,
+        installer, install,           ln,    launchctl, pgrep, sw_vers, killall,
     };
     for (paths) |path| {
         try std.testing.expect(std.fs.path.isAbsolute(path));

--- a/tests/install_pure_test.zig
+++ b/tests/install_pure_test.zig
@@ -1883,11 +1883,11 @@ test "driveSteps routes unsupported step types to the loud partial skip" {
     try std.Io.Dir.cwd().createDirPath(io, prefix);
     defer std.Io.Dir.cwd().deleteTree(io, prefix) catch {};
 
-    // `move` is defined upstream but has no native runner yet — the
-    // canonical "known-shape, unsupported" case.
+    // `configure_php` is defined upstream and deliberately left unimplemented —
+    // the canonical "known-shape, unsupported" case.
     const json =
         \\{"name":"glow","versions":{"stable":"1.2.3"},"post_install_defined":false,
-        \\ "post_install_steps":[{"type":"move","source":{"base":"var","path":"a"},"target":{"base":"var","path":"b"}}]}
+        \\ "post_install_steps":[{"type":"configure_php"}]}
     ;
     const r = try runDriveSteps(json, prefix);
     defer testing.allocator.free(r.out);


### PR DESCRIPTION
## Description

Homebrew is migrating formulas off Ruby `def post_install` onto a declarative `post_install_steps` array. malt ran 17 of the 29 step types upstream ships, so 45 macOS-reachable formulas silently skipped their post-install work and were told to retry with `--use-system-ruby` - a workaround that cannot succeed, because a migrated formula has no Ruby body to extract. For `llvm` that meant no `<prefix>/etc/clang/*.cfg`, so a malt-installed clang had no `-isysroot`.

This adds the platform guard and eight step types, covering 35 of those 45. The remaining ten (php, legacy python, pypy) stay deliberate loud skips, and the tests keep them that way. Already-installed kegs do not self-heal - the work happens on the next install, upgrade, or `mt migrate`.

## Related Issue

- None

## Notes for Reviewers

- Verified against real installs, not just unit tests: `<prefix>/etc/clang` after `mt install llvm` is byte-identical to brew's, and redis, nginx, ruby, python, gcc, bazel and mono all complete natively. `scripts/regressions/post-install-steps-live-artefacts.sh` pins that (23s; the heavyweight bottles are behind `MALT_REGRESSION_SLOW=1`). It earns its keep - unit fixtures are plain files, so nothing caught that a linked prefix hands `set_permissions` a symlink until a real install did.
- One deliberate behaviour change to call out: deferring the hooks also moves the `post_install` NDJSON events. They used to interleave per keg (`materialized/linked/post_install`, repeat); they now arrive as a batch after the last keg links. Each line still carries its own `name` and `status`, so a consumer keying off the line is unaffected - one correlating a hook against the immediately preceding `linked` event is not.