### PR TITLE
fix(net): stop a silent or unframed peer from parking a command

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -179,6 +179,7 @@ pub fn build(b: *std.Build) void {
         "tests/net_client_test.zig",
         "tests/net_client_pool_test.zig",
         "tests/net_redirect_auth_test.zig",
+        "tests/notifier_probe_budget_test.zig",
         "tests/http_inject_test.zig",
         "tests/term_sanitize_test.zig",
         "tests/perms_test.zig",

--- a/scripts/regressions/no-deadline-on-connect-tls-response-head.sh
+++ b/scripts/regressions/no-deadline-on-connect-tls-response-head.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Regression: the connect + TLS handshake phase of an HTTP walk must run under
+# a deadline.
+#
+# The bug: `std.http.Client.request` resolves DNS, opens the TCP connection and
+# runs the whole TLS handshake before it returns, and the head-phase watchdog
+# kills a stall by shutting down `req.connection`'s socket - which does not
+# exist yet during that window. A peer that completes the TCP accept and then
+# never speaks TLS parked the calling thread forever, with nothing sampling the
+# cancel flag, so Ctrl-C did not free it either. On a cask or bottle install the
+# stall happens while `db/malt.lock` is held, wedging every other invocation.
+#
+# The fix races the connect against a cancel-polling deadline and reports a
+# connect the deadline cut short as the peer's answer, sharing one budget per
+# hop with the head read.
+#
+# The assertion is behavioural and wall-clock-bound, and `MALT_API_DOMAIN` is
+# https-only so the real binary cannot be pointed at a loopback fixture. It is
+# judged through the integration test binary instead: loopback only, no
+# network, well under 30s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+SRC="src/net/client.zig"
+TESTS="tests/net_redirect_auth_test.zig"
+BIN="$ROOT/zig-out/test-bin/net_redirect_auth_test"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+# A dropped guard or a dropped fixture would let the binary go green vacuously.
+grep -Fqs -- "requestDeadlined" "$SRC" || fail "the connect-phase deadline is gone"
+grep -Fqs -- "tls_silent" "$TESTS" || fail "the silent-handshake fixture is gone"
+
+# Every walk must open through the helper; a bare call is the pre-fix shape.
+if [[ "$(grep -Fc -- "self.client.request(" "$SRC")" -ne 0 ]]; then
+  fail "a walk still connects with no deadline"
+fi
+
+# Always rebuild: a prebuilt binary could predate the fix, and zig 0.16 has no
+# --test-filter to narrow this down.
+zig build test-bin >/dev/null 2>&1 || fail "could not build the test binaries"
+
+OUT=$(mktemp -t connect-deadline)
+trap 'rm -f "$OUT"' EXIT
+
+start=$(date +%s)
+timeout 90 "$BIN" >"$OUT" 2>&1 || fail "a silent TLS peer was not cut off: $(tail -3 "$OUT")"
+elapsed=$(($(date +%s) - start))
+
+# Wide enough for a loaded CI box: the pre-fix shape parks forever, so the
+# ceiling only has to separate "finished" from "never".
+((elapsed < 75)) || fail "the connect phase took ${elapsed}s - the deadline did not fire"
+
+echo "PASS: a silent TLS peer cannot park the connect phase"

--- a/scripts/regressions/no-deadline-on-connect-tls-response-head.sh
+++ b/scripts/regressions/no-deadline-on-connect-tls-response-head.sh
@@ -42,6 +42,10 @@ if [[ "$(grep -Fc -- "self.client.request(" "$SRC")" -ne 0 ]]; then
   fail "a walk still connects with no deadline"
 fi
 
+# `zig build test-bin` does not prune, so a binary left by an earlier build
+# still runs after its file is dropped from the build. Pin the registration.
+grep -Fqs -- "tests/net_redirect_auth_test.zig" build.zig || fail "the test file is no longer built"
+
 # Always rebuild: a prebuilt binary could predate the fix, and zig 0.16 has no
 # --test-filter to narrow this down.
 zig build test-bin >/dev/null 2>&1 || fail "could not build the test binaries"
@@ -56,5 +60,8 @@ elapsed=$(($(date +%s) - start))
 # Wide enough for a loaded CI box: the pre-fix shape parks forever, so the
 # ceiling only has to separate "finished" from "never".
 ((elapsed < 75)) || fail "the connect phase took ${elapsed}s - the deadline did not fire"
+
+grep -Fqs -- "never starts its TLS handshake...OK" "$OUT" || fail "the connect-deadline tests did not run"
+grep -Fqs -- "stalled TLS handshake is the answer, not a blip to retry...OK" "$OUT" || fail "the connect-deadline tests did not run"
 
 echo "PASS: a silent TLS peer cannot park the connect phase"

--- a/scripts/regressions/notifier-probe-unbounded-by-client-retry-backoff.sh
+++ b/scripts/regressions/notifier-probe-unbounded-by-client-retry-backoff.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Regression: the passive version probe must not inherit the client's retry
+# schedule.
+#
+# The bug: the probe's timeout knobs bound a single attempt. A transient
+# failure - a 5xx, a reset, a timeout - bought four attempts plus seven
+# seconds of backoff on top, so a GitHub brownout held *every* command for
+# around 13 seconds while the probe advertised a 1.5 s bound.
+#
+# The fix gives the probe a no-retry budget alongside the per-phase deadlines.
+# That is the notifier's choice, not a new client default: an install losing
+# its retries would be a worse regression than the latency this fixes, so the
+# stock schedule is asserted here too.
+#
+# The fixture is a loopback TLS endpoint answering 503 to everything. TLS
+# rather than cleartext because the probe's endpoint is https and the
+# handshake is the phase that costs; a self-signed cert plus a trust store
+# scoped to the test keeps it hermetic. Judged through the integration test
+# binary: the probe's URL is a hardcoded constant, so the real binary cannot
+# be pointed at a fixture without a seam that would also redirect self-update.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+NOTIFIER="src/update/notifier.zig"
+TESTS="tests/notifier_probe_budget_test.zig"
+BIN="$ROOT/zig-out/test-bin/notifier_probe_budget_test"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+# A dropped guard or a dropped fixture would let the binary go green vacuously.
+grep -Fqs -- "applyProbeBudget(&http)" "$NOTIFIER" || fail "the probe no longer applies its budget"
+grep -Fqs -- "retry_backoff_ms" "$NOTIFIER" || fail "the probe's retry budget is gone"
+grep -Fqs -- "MALT_TEST_PROBE_CA" "$TESTS" || fail "the https fixture wiring is gone"
+
+command -v openssl >/dev/null 2>&1 || fail "openssl is required to mint the fixture cert"
+command -v python3 >/dev/null 2>&1 || fail "python3 is required to serve the fixture"
+
+# Always rebuild: a prebuilt binary could predate the fix, and zig 0.16 has no
+# --test-filter to narrow this down.
+zig build test-bin >/dev/null 2>&1 || fail "could not build the test binaries"
+
+WORK=$(mktemp -d -t probe-budget)
+SERVER_PID=""
+cleanup() {
+  [[ -n "$SERVER_PID" ]] && kill "$SERVER_PID" 2>/dev/null
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+# P-256 and a DNS SAN: the client verifies host names against DNS entries, and
+# an IP SAN never satisfies that.
+openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:P-256 -nodes \
+  -keyout "$WORK/key.pem" -out "$WORK/cert.pem" -days 1 \
+  -subj "/CN=localhost" -addext "subjectAltName=DNS:localhost" \
+  >/dev/null 2>&1 || fail "could not mint the fixture certificate"
+
+LOG_FILE="$WORK/requests"
+: >"$LOG_FILE"
+
+# A loopback TLS endpoint that answers 503 to everything, prints its port once
+# bound, and appends each request's path so attempts can be counted per walk.
+cat >"$WORK/fixture.py" <<'FIXTURE'
+import http.server
+import os
+import ssl
+import sys
+
+log_path = os.environ["REQUEST_LOG_FILE"]
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self):
+        with open(log_path, "a") as f:
+            f.write("%s\n" % self.path)
+        body = b"busy"
+        self.send_response(503)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+ctx.load_cert_chain(certfile=sys.argv[1], keyfile=sys.argv[2])
+ctx.minimum_version = ssl.TLSVersion.TLSv1_3
+server.socket = ctx.wrap_socket(server.socket, server_side=True)
+print(server.server_address[1], flush=True)
+server.serve_forever()
+FIXTURE
+
+REQUEST_LOG_FILE="$LOG_FILE" python3 "$WORK/fixture.py" "$WORK/cert.pem" "$WORK/key.pem" \
+  >"$WORK/port" 2>"$WORK/server.err" &
+SERVER_PID=$!
+
+# Bound the wait: a fixture that never binds must fail, not hang.
+for _ in $(seq 1 50); do
+  [[ -s "$WORK/port" ]] && break
+  sleep 0.1
+done
+PORT=$(cat "$WORK/port" 2>/dev/null || true)
+[[ -n "$PORT" ]] || fail "the fixture never bound a port: $(tail -3 "$WORK/server.err")"
+
+MALT_TEST_PROBE_PORT="$PORT" MALT_TEST_PROBE_CA="$WORK/cert.pem" \
+  timeout 60 "$BIN" >"$WORK/out" 2>&1 || fail "the probe walk failed: $(tail -5 "$WORK/out")"
+
+grep -Fqs "All 2 tests passed" "$WORK/out" || fail "the fixture was not exercised: $(tail -5 "$WORK/out")"
+
+# Counted per walk, so the assertion does not move when a test is added.
+PROBE=$(grep -c '^/releases/latest$' "$LOG_FILE" || true)
+[[ "$PROBE" -eq 1 ]] || fail "the probe made ${PROBE} attempts, expected 1 - it inherited the retry schedule"
+
+# The stock schedule is three retries on top of the first attempt. Asserted
+# against the same endpoint so a client-wide loss of retries fails here too.
+RETRIED=$(grep -c '^/retried$' "$LOG_FILE" || true)
+[[ "$RETRIED" -eq 4 ]] || fail "a retrying walk made ${RETRIED} attempts, expected 4"
+
+echo "PASS: the version probe spends one attempt on a failing endpoint"

--- a/scripts/regressions/redirect-response-released-with-draining-deinit.sh
+++ b/scripts/regressions/redirect-response-released-with-draining-deinit.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Regression: a redirect hop must be released without draining its body.
+#
+# The bug: a 3xx body is never read, and the stdlib release path drains an
+# unread body. Absent `Content-Length` and a transfer encoding the body is
+# close-delimited, so that drain ends only when the peer closes - and no
+# watchdog runs across a redirect hop. A peer answering `302` plus `Location`
+# with no framing headers, on a socket it holds open, parked the walk there.
+#
+# `finishBodiless` already existed for the 1xx/204/304 case; the fix routes an
+# unframed redirect through it too, and retires the connection rather than
+# pooling bytes nobody read.
+#
+# The assertion is behavioural and wall-clock-bound: the fixture holds the
+# socket open long enough that a draining release is unmistakable, and closes
+# it afterwards so a regression fails cleanly instead of hanging. Loopback
+# only, no network.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+SRC="src/net/client.zig"
+TESTS="tests/net_redirect_auth_test.zig"
+BIN="$ROOT/zig-out/test-bin/net_redirect_auth_test"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+# A dropped guard or a dropped fixture would let the binary go green vacuously.
+grep -Fqs -- "finishRedirect" "$SRC" || fail "the redirect release helper is gone"
+grep -Fqs -- "UnframedRedirectPeer" "$TESTS" || fail "the unframed-redirect fixture is gone"
+
+# Both walks must release a committed hop through the helper; a bare release is
+# the pre-fix shape.
+if [[ "$(grep -Fc -- "finishRedirect(&req, &response.head)" "$SRC")" -ne 2 ]]; then
+  fail "a redirect hop is still released with a draining deinit"
+fi
+
+# Always rebuild: a prebuilt binary could predate the fix, and zig 0.16 has no
+# --test-filter to narrow this down.
+zig build test-bin >/dev/null 2>&1 || fail "could not build the test binaries"
+
+OUT=$(mktemp -t redirect-drain)
+trap 'rm -f "$OUT"' EXIT
+
+timeout 60 "$BIN" >"$OUT" 2>&1 || fail "an unframed redirect was not released: $(tail -3 "$OUT")"
+
+echo "PASS: an unframed redirect is released without draining until close"

--- a/scripts/regressions/redirect-response-released-with-draining-deinit.sh
+++ b/scripts/regressions/redirect-response-released-with-draining-deinit.sh
@@ -40,6 +40,10 @@ if [[ "$(grep -Fc -- "finishRedirect(&req, &response.head)" "$SRC")" -ne 2 ]]; t
   fail "a redirect hop is still released with a draining deinit"
 fi
 
+# `zig build test-bin` does not prune, so a binary left by an earlier build
+# still runs after its file is dropped from the build. Pin the registration.
+grep -Fqs -- "tests/net_redirect_auth_test.zig" build.zig || fail "the test file is no longer built"
+
 # Always rebuild: a prebuilt binary could predate the fix, and zig 0.16 has no
 # --test-filter to narrow this down.
 zig build test-bin >/dev/null 2>&1 || fail "could not build the test binaries"
@@ -48,5 +52,8 @@ OUT=$(mktemp -t redirect-drain)
 trap 'rm -f "$OUT"' EXIT
 
 timeout 60 "$BIN" >"$OUT" 2>&1 || fail "an unframed redirect was not released: $(tail -3 "$OUT")"
+
+grep -Fqs -- "released without draining until the peer closes...OK" "$OUT" || fail "the redirect-release tests did not run"
+grep -Fqs -- "released on the way out, not drained...OK" "$OUT" || fail "the redirect-release tests did not run"
 
 echo "PASS: an unframed redirect is released without draining until close"

--- a/src/net/client.zig
+++ b/src/net/client.zig
@@ -202,6 +202,15 @@ const Wake = struct {
     }
 };
 
+/// Clock every deadline in this file measures elapsed time against. `.awake`
+/// rather than `.real` because the wall clock steps backwards under NTP or a
+/// laptop waking, and an elapsed time that goes negative underflows into an
+/// effectively unbounded budget - the stall these deadlines exist to prevent.
+/// It also stops a suspend from being counted as time the peer was silent.
+fn nowNs(io: std.Io) u64 {
+    return @intCast(std.Io.Clock.awake.now(io).toNanoseconds());
+}
+
 /// Watchdog tick loop, pure of any `std.http` coupling so it's testable
 /// without a live request. Returns true iff a deadline (or cancel) tripped
 /// and the caller should shut the connection down; false iff `wake_fd`
@@ -214,7 +223,7 @@ fn watchdogLoop(
     total_timeout_ns: u64,
     cancel: ?*const fn () bool,
 ) bool {
-    const start_ns: u64 = @intCast(std.Io.Clock.real.now(io).toNanoseconds());
+    const start_ns: u64 = nowNs(io);
     var last_seen_bytes: u64 = bytes_progress.load(.acquire);
     var last_progress_ns: u64 = start_ns;
     // Quarter of the smallest deadline, capped at 5 s, floored at
@@ -238,7 +247,7 @@ fn watchdogLoop(
         if (n > 0) return false; // POLLIN or POLLHUP both clear revents
 
         const cur_bytes = bytes_progress.load(.acquire);
-        const now_ns: u64 = @intCast(std.Io.Clock.real.now(io).toNanoseconds());
+        const now_ns: u64 = nowNs(io);
         if (cur_bytes > last_seen_bytes) {
             last_seen_bytes = cur_bytes;
             last_progress_ns = now_ns;
@@ -619,7 +628,7 @@ pub const HttpClient = struct {
         const uri = std.Uri.parse(url) catch return error.InvalidUrl;
 
         var fired = std.atomic.Value(bool).init(false);
-        const hop_start_ns: u64 = @intCast(std.Io.Clock.real.now(self.io).toNanoseconds());
+        const hop_start_ns: u64 = nowNs(self.io);
         var req = self.requestDeadlined(.HEAD, uri, .{
             .extra_headers = &.{},
             // Stdlib returns every HEAD response before its redirect branch,
@@ -739,7 +748,7 @@ pub const HttpClient = struct {
             const uri = std.Uri.parse(resolved.final_url) catch return error.InvalidUrl;
 
             var fired = std.atomic.Value(bool).init(false);
-            const hop_start_ns: u64 = @intCast(std.Io.Clock.real.now(self.io).toNanoseconds());
+            const hop_start_ns: u64 = nowNs(self.io);
             var req = self.requestDeadlined(.HEAD, uri, .{
                 .extra_headers = &.{},
                 // This walk follows Location itself; stdlib returns a HEAD
@@ -959,14 +968,14 @@ pub const HttpClient = struct {
     /// What is left of a hop's budget, given when it started and what the
     /// clock reads now. Connect and head share one budget, so a hop's worst
     /// case stays `head_timeout_ns` instead of doubling. Both subtractions
-    /// saturate: a hop can outrun its budget, and `Clock.real` can step
-    /// backwards under NTP or a laptop waking.
+    /// saturate: a hop can outrun its budget, and the elapsed guard holds even
+    /// if the clock behind `nowNs` is ever changed.
     fn remainingBudgetNs(budget_ns: u64, hop_start_ns: u64, now_ns: u64) u64 {
         return budget_ns -| (now_ns -| hop_start_ns);
     }
 
     fn remainingHopBudget(self: *HttpClient, hop_start_ns: u64) u64 {
-        const now_ns: u64 = @intCast(std.Io.Clock.real.now(self.io).toNanoseconds());
+        const now_ns: u64 = nowNs(self.io);
         return remainingBudgetNs(self.head_timeout_ns, hop_start_ns, now_ns);
     }
 
@@ -1370,7 +1379,7 @@ pub const HttpClient = struct {
             const uri = std.Uri.parse(current) catch return error.InvalidUrl;
 
             var fired = std.atomic.Value(bool).init(false);
-            const hop_start_ns: u64 = @intCast(std.Io.Clock.real.now(self.io).toNanoseconds());
+            const hop_start_ns: u64 = nowNs(self.io);
             var req = self.requestDeadlined(.GET, uri, .{
                 .extra_headers = live_creds,
                 .redirect_behavior = .unhandled,
@@ -1534,7 +1543,7 @@ pub const HttpClient = struct {
             const uri = std.Uri.parse(current) catch return error.InvalidUrl;
 
             var fired = std.atomic.Value(bool).init(false);
-            const hop_start_ns: u64 = @intCast(std.Io.Clock.real.now(self.io).toNanoseconds());
+            const hop_start_ns: u64 = nowNs(self.io);
             var req = self.requestDeadlined(.GET, uri, .{
                 .extra_headers = live_creds,
                 .redirect_behavior = .unhandled,
@@ -2363,11 +2372,11 @@ test "remainingBudgetNs: an overrun leaves nothing rather than wrapping" {
     try std.testing.expectEqual(@as(u64, 0), HttpClient.remainingBudgetNs(1000, 100, 9000));
 }
 
-test "remainingBudgetNs: a clock that steps backwards does not underflow" {
-    // `Clock.real` is the wall clock: NTP or a laptop waking can move it back
-    // mid-hop. An unsaturated subtraction panics in ReleaseSafe and wraps to
-    // an effectively infinite budget in ReleaseFast - the very stall the
-    // deadline exists to prevent.
+test "remainingBudgetNs: elapsed time that runs backwards does not underflow" {
+    // `nowNs` cannot go backwards, so this is the second line of defence: an
+    // unsaturated subtraction panics in ReleaseSafe and wraps to an
+    // effectively infinite budget in ReleaseFast, and the arithmetic should
+    // not be the thing that depends on the clock choice.
     try std.testing.expectEqual(@as(u64, 1000), HttpClient.remainingBudgetNs(1000, 500, 400));
     try std.testing.expectEqual(@as(u64, 1000), HttpClient.remainingBudgetNs(1000, 9000, 1));
 }
@@ -2468,9 +2477,9 @@ test "a connect that cannot be armed still winds down its running deadline" {
     defer http.deinit();
     http.head_timeout_ns = 30 * std.time.ns_per_s;
 
-    const started_ns: i128 = std.Io.Clock.real.now(io).toNanoseconds();
+    const started_ns = nowNs(io);
     const result = http.head("http://127.0.0.1:1/probe");
-    const elapsed_ns = std.Io.Clock.real.now(io).toNanoseconds() - started_ns;
+    const elapsed_ns = nowNs(io) - started_ns;
 
     try std.testing.expectError(error.WatchdogSpawnFailed, result);
     try std.testing.expectEqual(@as(usize, 2), ConcurrentFailProbe.calls);

--- a/src/net/client.zig
+++ b/src/net/client.zig
@@ -618,21 +618,22 @@ pub const HttpClient = struct {
         try requireSecureOrigin(url, .transport_only);
         const uri = std.Uri.parse(url) catch return error.InvalidUrl;
 
-        var req = self.client.request(.HEAD, uri, .{
+        var fired = std.atomic.Value(bool).init(false);
+        const hop_start_ns: u64 = @intCast(std.Io.Clock.real.now(self.io).toNanoseconds());
+        var req = self.requestDeadlined(.HEAD, uri, .{
             .extra_headers = &.{},
             // Stdlib returns every HEAD response before its redirect branch,
             // so this is already the effective behaviour; pinning it keeps the
             // watchdog's connection stable by contract, not by stdlib branch
             // order.
             .redirect_behavior = .unhandled,
-        }) catch |e| return walkTransportError(e);
+        }, self.head_timeout_ns, &fired) catch |e| return self.headWalkError(&fired, e);
         defer req.deinit();
 
         // 32 KiB — GHCR's multi-scope token + signed-URL redirects exceed
         // the 8 KiB default and tripped `HeaderBufferTooSmall`.
         var redirect_buf: [32 * 1024]u8 = undefined;
-        var fired = std.atomic.Value(bool).init(false);
-        const response = self.receiveHeadDeadlined(&req, &redirect_buf, self.head_timeout_ns, &fired) catch |e|
+        const response = self.receiveHeadDeadlined(&req, &redirect_buf, self.remainingHopBudget(hop_start_ns), &fired) catch |e|
             return self.headWalkError(&fired, e);
 
         return @intFromEnum(response.head.status);
@@ -737,19 +738,23 @@ pub const HttpClient = struct {
         while (true) : (hops += 1) {
             const uri = std.Uri.parse(resolved.final_url) catch return error.InvalidUrl;
 
-            var req = self.client.request(.HEAD, uri, .{
+            var fired = std.atomic.Value(bool).init(false);
+            const hop_start_ns: u64 = @intCast(std.Io.Clock.real.now(self.io).toNanoseconds());
+            var req = self.requestDeadlined(.HEAD, uri, .{
                 .extra_headers = &.{},
                 // This walk follows Location itself; stdlib returns a HEAD
                 // before its redirect branch anyway, so pinning it keeps the
                 // watchdog's connection stable by contract, not by stdlib
                 // branch order.
                 .redirect_behavior = .unhandled,
-            }) catch |e| return walkTransportError(e);
+            }, self.head_timeout_ns, &fired) catch |e| switch (self.headWalkError(&fired, e)) {
+                error.WatchdogSpawnFailed => return error.RequestFailed,
+                else => |mapped| return mapped,
+            };
             defer req.deinit();
 
             var redirect_buf: [32 * 1024]u8 = undefined;
-            var fired = std.atomic.Value(bool).init(false);
-            const response = self.receiveHeadDeadlined(&req, &redirect_buf, self.head_timeout_ns, &fired) catch |e| switch (self.headWalkError(&fired, e)) {
+            const response = self.receiveHeadDeadlined(&req, &redirect_buf, self.remainingHopBudget(hop_start_ns), &fired) catch |e| switch (self.headWalkError(&fired, e)) {
                 // `HeadResolveError` stays closed: a watchdog that could not
                 // start is one more way the request failed.
                 error.WatchdogSpawnFailed => return error.RequestFailed,
@@ -862,12 +867,114 @@ pub const HttpClient = struct {
         return self.doGetWithRetry(url, extra_headers, max_metadata_bytes, null);
     }
 
+    /// The two arms of the connect race: whichever finishes first decides
+    /// whether the hop got a connection or spent its budget.
+    const ConnectRace = union(enum) {
+        req: std.http.Client.RequestError!std.http.Client.Request,
+        deadline: void,
+    };
+
+    /// Open the connection under the hop's deadline. Stdlib resolves DNS,
+    /// connects the socket and runs the whole TLS handshake inside
+    /// `client.request`, and the head watchdog's only lever is a socket
+    /// reachable through `req.connection` - which that call has not returned
+    /// yet. So the connect is raced against a deadline instead, and the loser
+    /// is cancelled.
+    fn requestDeadlined(
+        self: *HttpClient,
+        method: std.http.Method,
+        uri: std.Uri,
+        options: std.http.Client.RequestOptions,
+        budget_ns: u64,
+        fired: *std.atomic.Value(bool),
+    ) !std.http.Client.Request {
+        const Task = struct {
+            fn connect(
+                client: *std.http.Client,
+                m: std.http.Method,
+                u: std.Uri,
+                o: std.http.Client.RequestOptions,
+            ) std.http.Client.RequestError!std.http.Client.Request {
+                return client.request(m, u, o);
+            }
+            /// The same tick loop the head and body phases run, so the connect
+            /// gets one clock and one `cancel` poll rather than a second set.
+            /// A connect has no byte progress, so idle and total coincide.
+            fn deadline(http: *HttpClient, wake_fd: std.posix.fd_t, budget: u64) void {
+                var no_progress = std.atomic.Value(u64).init(0);
+                _ = watchdogLoop(http.io, wake_fd, &no_progress, budget, budget, http.cancel);
+            }
+        };
+
+        var wake = Wake.init() catch return error.WatchdogSpawnFailed;
+        defer wake.deinit();
+
+        var slots: [2]ConnectRace = undefined;
+        var sel: std.Io.Select(ConnectRace) = .init(self.io, &slots);
+        // Deadline first: with nothing else armed yet, its failure needs no
+        // unwind.
+        sel.concurrent(.deadline, Task.deadline, .{ self, wake.read_fd, budget_ns }) catch
+            return error.WatchdogSpawnFailed;
+        sel.concurrent(.req, Task.connect, .{ &self.client, method, uri, options }) catch {
+            wake.signal();
+            sel.cancelDiscard();
+            return error.WatchdogSpawnFailed;
+        };
+
+        const winner = sel.await() catch |e| {
+            wake.signal();
+            drainRacers(&sel);
+            return e;
+        };
+        // The loser can still finish first and hand back a live `Request`, so
+        // both arms drain rather than discard.
+        switch (winner) {
+            .req => |result| {
+                // Ends the tick loop now instead of at its next tick.
+                wake.signal();
+                drainRacers(&sel);
+                return result;
+            },
+            .deadline => {
+                // Ordered before the drain so the caller's classification sees it.
+                fired.store(true, .release);
+                drainRacers(&sel);
+                return error.HeadTimeout;
+            },
+        }
+    }
+
+    /// Cancels the outstanding connect race and closes any `Request` it still
+    /// managed to produce.
+    fn drainRacers(sel: *std.Io.Select(ConnectRace)) void {
+        while (sel.cancel()) |left| switch (left) {
+            .req => |result| if (result) |req| {
+                var owned = req;
+                owned.deinit();
+            } else |_| {},
+            .deadline => {},
+        };
+    }
+
+    /// What is left of a hop's budget, given when it started and what the
+    /// clock reads now. Connect and head share one budget, so a hop's worst
+    /// case stays `head_timeout_ns` instead of doubling. Both subtractions
+    /// saturate: a hop can outrun its budget, and `Clock.real` can step
+    /// backwards under NTP or a laptop waking.
+    fn remainingBudgetNs(budget_ns: u64, hop_start_ns: u64, now_ns: u64) u64 {
+        return budget_ns -| (now_ns -| hop_start_ns);
+    }
+
+    fn remainingHopBudget(self: *HttpClient, hop_start_ns: u64) u64 {
+        const now_ns: u64 = @intCast(std.Io.Clock.real.now(self.io).toNanoseconds());
+        return remainingBudgetNs(self.head_timeout_ns, hop_start_ns, now_ns);
+    }
+
     /// Send the request and read its head under the same watchdog the body
     /// gets: without one a connected-but-silent origin parks the walk forever
     /// and nothing polls `cancel`. Idle and total share a clock because a head
-    /// read has no byte progress to measure. A stall inside `client.request`
-    /// stays uncovered - the watchdog needs a connection that call has not
-    /// returned yet.
+    /// read has no byte progress to measure. Callers pass what
+    /// `requestDeadlined` left of the hop's budget, not a fresh copy.
     fn receiveHeadDeadlined(
         self: *HttpClient,
         req: *std.http.Client.Request,
@@ -1239,15 +1346,16 @@ pub const HttpClient = struct {
         while (true) : (hops += 1) {
             const uri = std.Uri.parse(current) catch return error.InvalidUrl;
 
-            var req = self.client.request(.GET, uri, .{
+            var fired = std.atomic.Value(bool).init(false);
+            const hop_start_ns: u64 = @intCast(std.Io.Clock.real.now(self.io).toNanoseconds());
+            var req = self.requestDeadlined(.GET, uri, .{
                 .extra_headers = live_creds,
                 .redirect_behavior = .unhandled,
-            }) catch |e| return walkTransportError(e);
+            }, self.head_timeout_ns, &fired) catch |e| return self.headWalkError(&fired, e);
             errdefer req.deinit();
 
             var redirect_buf: [32 * 1024]u8 = undefined;
-            var fired = std.atomic.Value(bool).init(false);
-            var response = self.receiveHeadDeadlined(&req, &redirect_buf, self.head_timeout_ns, &fired) catch |e|
+            var response = self.receiveHeadDeadlined(&req, &redirect_buf, self.remainingHopBudget(hop_start_ns), &fired) catch |e|
                 return self.headWalkError(&fired, e);
             const status: u16 = @intFromEnum(response.head.status);
 
@@ -1402,15 +1510,16 @@ pub const HttpClient = struct {
         while (true) : (hops += 1) {
             const uri = std.Uri.parse(current) catch return error.InvalidUrl;
 
-            var req = self.client.request(.GET, uri, .{
+            var fired = std.atomic.Value(bool).init(false);
+            const hop_start_ns: u64 = @intCast(std.Io.Clock.real.now(self.io).toNanoseconds());
+            var req = self.requestDeadlined(.GET, uri, .{
                 .extra_headers = live_creds,
                 .redirect_behavior = .unhandled,
-            }) catch |e| return walkTransportError(e);
+            }, self.head_timeout_ns, &fired) catch |e| return self.headWalkError(&fired, e);
             errdefer req.deinit();
 
             var redirect_buf: [32 * 1024]u8 = undefined;
-            var fired = std.atomic.Value(bool).init(false);
-            var response = self.receiveHeadDeadlined(&req, &redirect_buf, self.head_timeout_ns, &fired) catch |e|
+            var response = self.receiveHeadDeadlined(&req, &redirect_buf, self.remainingHopBudget(hop_start_ns), &fired) catch |e|
                 return self.headWalkError(&fired, e);
             const status: u16 = @intFromEnum(response.head.status);
 
@@ -2204,6 +2313,29 @@ test "shouldFireIdleWatchdog: cancellation fires regardless of elapsed time" {
     try std.testing.expect(shouldFireIdleWatchdog(1, 1, 999_999, 999_999, true));
 }
 
+test "remainingBudgetNs: the head read gets what the connect left" {
+    // One budget per hop, not one each: reusing the full budget for the head
+    // read would double a hop's worst case.
+    try std.testing.expectEqual(@as(u64, 700), HttpClient.remainingBudgetNs(1000, 100, 400));
+    try std.testing.expectEqual(@as(u64, 1000), HttpClient.remainingBudgetNs(1000, 100, 100));
+}
+
+test "remainingBudgetNs: an overrun leaves nothing rather than wrapping" {
+    // A connect that raced the deadline to a photo finish can spend more than
+    // the budget; wrapping would hand the head read ~584 years.
+    try std.testing.expectEqual(@as(u64, 0), HttpClient.remainingBudgetNs(1000, 100, 1100));
+    try std.testing.expectEqual(@as(u64, 0), HttpClient.remainingBudgetNs(1000, 100, 9000));
+}
+
+test "remainingBudgetNs: a clock that steps backwards does not underflow" {
+    // `Clock.real` is the wall clock: NTP or a laptop waking can move it back
+    // mid-hop. An unsaturated subtraction panics in ReleaseSafe and wraps to
+    // an effectively infinite budget in ReleaseFast - the very stall the
+    // deadline exists to prevent.
+    try std.testing.expectEqual(@as(u64, 1000), HttpClient.remainingBudgetNs(1000, 500, 400));
+    try std.testing.expectEqual(@as(u64, 1000), HttpClient.remainingBudgetNs(1000, 9000, 1));
+}
+
 test "the head phase is bounded by the same threshold as every other read" {
     // Its own knob so a test can shorten the head phase alone, but no number
     // of its own to justify: a third figure for "too quiet" is a third thing
@@ -2238,6 +2370,76 @@ const CancelSleepProbe = struct {
         if (sleep_calls >= cancel_at) return error.Canceled;
     }
 };
+
+// Patches an inner Io's vtable so `groupConcurrent` refuses from the given
+// call onwards. Nothing else in a walk spawns a group task, so the count is
+// the connect race's own arming sequence: 1 is the deadline, 2 is the request.
+const ConcurrentFailProbe = struct {
+    var vtable: std.Io.VTable = undefined;
+    var inner: *const std.Io.VTable = undefined;
+    var calls: usize = 0;
+    var fail_at: usize = 1;
+
+    fn wrap(io: std.Io, fail_at_call: usize) std.Io {
+        inner = io.vtable;
+        vtable = io.vtable.*;
+        vtable.groupConcurrent = groupConcurrentMaybeUnavailable;
+        calls = 0;
+        fail_at = fail_at_call;
+        return .{ .userdata = io.userdata, .vtable = &vtable };
+    }
+
+    fn groupConcurrentMaybeUnavailable(
+        userdata: ?*anyopaque,
+        group: *std.Io.Group,
+        context: []const u8,
+        context_alignment: std.mem.Alignment,
+        start: *const fn (context: *const anyopaque) void,
+    ) std.Io.ConcurrentError!void {
+        calls += 1;
+        if (calls >= fail_at) return error.ConcurrencyUnavailable;
+        return inner.groupConcurrent(userdata, group, context, context_alignment, start);
+    }
+};
+
+test "a connect refuses to dial when its deadline cannot be armed" {
+    // Nothing else can cut a silent handshake, so an unarmed deadline has to
+    // fail the walk rather than dial and hope. Retriable, because a unit of
+    // concurrency is a resource that frees up.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = ConcurrentFailProbe.wrap(threaded.io(), 1);
+
+    var http = HttpClient.init(io, std.process.Environ.empty, std.testing.allocator);
+    defer http.deinit();
+
+    // Nothing listens on port 1, so a walk that dialled anyway fails
+    // differently instead of passing this by accident.
+    try std.testing.expectError(error.WatchdogSpawnFailed, http.head("http://127.0.0.1:1/probe"));
+    try std.testing.expect(HttpClient.isRetriableWalkError(error.WatchdogSpawnFailed));
+}
+
+test "a connect that cannot be armed still winds down its running deadline" {
+    // The one arming order with something to clean up: the deadline is already
+    // polling when the request fails to spawn. Dropping the wind-down does not
+    // change the error - it just makes the caller wait out the whole budget
+    // first - so the budget is long here and the clock is the assertion.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = ConcurrentFailProbe.wrap(threaded.io(), 2);
+
+    var http = HttpClient.init(io, std.process.Environ.empty, std.testing.allocator);
+    defer http.deinit();
+    http.head_timeout_ns = 30 * std.time.ns_per_s;
+
+    const started_ns: i128 = std.Io.Clock.real.now(io).toNanoseconds();
+    const result = http.head("http://127.0.0.1:1/probe");
+    const elapsed_ns = std.Io.Clock.real.now(io).toNanoseconds() - started_ns;
+
+    try std.testing.expectError(error.WatchdogSpawnFailed, result);
+    try std.testing.expectEqual(@as(usize, 2), ConcurrentFailProbe.calls);
+    try std.testing.expect(elapsed_ns < std.time.ns_per_s);
+}
 
 test "doGetWithRetry surfaces sleep cancellation on the first backoff" {
     var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});

--- a/src/net/client.zig
+++ b/src/net/client.zig
@@ -1306,21 +1306,39 @@ pub const HttpClient = struct {
     }
 
     /// Release a redirect hop. Its body is never read, and stdlib's `deinit`
-    /// drains an unread one - with no framing headers that ends only when the
-    /// peer closes, and no watchdog covers a redirect hop. A declared body
-    /// drains cheaply and keeps the connection poolable, so only the unframed
-    /// case is retired.
-    fn finishRedirect(req: *std.http.Client.Request, hop_head: *const std.http.Client.Response.Head) void {
+    /// drains an unread one. Two different hazards live there, so two answers:
+    /// a body that can only end at close is skipped outright, and any other is
+    /// drained under a watchdog, because framing is a promise the peer can
+    /// simply not keep. Draining when it is cheap keeps the connection
+    /// poolable, which a same-host redirect chain would otherwise pay for.
+    fn finishRedirect(
+        self: *HttpClient,
+        req: *std.http.Client.Request,
+        hop_head: *const std.http.Client.Response.Head,
+    ) void {
         if (bodyIsCloseDelimited(hop_head.content_length, hop_head.transfer_encoding)) {
             finishBodiless(req);
             return;
+        }
+        var no_progress = std.atomic.Value(u64).init(0);
+        var wake = Wake.init() catch return finishBodiless(req);
+        const watchdog = std.Thread.spawn(.{}, watchdogFn, .{
+            self.io,              wake.read_fd, &no_progress, self.head_timeout_ns,
+            self.head_timeout_ns, req,          self.cancel,  null,
+        }) catch {
+            wake.deinit();
+            return finishBodiless(req);
+        };
+        defer {
+            wake.signal();
+            watchdog.join();
+            wake.deinit();
         }
         req.deinit();
     }
 
     /// A body with neither a length nor a chunked encoding ends only when the
-    /// peer closes, so draining one is unbounded. Anything else terminates on
-    /// its own and is cheaper to read than to re-handshake.
+    /// peer closes, so draining one can never finish on its own.
     fn bodyIsCloseDelimited(
         content_length: ?u64,
         transfer_encoding: std.http.TransferEncoding,
@@ -1384,7 +1402,9 @@ pub const HttpClient = struct {
                 .extra_headers = live_creds,
                 .redirect_behavior = .unhandled,
             }, self.head_timeout_ns, &fired) catch |e| return self.headWalkError(&fired, e);
-            errdefer req.deinit();
+            // Drains on a plain deinit, and no watchdog covers a redirect hop:
+            // a peer that stops mid-body parks the walk here too.
+            errdefer finishBodiless(&req);
 
             var redirect_buf: [32 * 1024]u8 = undefined;
             var response = self.receiveHeadDeadlined(&req, &redirect_buf, self.remainingHopBudget(hop_start_ns), &fired) catch |e|
@@ -1397,7 +1417,7 @@ pub const HttpClient = struct {
                 if (!credsSurviveRedirect(current, next)) live_creds = &.{};
                 // Hop committed: no fallible op past here, so the errdefers
                 // stay dormant while we hand `req`/`current` off cleanly.
-                finishRedirect(&req, &response.head);
+                self.finishRedirect(&req, &response.head);
                 self.allocator.free(current);
                 current = next;
                 continue;
@@ -1548,7 +1568,9 @@ pub const HttpClient = struct {
                 .extra_headers = live_creds,
                 .redirect_behavior = .unhandled,
             }, self.head_timeout_ns, &fired) catch |e| return self.headWalkError(&fired, e);
-            errdefer req.deinit();
+            // Drains on a plain deinit, and no watchdog covers a redirect hop:
+            // a peer that stops mid-body parks the walk here too.
+            errdefer finishBodiless(&req);
 
             var redirect_buf: [32 * 1024]u8 = undefined;
             var response = self.receiveHeadDeadlined(&req, &redirect_buf, self.remainingHopBudget(hop_start_ns), &fired) catch |e|
@@ -1559,7 +1581,7 @@ pub const HttpClient = struct {
             if (hop) |next| {
                 errdefer self.allocator.free(next);
                 if (!credsSurviveRedirect(current, next)) live_creds = &.{};
-                finishRedirect(&req, &response.head);
+                self.finishRedirect(&req, &response.head);
                 self.allocator.free(current);
                 current = next;
                 continue;
@@ -2345,16 +2367,17 @@ test "shouldFireIdleWatchdog: cancellation fires regardless of elapsed time" {
     try std.testing.expect(shouldFireIdleWatchdog(1, 1, 999_999, 999_999, true));
 }
 
-test "bodyIsCloseDelimited: only an unframed body waits on the peer to close" {
+test "bodyIsCloseDelimited: only an unframed body can never end on its own" {
+    // The one shape where draining is pointless rather than merely risky: it
+    // is skipped outright, while framed bodies get a bounded drain instead.
     try std.testing.expect(HttpClient.bodyIsCloseDelimited(null, .none));
     try std.testing.expect(!HttpClient.bodyIsCloseDelimited(12, .none));
     try std.testing.expect(!HttpClient.bodyIsCloseDelimited(null, .chunked));
 }
 
 test "bodyIsCloseDelimited: a declared empty body is framed, not missing" {
-    // `Content-Length: 0` and no header at all read the same on a redirect
-    // whose body nobody wants. Conflating them would retire a connection per
-    // hop of a healthy chain.
+    // `Content-Length: 0` is a complete answer; draining it is a no-op, so
+    // there is nothing to skip and the connection stays poolable.
     try std.testing.expect(!HttpClient.bodyIsCloseDelimited(0, .none));
 }
 

--- a/src/net/client.zig
+++ b/src/net/client.zig
@@ -1296,6 +1296,29 @@ pub const HttpClient = struct {
         req.deinit();
     }
 
+    /// Release a redirect hop. Its body is never read, and stdlib's `deinit`
+    /// drains an unread one - with no framing headers that ends only when the
+    /// peer closes, and no watchdog covers a redirect hop. A declared body
+    /// drains cheaply and keeps the connection poolable, so only the unframed
+    /// case is retired.
+    fn finishRedirect(req: *std.http.Client.Request, hop_head: *const std.http.Client.Response.Head) void {
+        if (bodyIsCloseDelimited(hop_head.content_length, hop_head.transfer_encoding)) {
+            finishBodiless(req);
+            return;
+        }
+        req.deinit();
+    }
+
+    /// A body with neither a length nor a chunked encoding ends only when the
+    /// peer closes, so draining one is unbounded. Anything else terminates on
+    /// its own and is cheaper to read than to re-handshake.
+    fn bodyIsCloseDelimited(
+        content_length: ?u64,
+        transfer_encoding: std.http.TransferEncoding,
+    ) bool {
+        return content_length == null and transfer_encoding == .none;
+    }
+
     /// GET that follows redirects manually so credential/validator headers are
     /// stripped before leaving the origin's scope. In Zig 0.16 stdlib,
     /// `extra_headers` ride every redirect and `privileged_headers` are never
@@ -1365,7 +1388,7 @@ pub const HttpClient = struct {
                 if (!credsSurviveRedirect(current, next)) live_creds = &.{};
                 // Hop committed: no fallible op past here, so the errdefers
                 // stay dormant while we hand `req`/`current` off cleanly.
-                req.deinit();
+                finishRedirect(&req, &response.head);
                 self.allocator.free(current);
                 current = next;
                 continue;
@@ -1527,7 +1550,7 @@ pub const HttpClient = struct {
             if (hop) |next| {
                 errdefer self.allocator.free(next);
                 if (!credsSurviveRedirect(current, next)) live_creds = &.{};
-                req.deinit();
+                finishRedirect(&req, &response.head);
                 self.allocator.free(current);
                 current = next;
                 continue;
@@ -2311,6 +2334,19 @@ test "shouldFireIdleWatchdog: cancellation fires regardless of elapsed time" {
     // deadline has elapsed yet — otherwise Ctrl-C waits out the read.
     try std.testing.expect(shouldFireIdleWatchdog(0, 0, 30, 600, true));
     try std.testing.expect(shouldFireIdleWatchdog(1, 1, 999_999, 999_999, true));
+}
+
+test "bodyIsCloseDelimited: only an unframed body waits on the peer to close" {
+    try std.testing.expect(HttpClient.bodyIsCloseDelimited(null, .none));
+    try std.testing.expect(!HttpClient.bodyIsCloseDelimited(12, .none));
+    try std.testing.expect(!HttpClient.bodyIsCloseDelimited(null, .chunked));
+}
+
+test "bodyIsCloseDelimited: a declared empty body is framed, not missing" {
+    // `Content-Length: 0` and no header at all read the same on a redirect
+    // whose body nobody wants. Conflating them would retire a connection per
+    // hop of a healthy chain.
+    try std.testing.expect(!HttpClient.bodyIsCloseDelimited(0, .none));
 }
 
 test "remainingBudgetNs: the head read gets what the connect left" {

--- a/src/update/notifier.zig
+++ b/src/update/notifier.zig
@@ -45,9 +45,19 @@ pub const writeCache = cache.writeCache;
 /// dispatch, so the command's output is already on screen.
 pub const network_timeout_ns: u64 = 1_500 * std.time.ns_per_ms;
 
+/// Hold every phase of the probe to the bound above. Connect, head read and
+/// body each carry their own knob, and the retry schedule sits outside all
+/// three - a transient failure otherwise costs four attempts plus seven
+/// seconds of backoff, on the hot path of every command.
+pub fn applyProbeBudget(http: *client_mod.HttpClient) void {
+    http.timeout_ns = network_timeout_ns;
+    http.head_timeout_ns = network_timeout_ns;
+    http.retry_backoff_ms = &.{};
+}
+
 fn fetchLatestTag(ctx: *const AppCtx, allocator: std.mem.Allocator) ![]u8 {
     var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);
-    http.timeout_ns = network_timeout_ns;
+    applyProbeBudget(&http);
     // SIGINT on the prompt-after-success window collapses the probe
     // instead of stalling the user behind the 1.5 s deadline.
     http.cancel = signals.isInterrupted;
@@ -258,6 +268,35 @@ pub fn writeFailureMarker(io: std.Io, path: []const u8, prior: ?State, now: i64,
 }
 
 // --- inline tests --------------------------------------------------------
+
+test "applyProbeBudget: every phase of the probe shares the advertised bound" {
+    // The connect, the head read and the body each have their own knob, and
+    // any one left at the 30 s default makes the bound above a claim the
+    // probe cannot keep.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    var http = client_mod.HttpClient.init(threaded.io(), std.process.Environ.empty, std.testing.allocator);
+    defer http.deinit();
+
+    applyProbeBudget(&http);
+
+    try std.testing.expectEqual(network_timeout_ns, http.timeout_ns);
+    try std.testing.expectEqual(network_timeout_ns, http.head_timeout_ns);
+}
+
+test "applyProbeBudget: the probe does not retry" {
+    // The retry schedule is the probe's real worst case: four attempts plus
+    // seven seconds of backoff is what held every command through a brownout.
+    // A passive notice is not worth a second attempt the user waits through.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    var http = client_mod.HttpClient.init(threaded.io(), std.process.Environ.empty, std.testing.allocator);
+    defer http.deinit();
+
+    applyProbeBudget(&http);
+
+    try std.testing.expectEqual(@as(usize, 0), http.retry_backoff_ms.len);
+}
 
 // Pins the heads-up layout: blank-line separator + flush-left prefixes
 // in both palettes. The blank line keeps the notice from sticking to a

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -97,6 +97,7 @@ comptime {
     _ = @import("net_client_test.zig");
     _ = @import("net_get_to_writer_test.zig");
     _ = @import("net_redirect_auth_test.zig");
+    _ = @import("notifier_probe_budget_test.zig");
     _ = @import("no_cli_in_core_test.zig");
     _ = @import("no_io_mod_in_src_test.zig");
     _ = @import("no_main_reach_in_cli_test.zig");

--- a/tests/net_redirect_auth_test.zig
+++ b/tests/net_redirect_auth_test.zig
@@ -6,6 +6,7 @@
 
 const std = @import("std");
 const client = @import("malt").client;
+const notifier = @import("malt").update_notifier;
 const net = std.Io.net;
 
 const auth_value = "token SECRET-PAT";
@@ -1486,4 +1487,75 @@ test "a framed redirect still drains, so its connection stays poolable" {
     var resp = try result;
     defer resp.deinit();
     try std.testing.expectEqualStrings(blob_body, resp.body);
+}
+
+test "the version probe's budget spends one attempt on a peer that keeps failing" {
+    // The behavioural half of the probe's contract, over plaintext so it runs
+    // on every unit-test pass rather than only when the https fixture is up.
+    // Asserting the field alone would still pass if the retry loop stopped
+    // reading it - the attempt count is what the user actually waits through.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var l1 = try bindIp4(io);
+    defer l1.deinit(io);
+    const p1 = l1.socket.address.getPort();
+
+    // 503 is transient, so the stock schedule would re-dial three more times.
+    var hop1 = Hop{ .io = io, .listener = &l1, .status = .service_unavailable };
+    const t1 = try std.Thread.spawn(.{}, serveCountThenRefuse, .{ &hop1, 4 });
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/releases/latest", .{p1});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+    notifier.applyProbeBudget(&http);
+
+    const result = http.get(url);
+    http.deinit();
+    knock(io, p1);
+    t1.join();
+
+    if (result) |resp| {
+        var owned = resp;
+        owned.deinit();
+    } else |_| {}
+    try std.testing.expectEqual(@as(usize, 1), hop1.requests);
+}
+
+test "the stock client still retries a failing peer" {
+    // The no-retry budget is the notifier's choice, not a new client default.
+    // An install quietly losing its retries would be a worse regression than
+    // the latency the probe's budget fixes.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var l1 = try bindIp4(io);
+    defer l1.deinit(io);
+    const p1 = l1.socket.address.getPort();
+
+    var hop1 = Hop{ .io = io, .listener = &l1, .status = .service_unavailable };
+    const t1 = try std.Thread.spawn(.{}, serveCountThenRefuse, .{ &hop1, 4 });
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/artifact", .{p1});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+    // Zeroed delays: the count is the assertion, not the wall-clock.
+    http.retry_backoff_ms = &.{ 0, 0, 0 };
+
+    const result = http.get(url);
+    http.deinit();
+    knock(io, p1);
+    t1.join();
+
+    if (result) |resp| {
+        var owned = resp;
+        owned.deinit();
+    } else |_| {}
+    try std.testing.expectEqual(@as(usize, 4), hop1.requests);
 }

--- a/tests/net_redirect_auth_test.zig
+++ b/tests/net_redirect_auth_test.zig
@@ -178,6 +178,53 @@ fn bindIp6(io: std.Io) !net.Server {
     return try addr.listen(io, .{ .reuse_address = true });
 }
 
+// A hop that answers a redirect carrying neither `Content-Length` nor a
+// transfer encoding, then holds the socket open. The body is close-delimited,
+// so the drain a plain release performs has no end.
+const UnframedRedirectPeer = struct {
+    io: std.Io,
+    listener: *net.Server,
+    location: []const u8,
+};
+
+// Bounds a regression: the drain hits EOF here instead of hanging the suite,
+// so the wall-clock assertion fails cleanly.
+const hold_open_ms: i32 = 6_000;
+
+// A healthy release returns in milliseconds; a draining one waits out
+// `hold_open_ms`. The budget sits between the two.
+const drain_budget_ms: i64 = 3_000;
+
+fn serveUnframedRedirect(peer: *UnframedRedirectPeer) void {
+    const stream = peer.listener.accept(peer.io) catch return;
+    defer stream.close(peer.io);
+
+    var rbuf: [8 * 1024]u8 = undefined;
+    var wbuf: [1024]u8 = undefined;
+    var reader = stream.reader(peer.io, &rbuf);
+    var writer = stream.writer(peer.io, &wbuf);
+
+    // One blocking read is enough: the client's whole GET head arrives in a
+    // single loopback segment.
+    _ = reader.interface.peek(1) catch return;
+
+    writer.interface.print(
+        "HTTP/1.1 302 Found\r\nLocation: {s}\r\n\r\nredirecting\n",
+        .{peer.location},
+    ) catch return;
+    writer.interface.flush() catch return;
+
+    // Hold it open: an undeclared body ends at close, which is the condition
+    // the bug needs. A healthy client hangs up at once and `poll` returns
+    // immediately.
+    var pfds = [_]std.posix.pollfd{.{
+        .fd = stream.socket.handle,
+        .events = std.posix.POLL.IN,
+        .revents = 0,
+    }};
+    _ = std.posix.poll(&pfds, hold_open_ms) catch {};
+}
+
 // A peer that completes the TCP accept and then never speaks TLS. `Hop` cannot
 // stand in for it: the client parks inside `client.request` before any request
 // line is written, so an `http.Server` has nothing to read.
@@ -1306,4 +1353,137 @@ test "Ctrl-C during a stalled TLS handshake is the answer, not a blip to retry" 
 
     try std.testing.expectError(error.Canceled, result);
     try std.testing.expectEqual(@as(usize, 1), tls_silent.accepts.load(.acquire));
+}
+
+test "an unframed redirect is released without draining until the peer closes" {
+    // The 3xx body is never read and the stdlib release drains it; with no
+    // framing headers that drain ends only when the peer closes, and no
+    // watchdog runs across a redirect hop.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var l2 = try bindIp4(io);
+    defer l2.deinit(io);
+    const p2 = l2.socket.address.getPort();
+    var hop2 = Hop{ .io = io, .listener = &l2 };
+    const t2 = try std.Thread.spawn(.{}, serveOne, .{&hop2});
+
+    var loc_buf: [64]u8 = undefined;
+    const loc = try std.fmt.bufPrint(&loc_buf, "http://127.0.0.1:{d}/blob", .{p2});
+
+    var l1 = try bindIp4(io);
+    defer l1.deinit(io);
+    const p1 = l1.socket.address.getPort();
+    var peer = UnframedRedirectPeer{ .io = io, .listener = &l1, .location = loc };
+    const t1 = try std.Thread.spawn(.{}, serveUnframedRedirect, .{&peer});
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/start", .{p1});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+    http.retry_backoff_ms = &.{};
+
+    const started_ns: i128 = std.Io.Clock.real.now(io).toNanoseconds();
+    const result = http.get(url);
+    const elapsed_ms: i64 = @intCast(@divTrunc(
+        std.Io.Clock.real.now(io).toNanoseconds() - started_ns,
+        std.time.ns_per_ms,
+    ));
+    http.deinit();
+    t1.join();
+    t2.join();
+
+    var resp = try result;
+    defer resp.deinit();
+    try std.testing.expectEqualStrings(blob_body, resp.body);
+    try std.testing.expect(elapsed_ms < drain_budget_ms);
+}
+
+test "a streamed walk releases an unframed redirect without draining it" {
+    // `followGetToWriter` releases its hops on its own code path.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var l2 = try bindIp4(io);
+    defer l2.deinit(io);
+    const p2 = l2.socket.address.getPort();
+    var hop2 = Hop{ .io = io, .listener = &l2 };
+    const t2 = try std.Thread.spawn(.{}, serveOne, .{&hop2});
+
+    var loc_buf: [64]u8 = undefined;
+    const loc = try std.fmt.bufPrint(&loc_buf, "http://127.0.0.1:{d}/bottle", .{p2});
+
+    var l1 = try bindIp4(io);
+    defer l1.deinit(io);
+    const p1 = l1.socket.address.getPort();
+    var peer = UnframedRedirectPeer{ .io = io, .listener = &l1, .location = loc };
+    const t1 = try std.Thread.spawn(.{}, serveUnframedRedirect, .{&peer});
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/start", .{p1});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+    http.retry_backoff_ms = &.{};
+
+    var sink: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer sink.deinit();
+
+    const started_ns: i128 = std.Io.Clock.real.now(io).toNanoseconds();
+    const result = http.getToWriter(url, &.{}, &sink.writer, null);
+    const elapsed_ms: i64 = @intCast(@divTrunc(
+        std.Io.Clock.real.now(io).toNanoseconds() - started_ns,
+        std.time.ns_per_ms,
+    ));
+    http.deinit();
+    t1.join();
+    t2.join();
+
+    try std.testing.expectEqual(@as(u16, 200), try result);
+    try std.testing.expectEqualStrings(blob_body, sink.written());
+    try std.testing.expect(elapsed_ms < drain_budget_ms);
+}
+
+test "a framed redirect still drains, so its connection stays poolable" {
+    // Only the unframed case skips the drain. A 302 that declares its body
+    // costs a cheap read, and retiring that connection would pay for a fresh
+    // handshake on every hop of a healthy chain.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var l2 = try bindIp4(io);
+    defer l2.deinit(io);
+    const p2 = l2.socket.address.getPort();
+    var hop2 = Hop{ .io = io, .listener = &l2 };
+    const t2 = try std.Thread.spawn(.{}, serveOne, .{&hop2});
+
+    var loc_buf: [64]u8 = undefined;
+    const loc = try std.fmt.bufPrint(&loc_buf, "http://127.0.0.1:{d}/blob", .{p2});
+
+    var l1 = try bindIp4(io);
+    defer l1.deinit(io);
+    const p1 = l1.socket.address.getPort();
+    // `Hop` answers a 302 with a declared body.
+    var hop1 = Hop{ .io = io, .listener = &l1, .redirect_to = loc, .status = .found };
+    const t1 = try std.Thread.spawn(.{}, serveOne, .{&hop1});
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/start", .{p1});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+    http.retry_backoff_ms = &.{};
+
+    const result = http.get(url);
+    http.deinit();
+    t1.join();
+    t2.join();
+
+    var resp = try result;
+    defer resp.deinit();
+    try std.testing.expectEqualStrings(blob_body, resp.body);
 }

--- a/tests/net_redirect_auth_test.zig
+++ b/tests/net_redirect_auth_test.zig
@@ -39,6 +39,9 @@ const Hop = struct {
     answer_delay_ns: u64 = 0,
     // Requests actually received, so a test can assert how many walks happened.
     requests: usize = 0,
+    // Mirrors `requests` for the cancel probes, which read it from the client
+    // thread while this one is still running.
+    served: std.atomic.Value(usize) = .init(0),
 };
 
 fn serveOne(hop: *Hop) void {
@@ -64,6 +67,7 @@ fn serveCount(hop: *Hop, count: usize) void {
             served_here = true;
             served += 1;
             hop.requests += 1;
+            _ = hop.served.fetchAdd(1, .release);
             if (hop.fail_first) {
                 hop.fail_first = false;
                 break; // close mid-request: the client sees a dead connection
@@ -172,6 +176,26 @@ fn closedPort(io: std.Io) !u16 {
 fn bindIp6(io: std.Io) !net.Server {
     var addr = try net.IpAddress.parseIp6("::1", 0);
     return try addr.listen(io, .{ .reuse_address = true });
+}
+
+// A peer that completes the TCP accept and then never speaks TLS. `Hop` cannot
+// stand in for it: the client parks inside `client.request` before any request
+// line is written, so an `http.Server` has nothing to read.
+const TlsSilentPeer = struct {
+    io: std.Io,
+    listener: *net.Server,
+    accepts: std.atomic.Value(usize) = .init(0),
+};
+
+fn acceptAndSayNothing(peer: *TlsSilentPeer) void {
+    const stream = peer.listener.accept(peer.io) catch return;
+    defer stream.close(peer.io);
+    _ = peer.accepts.fetchAdd(1, .release);
+    // Hold the connection until the client hangs up, so the handshake stalls
+    // instead of failing fast on a reset.
+    var rbuf: [64]u8 = undefined;
+    var reader = stream.reader(peer.io, &rbuf);
+    _ = reader.interface.discardRemaining() catch {};
 }
 
 test "auth headers stripped on redirect across a cross-domain hop" {
@@ -954,16 +978,20 @@ test "a download gives up on an origin that never answers" {
     try std.testing.expectEqual(@as(usize, 1), hop1.requests);
 }
 
+// The hop the probe below watches. Gating on a request the hop has actually
+// received keeps the Ctrl-C inside the head-read window rather than collapsing
+// the connect that precedes it.
+var cancel_after_served: ?*const Hop = null;
+
+fn cancelledOnceServed() bool {
+    const hop = cancel_after_served orelse return false;
+    return hop.served.load(.acquire) > 0;
+}
+
 test "Ctrl-C during a stalled head read is the answer, not a blip to retry" {
     // Without the cancel check the fix makes Ctrl-C slower: the watchdog's
     // socket shutdown looks like an ordinary transport fault, so the walk
     // would sleep off the whole backoff and re-dial while the flag stays set.
-    const Probe = struct {
-        fn cancelled() bool {
-            return true;
-        }
-    };
-
     var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
     defer threaded.deinit();
     const io = threaded.io();
@@ -974,6 +1002,8 @@ test "Ctrl-C during a stalled head read is the answer, not a blip to retry" {
 
     var hop1 = Hop{ .io = io, .listener = &l1, .stall = true };
     const t1 = try std.Thread.spawn(.{}, serveOne, .{&hop1});
+    cancel_after_served = &hop1;
+    defer cancel_after_served = null;
 
     var url_buf: [64]u8 = undefined;
     const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/artifact", .{p1});
@@ -981,7 +1011,7 @@ test "Ctrl-C during a stalled head read is the answer, not a blip to retry" {
     var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
     var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
     http.head_timeout_ns = stall_budget_ns;
-    http.cancel = &Probe.cancelled;
+    http.cancel = &cancelledOnceServed;
     // A budget the retry loop could spend if it treated the cancel as a blip.
     http.retry_backoff_ms = &.{ 0, 0, 0 };
 
@@ -1135,4 +1165,145 @@ test "a hop that answers refreshes the budget for the next one" {
     var resolved = try result;
     defer resolved.deinit();
     try std.testing.expectEqualStrings(loc, resolved.final_url);
+}
+
+// Long enough that the connect is observably cut, short enough that a green
+// run costs nothing.
+const tls_silent_budget_ns: u64 = 500 * std.time.ns_per_ms;
+
+test "a bare HEAD gives up on a peer that never starts its TLS handshake" {
+    // Connect runs DNS, TCP and the whole TLS handshake before the head
+    // watchdog has a connection to shut down, so this window had no deadline
+    // at all - and `mt install` holds `db/malt.lock` across it.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var l1 = try bindIp4(io);
+    defer l1.deinit(io);
+    const p1 = l1.socket.address.getPort();
+
+    var tls_silent = TlsSilentPeer{ .io = io, .listener = &l1 };
+    const t1 = try std.Thread.spawn(.{}, acceptAndSayNothing, .{&tls_silent});
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "https://127.0.0.1:{d}/probe", .{p1});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+    http.head_timeout_ns = tls_silent_budget_ns;
+
+    const result = http.head(url);
+    http.deinit();
+    t1.join();
+
+    try std.testing.expectError(error.HeadTimeout, result);
+    try std.testing.expectEqual(@as(usize, 1), tls_silent.accepts.load(.acquire));
+}
+
+test "a download gives up on a peer that never starts its TLS handshake" {
+    // `followGet` opens its own connection, so the buffered walk needs its own
+    // fixture to prove the deadline is wired there too.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var l1 = try bindIp4(io);
+    defer l1.deinit(io);
+    const p1 = l1.socket.address.getPort();
+
+    var tls_silent = TlsSilentPeer{ .io = io, .listener = &l1 };
+    const t1 = try std.Thread.spawn(.{}, acceptAndSayNothing, .{&tls_silent});
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "https://127.0.0.1:{d}/blob", .{p1});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+    http.head_timeout_ns = tls_silent_budget_ns;
+    http.retry_backoff_ms = &.{};
+
+    const result = http.getWithHeaders(url, &.{}, null, .transport_only);
+    http.deinit();
+    t1.join();
+
+    try std.testing.expectError(error.HeadTimeout, result);
+    try std.testing.expectEqual(@as(usize, 1), tls_silent.accepts.load(.acquire));
+}
+
+test "a blob stream gives up on a peer that never starts its TLS handshake" {
+    // `followGetToWriter` wires its deadline separately from the buffered walk.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var l1 = try bindIp4(io);
+    defer l1.deinit(io);
+    const p1 = l1.socket.address.getPort();
+
+    var tls_silent = TlsSilentPeer{ .io = io, .listener = &l1 };
+    const t1 = try std.Thread.spawn(.{}, acceptAndSayNothing, .{&tls_silent});
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "https://127.0.0.1:{d}/bottle", .{p1});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+    http.head_timeout_ns = tls_silent_budget_ns;
+    http.retry_backoff_ms = &.{};
+
+    var sink: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer sink.deinit();
+    const result = http.getToWriter(url, &.{}, &sink.writer, null);
+    http.deinit();
+    t1.join();
+
+    try std.testing.expectError(error.HeadTimeout, result);
+    try std.testing.expectEqual(@as(usize, 1), tls_silent.accepts.load(.acquire));
+}
+
+// The peer the cancel probe below watches. A Ctrl-C only counts once the
+// connection exists, so the assertion is about the handshake window rather
+// than a race with the dial.
+var cancel_watch: ?*const TlsSilentPeer = null;
+
+fn cancelledOnceAccepted() bool {
+    const peer = cancel_watch orelse return false;
+    return peer.accepts.load(.acquire) > 0;
+}
+
+test "Ctrl-C during a stalled TLS handshake is the answer, not a blip to retry" {
+    // Nothing sampled the cancel flag inside the handshake, so a Ctrl-C waited
+    // out the full budget - and, read as an ordinary transport fault, was then
+    // slept off and re-dialled.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var l1 = try bindIp4(io);
+    defer l1.deinit(io);
+    const p1 = l1.socket.address.getPort();
+
+    var tls_silent = TlsSilentPeer{ .io = io, .listener = &l1 };
+    const t1 = try std.Thread.spawn(.{}, acceptAndSayNothing, .{&tls_silent});
+    cancel_watch = &tls_silent;
+    defer cancel_watch = null;
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "https://127.0.0.1:{d}/artifact", .{p1});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+    // A budget far past the point of the test: only the cancel can end this.
+    http.head_timeout_ns = 60 * std.time.ns_per_s;
+    http.cancel = &cancelledOnceAccepted;
+    // A budget the retry loop could spend if it read the cancel as a blip.
+    http.retry_backoff_ms = &.{ 0, 0, 0 };
+
+    const result = http.headResolved(url);
+    http.deinit();
+    t1.join();
+
+    try std.testing.expectError(error.Canceled, result);
+    try std.testing.expectEqual(@as(usize, 1), tls_silent.accepts.load(.acquire));
 }

--- a/tests/net_redirect_auth_test.zig
+++ b/tests/net_redirect_auth_test.zig
@@ -8,6 +8,7 @@ const std = @import("std");
 const client = @import("malt").client;
 const notifier = @import("malt").update_notifier;
 const net = std.Io.net;
+const test_io = @import("test_io");
 
 const auth_value = "token SECRET-PAT";
 const blob_body = "the-protected-blob";
@@ -186,6 +187,9 @@ const UnframedRedirectPeer = struct {
     io: std.Io,
     listener: *net.Server,
     location: []const u8,
+    // Frame the body with a chunked encoding instead of leaving it to end at
+    // close. Chunked terminates itself, so this hop must still be drained.
+    chunked: bool = false,
 };
 
 // Bounds a regression: the drain hits EOF here instead of hanging the suite,
@@ -209,10 +213,18 @@ fn serveUnframedRedirect(peer: *UnframedRedirectPeer) void {
     // single loopback segment.
     _ = reader.interface.peek(1) catch return;
 
-    writer.interface.print(
-        "HTTP/1.1 302 Found\r\nLocation: {s}\r\n\r\nredirecting\n",
-        .{peer.location},
-    ) catch return;
+    if (peer.chunked) {
+        writer.interface.print(
+            "HTTP/1.1 302 Found\r\nLocation: {s}\r\n" ++
+                "Transfer-Encoding: chunked\r\n\r\nc\r\nredirecting\n\r\n0\r\n\r\n",
+            .{peer.location},
+        ) catch return;
+    } else {
+        writer.interface.print(
+            "HTTP/1.1 302 Found\r\nLocation: {s}\r\n\r\nredirecting\n",
+            .{peer.location},
+        ) catch return;
+    }
     writer.interface.flush() catch return;
 
     // Hold it open: an undeclared body ends at close, which is the condition
@@ -1558,4 +1570,48 @@ test "the stock client still retries a failing peer" {
         owned.deinit();
     } else |_| {}
     try std.testing.expectEqual(@as(usize, 4), hop1.requests);
+}
+
+test "a chunked redirect is drained rather than retired" {
+    // Chunked framing ends at its own zero-chunk, so the drain terminates
+    // without the peer closing - which is why this hop keeps its connection
+    // instead of paying for a fresh handshake. The classifier says so; this
+    // proves it at the socket, against a peer that never closes.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var l2 = try bindIp4(io);
+    defer l2.deinit(io);
+    const p2 = l2.socket.address.getPort();
+    var hop2 = Hop{ .io = io, .listener = &l2 };
+    const t2 = try std.Thread.spawn(.{}, serveOne, .{&hop2});
+
+    var loc_buf: [64]u8 = undefined;
+    const loc = try std.fmt.bufPrint(&loc_buf, "http://127.0.0.1:{d}/blob", .{p2});
+
+    var l1 = try bindIp4(io);
+    defer l1.deinit(io);
+    const p1 = l1.socket.address.getPort();
+    var peer = UnframedRedirectPeer{ .io = io, .listener = &l1, .location = loc, .chunked = true };
+    const t1 = try std.Thread.spawn(.{}, serveUnframedRedirect, .{&peer});
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/start", .{p1});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+    http.retry_backoff_ms = &.{};
+
+    const started_ms = test_io.milliTimestamp(io);
+    const result = http.get(url);
+    const elapsed_ms = test_io.milliTimestamp(io) - started_ms;
+    http.deinit();
+    t1.join();
+    t2.join();
+
+    var resp = try result;
+    defer resp.deinit();
+    try std.testing.expectEqualStrings(blob_body, resp.body);
+    try std.testing.expect(elapsed_ms < drain_budget_ms);
 }

--- a/tests/net_redirect_auth_test.zig
+++ b/tests/net_redirect_auth_test.zig
@@ -187,9 +187,13 @@ const UnframedRedirectPeer = struct {
     io: std.Io,
     listener: *net.Server,
     location: []const u8,
-    // Frame the body with a chunked encoding instead of leaving it to end at
-    // close. Chunked terminates itself, so this hop must still be drained.
-    chunked: bool = false,
+    // How the 3xx frames its body. Framing does not make a drain bounded: a
+    // peer that announces a body and never sends it parks the reader just as
+    // an unframed one does.
+    framing: enum { none, chunked, oversize_length } = .none,
+    // Omit `Location` so the walk unwinds through its error path, which
+    // releases the hop somewhere else entirely.
+    omit_location: bool = false,
 };
 
 // Bounds a regression: the drain hits EOF here instead of hanging the suite,
@@ -213,17 +217,27 @@ fn serveUnframedRedirect(peer: *UnframedRedirectPeer) void {
     // single loopback segment.
     _ = reader.interface.peek(1) catch return;
 
-    if (peer.chunked) {
-        writer.interface.print(
+    if (peer.omit_location) {
+        // No Location and no framing: the walk errors out, and the hop is
+        // released on the unwind path rather than the committed-hop one.
+        writer.interface.writeAll("HTTP/1.1 302 Found\r\n\r\nredirecting\n") catch return;
+    } else switch (peer.framing) {
+        // Chunked, but the terminating zero-chunk never arrives.
+        .chunked => writer.interface.print(
             "HTTP/1.1 302 Found\r\nLocation: {s}\r\n" ++
-                "Transfer-Encoding: chunked\r\n\r\nc\r\nredirecting\n\r\n0\r\n\r\n",
+                "Transfer-Encoding: chunked\r\n\r\nc\r\nredirecting\n",
             .{peer.location},
-        ) catch return;
-    } else {
-        writer.interface.print(
+        ) catch return,
+        // A declared length far larger than anything that follows.
+        .oversize_length => writer.interface.print(
+            "HTTP/1.1 302 Found\r\nLocation: {s}\r\n" ++
+                "Content-Length: 4294967296\r\n\r\nredirecting\n",
+            .{peer.location},
+        ) catch return,
+        .none => writer.interface.print(
             "HTTP/1.1 302 Found\r\nLocation: {s}\r\n\r\nredirecting\n",
             .{peer.location},
-        ) catch return;
+        ) catch return,
     }
     writer.interface.flush() catch return;
 
@@ -1398,12 +1412,9 @@ test "an unframed redirect is released without draining until the peer closes" {
     var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
     http.retry_backoff_ms = &.{};
 
-    const started_ns: i128 = std.Io.Clock.real.now(io).toNanoseconds();
+    const started_ms = test_io.elapsedMillis(io);
     const result = http.get(url);
-    const elapsed_ms: i64 = @intCast(@divTrunc(
-        std.Io.Clock.real.now(io).toNanoseconds() - started_ns,
-        std.time.ns_per_ms,
-    ));
+    const elapsed_ms = test_io.elapsedMillis(io) - started_ms;
     http.deinit();
     t1.join();
     t2.join();
@@ -1445,12 +1456,9 @@ test "a streamed walk releases an unframed redirect without draining it" {
     var sink: std.Io.Writer.Allocating = .init(std.testing.allocator);
     defer sink.deinit();
 
-    const started_ns: i128 = std.Io.Clock.real.now(io).toNanoseconds();
+    const started_ms = test_io.elapsedMillis(io);
     const result = http.getToWriter(url, &.{}, &sink.writer, null);
-    const elapsed_ms: i64 = @intCast(@divTrunc(
-        std.Io.Clock.real.now(io).toNanoseconds() - started_ns,
-        std.time.ns_per_ms,
-    ));
+    const elapsed_ms = test_io.elapsedMillis(io) - started_ms;
     http.deinit();
     t1.join();
     t2.join();
@@ -1458,47 +1466,6 @@ test "a streamed walk releases an unframed redirect without draining it" {
     try std.testing.expectEqual(@as(u16, 200), try result);
     try std.testing.expectEqualStrings(blob_body, sink.written());
     try std.testing.expect(elapsed_ms < drain_budget_ms);
-}
-
-test "a framed redirect still drains, so its connection stays poolable" {
-    // Only the unframed case skips the drain. A 302 that declares its body
-    // costs a cheap read, and retiring that connection would pay for a fresh
-    // handshake on every hop of a healthy chain.
-    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
-    defer threaded.deinit();
-    const io = threaded.io();
-
-    var l2 = try bindIp4(io);
-    defer l2.deinit(io);
-    const p2 = l2.socket.address.getPort();
-    var hop2 = Hop{ .io = io, .listener = &l2 };
-    const t2 = try std.Thread.spawn(.{}, serveOne, .{&hop2});
-
-    var loc_buf: [64]u8 = undefined;
-    const loc = try std.fmt.bufPrint(&loc_buf, "http://127.0.0.1:{d}/blob", .{p2});
-
-    var l1 = try bindIp4(io);
-    defer l1.deinit(io);
-    const p1 = l1.socket.address.getPort();
-    // `Hop` answers a 302 with a declared body.
-    var hop1 = Hop{ .io = io, .listener = &l1, .redirect_to = loc, .status = .found };
-    const t1 = try std.Thread.spawn(.{}, serveOne, .{&hop1});
-
-    var url_buf: [64]u8 = undefined;
-    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/start", .{p1});
-
-    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
-    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
-    http.retry_backoff_ms = &.{};
-
-    const result = http.get(url);
-    http.deinit();
-    t1.join();
-    t2.join();
-
-    var resp = try result;
-    defer resp.deinit();
-    try std.testing.expectEqualStrings(blob_body, resp.body);
 }
 
 test "the version probe's budget spends one attempt on a peer that keeps failing" {
@@ -1572,11 +1539,10 @@ test "the stock client still retries a failing peer" {
     try std.testing.expectEqual(@as(usize, 4), hop1.requests);
 }
 
-test "a chunked redirect is drained rather than retired" {
-    // Chunked framing ends at its own zero-chunk, so the drain terminates
-    // without the peer closing - which is why this hop keeps its connection
-    // instead of paying for a fresh handshake. The classifier says so; this
-    // proves it at the socket, against a peer that never closes.
+test "a chunked redirect whose zero-chunk never arrives is still released" {
+    // Framing was the old reason to drain a redirect. It is not a guarantee:
+    // a peer that opens a chunked body and stops parks the drain exactly like
+    // an unframed one, so the hop is retired regardless of how it is framed.
     var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
     defer threaded.deinit();
     const io = threaded.io();
@@ -1593,7 +1559,7 @@ test "a chunked redirect is drained rather than retired" {
     var l1 = try bindIp4(io);
     defer l1.deinit(io);
     const p1 = l1.socket.address.getPort();
-    var peer = UnframedRedirectPeer{ .io = io, .listener = &l1, .location = loc, .chunked = true };
+    var peer = UnframedRedirectPeer{ .io = io, .listener = &l1, .location = loc, .framing = .chunked };
     const t1 = try std.Thread.spawn(.{}, serveUnframedRedirect, .{&peer});
 
     var url_buf: [64]u8 = undefined;
@@ -1602,10 +1568,12 @@ test "a chunked redirect is drained rather than retired" {
     var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
     var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
     http.retry_backoff_ms = &.{};
+    // Bounds the drain of a framed body the peer never finishes sending.
+    http.head_timeout_ns = stall_budget_ns;
 
-    const started_ms = test_io.milliTimestamp(io);
+    const started_ms = test_io.elapsedMillis(io);
     const result = http.get(url);
-    const elapsed_ms = test_io.milliTimestamp(io) - started_ms;
+    const elapsed_ms = test_io.elapsedMillis(io) - started_ms;
     http.deinit();
     t1.join();
     t2.join();
@@ -1613,5 +1581,82 @@ test "a chunked redirect is drained rather than retired" {
     var resp = try result;
     defer resp.deinit();
     try std.testing.expectEqualStrings(blob_body, resp.body);
+    try std.testing.expect(elapsed_ms < drain_budget_ms);
+}
+
+test "a redirect that declares a body it never sends is still released" {
+    // `Content-Length` was the strongest framing signal, and it is the easiest
+    // to lie about: the drain waits for bytes that never come.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var l2 = try bindIp4(io);
+    defer l2.deinit(io);
+    const p2 = l2.socket.address.getPort();
+    var hop2 = Hop{ .io = io, .listener = &l2 };
+    const t2 = try std.Thread.spawn(.{}, serveOne, .{&hop2});
+
+    var loc_buf: [64]u8 = undefined;
+    const loc = try std.fmt.bufPrint(&loc_buf, "http://127.0.0.1:{d}/blob", .{p2});
+
+    var l1 = try bindIp4(io);
+    defer l1.deinit(io);
+    const p1 = l1.socket.address.getPort();
+    var peer = UnframedRedirectPeer{ .io = io, .listener = &l1, .location = loc, .framing = .oversize_length };
+    const t1 = try std.Thread.spawn(.{}, serveUnframedRedirect, .{&peer});
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/start", .{p1});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+    http.retry_backoff_ms = &.{};
+    // Bounds the drain of a framed body the peer never finishes sending.
+    http.head_timeout_ns = stall_budget_ns;
+
+    const started_ms = test_io.elapsedMillis(io);
+    const result = http.get(url);
+    const elapsed_ms = test_io.elapsedMillis(io) - started_ms;
+    http.deinit();
+    t1.join();
+    t2.join();
+
+    var resp = try result;
+    defer resp.deinit();
+    try std.testing.expectEqualStrings(blob_body, resp.body);
+    try std.testing.expect(elapsed_ms < drain_budget_ms);
+}
+
+test "a redirect the walk refuses is released on the way out, not drained" {
+    // The unwind path had its own release. A malformed `Location`, an
+    // exhausted budget, or a refused https downgrade all land there, so a
+    // hostile peer could park the walk on the very error that rejected it.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var l1 = try bindIp4(io);
+    defer l1.deinit(io);
+    const p1 = l1.socket.address.getPort();
+    var peer = UnframedRedirectPeer{ .io = io, .listener = &l1, .location = "", .omit_location = true };
+    const t1 = try std.Thread.spawn(.{}, serveUnframedRedirect, .{&peer});
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/start", .{p1});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+    http.retry_backoff_ms = &.{};
+    // Bounds the drain of a framed body the peer never finishes sending.
+    http.head_timeout_ns = stall_budget_ns;
+
+    const started_ms = test_io.elapsedMillis(io);
+    const result = http.get(url);
+    const elapsed_ms = test_io.elapsedMillis(io) - started_ms;
+    http.deinit();
+    t1.join();
+
+    try std.testing.expectError(error.HttpRedirectInvalid, result);
     try std.testing.expect(elapsed_ms < drain_budget_ms);
 }

--- a/tests/notifier_probe_budget_test.zig
+++ b/tests/notifier_probe_budget_test.zig
@@ -1,0 +1,108 @@
+//! malt — the passive version probe's budget, judged over real TLS.
+//!
+//! The probe fires on the hot path of every command and advertises a 1.5 s
+//! bound. Its real worst case used to be the retry schedule sitting outside
+//! that bound: a transiently failing endpoint bought four attempts plus seven
+//! seconds of backoff, holding every command through a brownout.
+//!
+//! `applyProbeBudget` is what closes that, so this walks a live TLS endpoint
+//! that answers 503 to everything and asserts the probe spends exactly one
+//! attempt on it. Cleartext would not do: the probe's endpoint is https, and
+//! a plaintext fixture would leave the handshake - the phase that actually
+//! costs time - out of the measurement.
+//!
+//! The fixture is owned by the regression script, which generates the cert,
+//! starts the server and asserts the request count it observed. Without those
+//! env vars this file skips, so `zig build test` stays hermetic.
+
+const std = @import("std");
+const malt = @import("malt");
+const client = malt.client;
+const notifier = malt.update_notifier;
+const test_io = @import("test_io");
+const testing = std.testing;
+
+/// The stock schedule sleeps 1+2+4 s across three retries. A budget between
+/// the two tells "one attempt" from "four" without pinning either number.
+const retry_budget_ms: i64 = 3_000;
+
+const Fixture = struct {
+    port: [:0]const u8,
+    ca_path: [:0]const u8,
+};
+
+fn fixture() ?Fixture {
+    return .{
+        .port = test_io.getenv("MALT_TEST_PROBE_PORT") orelse return null,
+        .ca_path = test_io.getenv("MALT_TEST_PROBE_CA") orelse return null,
+    };
+}
+
+/// Trusts only the fixture's CA. Pinning `now` is what makes that stick:
+/// stdlib otherwise rescans the system store on the first https request and
+/// swaps the bundle out from under us.
+fn trustFixtureCa(inner: *std.http.Client, io: std.Io, ca_path: []const u8) !void {
+    const now = std.Io.Clock.real.now(io);
+    try inner.ca_bundle.addCertsFromFilePathAbsolute(inner.allocator, io, now, ca_path);
+    inner.now = now;
+}
+
+test "the version probe spends one attempt on an endpoint that keeps failing" {
+    const fx = fixture() orelse return error.SkipZigTest;
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var inner: std.http.Client = .{ .allocator = testing.allocator, .io = io };
+    try trustFixtureCa(&inner, io, fx.ca_path);
+
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, testing.allocator);
+    notifier.applyProbeBudget(&http);
+
+    // `localhost`, not `127.0.0.1`: certificate host verification matches DNS
+    // names, and an IP SAN never satisfies it.
+    var url_buf: [96]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "https://localhost:{s}/releases/latest", .{fx.port});
+
+    const started_ms = test_io.milliTimestamp(io);
+    const result = http.get(url);
+    const elapsed_ms = test_io.milliTimestamp(io) - started_ms;
+    http.deinit();
+
+    var resp = try result;
+    defer resp.deinit();
+
+    try testing.expectEqual(@as(u16, 503), resp.status);
+    try testing.expect(elapsed_ms < retry_budget_ms);
+}
+
+test "a transient failure is still worth retrying for everyone else" {
+    // The probe's no-retry budget is the notifier's choice, not the client's
+    // default. An install losing its retries to this change would be a far
+    // worse regression than the latency it fixes.
+    const fx = fixture() orelse return error.SkipZigTest;
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var inner: std.http.Client = .{ .allocator = testing.allocator, .io = io };
+    try trustFixtureCa(&inner, io, fx.ca_path);
+
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, testing.allocator);
+    try testing.expect(http.retry_backoff_ms.len > 0);
+
+    // Zeroed delays: the count is the assertion, not the wall-clock.
+    http.retry_backoff_ms = &.{ 0, 0, 0 };
+
+    var url_buf: [96]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "https://localhost:{s}/retried", .{fx.port});
+
+    const result = http.get(url);
+    http.deinit();
+
+    var resp = try result;
+    defer resp.deinit();
+    try testing.expectEqual(@as(u16, 503), resp.status);
+}

--- a/tests/notifier_probe_budget_test.zig
+++ b/tests/notifier_probe_budget_test.zig
@@ -91,9 +91,13 @@ test "a transient failure is still worth retrying for everyone else" {
     try trustFixtureCa(&inner, io, fx.ca_path);
 
     var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, testing.allocator);
-    try testing.expect(http.retry_backoff_ms.len > 0);
+    // Pin the stock schedule itself: the attempt count below is only evidence
+    // about the client default if that default is what is being shortened.
+    const stock_retries = http.retry_backoff_ms.len;
+    try testing.expectEqual(@as(usize, 3), stock_retries);
 
-    // Zeroed delays: the count is the assertion, not the wall-clock.
+    // Zeroed delays of the same length: the count is the assertion, not the
+    // wall-clock.
     http.retry_backoff_ms = &.{ 0, 0, 0 };
 
     var url_buf: [96]u8 = undefined;

--- a/tests/test_io.zig
+++ b/tests/test_io.zig
@@ -68,6 +68,14 @@ pub fn milliTimestamp(io: std.Io) i64 {
     return std.Io.Clock.real.now(io).toMilliseconds();
 }
 
+/// Elapsed-time clock for tests that assert a duration. `.awake`, not
+/// `.real`: a wall-clock step inside the measured window would otherwise
+/// decide the result, which is the same reason the deadlines under test
+/// stopped using `.real`.
+pub fn elapsedMillis(io: std.Io) i64 {
+    return std.Io.Clock.awake.now(io).toMilliseconds();
+}
+
 pub fn isatty(io: std.Io, fd: std.posix.fd_t) bool {
     const file: std.Io.File = .{ .handle = fd, .flags = .{ .nonblocking = false } };
     return file.isTty(io) catch false;


### PR DESCRIPTION
## Description

A peer could hold any malt command hostage in three ways: never speaking TLS after the TCP accept, answering a redirect with a body it never finishes, or simply failing while the passive version probe retried it. All three were unbounded waits, and installs hold `db/malt.lock` across them, so one slow peer wedged every other invocation.

Each now has a deadline it cannot outlast: the connect is raced against the hop's budget, a redirect hop is released without an unbounded drain, and the version probe holds every phase to the 1.5 s it advertises without retrying.

## Related Issue

- None

## Notes for Reviewers

- Behaviour change worth naming: connect and head read now share one `head_timeout_ns` per hop rather than getting one each, so a peer with a very slow handshake but a fast head can now hit the bound. Unbounded connect was the bug, so this is the intended trade.
- Deadlines moved off the wall clock onto `Clock.awake`; the old reads could step backwards under NTP or a laptop waking and underflow into an effectively unbounded budget.
- Redirect release is split deliberately: a body that can only end at close is skipped outright, anything else is drained under a watchdog. Framing is a promise a hostile peer can decline to keep, but dropping the drain entirely would cost keep-alive on every legitimate same-host chain.