### PR TITLE
ci: gate every PR on the loopback regression guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,10 @@ jobs:
         with:
           tool: just
 
+      # The guards bound themselves with `timeout`, which macOS does not ship.
+      - name: Install coreutils
+        run: brew install coreutils
+
       - name: Hermetic regression guards
         run: just regressions-hermetic
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
       - "**/*.zon"
       - "scripts/**/*.sh"
       - "src/core/pins_manifest.txt"
+      - "justfile"
       - ".github/workflows/ci.yml"
   pull_request:
     branches:
@@ -20,6 +21,7 @@ on:
       - "**/*.zon"
       - "scripts/**/*.sh"
       - "src/core/pins_manifest.txt"
+      - "justfile"
       - ".github/workflows/ci.yml"
 
 jobs:
@@ -110,6 +112,32 @@ jobs:
         run: |
           shellcheck scripts/*.sh scripts/lib/*.sh scripts/test/*.sh scripts/e2e/*.sh scripts/regressions/*.sh scripts/smokes/*.sh scripts/release/*.sh
           shfmt -i 2 -d scripts/*.sh scripts/lib/*.sh scripts/test/*.sh scripts/e2e/*.sh scripts/regressions/*.sh scripts/smokes/*.sh scripts/release/*.sh
+
+  # The regression pool is where field bugs get their permanent guard, but
+  # only the loopback ones can gate a PR - the rest need a token and live
+  # installs. Running that subset here is what stops a guard from silently
+  # never being run again after the branch that added it merges.
+  regressions-hermetic:
+    name: Regression guards (hermetic)
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+          use-cache: false
+
+      - name: Install just
+        uses: taiki-e/install-action@v2.85.4
+        with:
+          tool: just
+
+      - name: Hermetic regression guards
+        run: just regressions-hermetic
 
   # Drift guard: verify every committed manifest entry's hash against the
   # committed pin on every PR. Catches "bumped pins.zig, forgot to

--- a/justfile
+++ b/justfile
@@ -46,6 +46,16 @@ regressions-static:
 test: regressions-static
     zig build test --summary all
 
+# Loopback-only regression guards: no network, no GitHub API, no rate limit,
+# so they are safe to gate every PR on. The full pool (`just regressions`)
+# needs a token and live installs, which is why it stays manual.
+[group('test')]
+regressions-hermetic:
+    @./scripts/regressions/head-read-deadline-response-head-reads-have-no-deadline.sh
+    @./scripts/regressions/no-deadline-on-connect-tls-response-head.sh
+    @./scripts/regressions/redirect-response-released-with-draining-deinit.sh
+    @./scripts/regressions/notifier-probe-unbounded-by-client-retry-backoff.sh
+
 # Run the full regression pool (token + built binary + per-script timeout).
 # Pass script names to run a subset; MALT_REGRESSION_TIMEOUT overrides the cap.
 [group('test')]


### PR DESCRIPTION
## Description

The regression pool is where field bugs get their permanent guard, but nothing ran it: `regressions-static` covers four scripts and CI ran one, so a guard added by a merged branch was never executed again. The loopback guards need no token and no network, so they can gate a PR; this wires that subset in.

## Related Issue

- None

## Notes for Reviewers

- Only the hermetic guards are listed; the rest need a token and live installs and stay manual behind `just regressions`.
- The job installs coreutils: the scripts bound themselves with `timeout`, which macOS does not ship.