### PR TITLE
fix(install): blame the machine, not the network, when local resources run out

### DIFF
--- a/scripts/regressions/notifier-probe-unbounded-by-client-retry-backoff.sh
+++ b/scripts/regressions/notifier-probe-unbounded-by-client-retry-backoff.sh
@@ -48,7 +48,11 @@ zig build test-bin >/dev/null 2>&1 || fail "could not build the test binaries"
 WORK=$(mktemp -d -t probe-budget)
 SERVER_PID=""
 cleanup() {
-  [[ -n "$SERVER_PID" ]] && kill "$SERVER_PID" 2>/dev/null
+  # `[[ ... ]] && kill` as a bare statement aborts the trap under `errexit`
+  # when the server is already gone, stranding the key in $WORK.
+  if [[ -n "$SERVER_PID" ]]; then
+    kill "$SERVER_PID" 2>/dev/null || true
+  fi
   rm -rf "$WORK"
 }
 trap cleanup EXIT

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -1379,6 +1379,8 @@ fn mapHeadResolveError(e: client_mod.HeadResolveError) ?InstallError {
         error.TooManyHttpRedirects,
         error.HeadTimeout,
         => InstallError.NetworkError,
+        // Local exhaustion, not the peer: retrying the network cannot help.
+        error.WatchdogSpawnFailed => InstallError.LocalResourceExhausted,
         // One is malt running out of memory, the other the user stopping.
         error.OutOfMemory, error.Canceled => null,
     };
@@ -1477,6 +1479,14 @@ fn installCask(
     // resolve via HEAD to discover the final URL and Content-Disposition.
     if (artifact_type == .unknown) {
         artifact_type = resolveCaskArtifactViaHead(ctx, allocator, cask.url) catch |e| {
+            // Names the machine, not the network: the peer was never reached.
+            if (e == error.WatchdogSpawnFailed) {
+                sink.err(
+                    "Ran out of local threads or file descriptors while resolving '{s}' — close other processes or retry with fewer workers.",
+                    .{cask.token},
+                );
+                return InstallError.LocalResourceExhausted;
+            }
             if (mapHeadResolveError(e)) |classified| {
                 // Report the walk's own error — "NetworkError" would say less
                 // than the message already does.
@@ -1718,6 +1728,15 @@ test "mapHeadResolveError reports a dead walk as a network failure, not a format
     try std.testing.expectEqual(InstallError.NetworkError, mapHeadResolveError(error.HttpRedirectLocationInvalid).?);
     try std.testing.expectEqual(InstallError.NetworkError, mapHeadResolveError(error.HttpRedirectLocationOversize).?);
     try std.testing.expectEqual(InstallError.NetworkError, mapHeadResolveError(error.TooManyHttpRedirects).?);
+}
+
+test "mapHeadResolveError blames the machine, not the network, when it runs out of local resources" {
+    // A walk that never reached the peer must not send the user off to debug
+    // their connection - no amount of retrying the network frees a thread.
+    try std.testing.expectEqual(
+        InstallError.LocalResourceExhausted,
+        mapHeadResolveError(error.WatchdogSpawnFailed).?,
+    );
 }
 
 test "mapHeadResolveError keeps a cleartext artifact URL distinct from a network failure" {

--- a/src/cli/install/download.zig
+++ b/src/cli/install/download.zig
@@ -117,7 +117,17 @@ pub fn isDeterministicDownloadError(err: bottle_mod.BottleError) bool {
         bottle_mod.BottleError.PathTooLong,
         bottle_mod.BottleError.OutOfMemory,
         => true,
-        else => false,
+
+        // Exhaustive rather than `else`: a new tag defaulting silently into
+        // "retriable" is how a fault that cannot be retried gets retried
+        // three times under the install lock.
+        bottle_mod.BottleError.DownloadFailed,
+        bottle_mod.BottleError.DownloadPermanent,
+        bottle_mod.BottleError.DownloadRateLimited,
+        bottle_mod.BottleError.DownloadLocalResourceExhausted,
+        bottle_mod.BottleError.Sha256Mismatch,
+        bottle_mod.BottleError.IoError,
+        => false,
     };
 }
 
@@ -709,6 +719,10 @@ pub fn downloadBottleToStore(
             deps.sink.err("  {s}: {s} (after {d} attempts)", .{ formula.name, @errorName(last_err), max_download_attempts });
         }
         allocator.free(tmp_dir);
+        // Exhausting local threads or descriptors is this machine's fault, and
+        // the user's next move differs from a dead registry's.
+        if (last_err == bottle_mod.BottleError.DownloadLocalResourceExhausted)
+            return InstallError.LocalResourceExhausted;
         return InstallError.DownloadFailed;
     }
     if (deps.bar) |bar| bar.finish();
@@ -1045,10 +1059,9 @@ test "isDeterministicDownloadError: IoError IS retried" {
 }
 
 test "isDeterministicDownloadError: every BottleError variant has an explicit verdict" {
-    // Comptime sweep: if a future BottleError tag is added without a
-    // classification, this test fails to compile (the switch is
-    // exhaustive inside the helper). The walk here is the runtime
-    // mirror — every tag returns either true or false, never panics.
+    // Comptime sweep: the helper's switch is exhaustive, so a future
+    // BottleError tag added without a classification fails to compile there.
+    // The walk here is the runtime mirror — every tag returns true or false.
     inline for (@typeInfo(bottle_mod.BottleError).error_set.?) |err| {
         const tag = @field(bottle_mod.BottleError, err.name);
         _ = isDeterministicDownloadError(tag);

--- a/src/cli/install/download.zig
+++ b/src/cli/install/download.zig
@@ -1016,6 +1016,14 @@ test "isDeterministicDownloadError: DownloadFailed IS retried" {
     try std.testing.expect(!isDeterministicDownloadError(bottle_mod.BottleError.DownloadFailed));
 }
 
+test "isDeterministicDownloadError: local exhaustion IS retried" {
+    // A sibling worker finishing frees the thread or descriptor this one
+    // could not get, so the second attempt can genuinely succeed.
+    try std.testing.expect(!isDeterministicDownloadError(
+        bottle_mod.BottleError.DownloadLocalResourceExhausted,
+    ));
+}
+
 test "isDeterministicDownloadError: DownloadRateLimited IS retried" {
     // Rate limits are time-based, not deterministic — backoff gets a
     // shot at the next request.

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -1003,6 +1003,7 @@ fn materializeTapCask(
             sink.err("Failed to download cask {s}: {s}", .{ cask.token, @errorName(e) });
             return switch (e) {
                 error.DownloadFailed, error.Sha256Mismatch, error.Sha256Missing => InstallError.DownloadFailed,
+                error.DownloadLocalResourceExhausted => InstallError.LocalResourceExhausted,
                 error.OutOfMemory => InstallError.RecordFailed,
                 else => InstallError.CaskNotFound,
             };
@@ -1019,6 +1020,7 @@ fn materializeTapCask(
         sink.err("Failed to install cask {s}: {s}", .{ cask.token, @errorName(e) });
         return switch (e) {
             error.DownloadFailed, error.Sha256Mismatch, error.Sha256Missing => InstallError.DownloadFailed,
+            error.DownloadLocalResourceExhausted => InstallError.LocalResourceExhausted,
             error.OutOfMemory => InstallError.RecordFailed,
             else => InstallError.CaskNotFound,
         };

--- a/src/cli/install/record.zig
+++ b/src/cli/install/record.zig
@@ -25,6 +25,10 @@ pub const InstallError = error{
     /// or was skipped because an ancestor dep failed. Returned from `execute`
     /// so `main` exits non-zero.
     PartialFailure,
+    /// This machine ran out of threads or file descriptors, not the network.
+    /// Separate from `NetworkError` so the user is pointed at their own box
+    /// instead of at their connection.
+    LocalResourceExhausted,
     /// MALT_PREFIX is absurdly long (exceeds the 256-byte sanity cap).
     /// Raised before any network activity so pathological values never
     /// reach the relocation subprocess.
@@ -90,6 +94,9 @@ pub fn localErrorIsAnnounced(e: InstallError) bool {
         InstallError.CellarFailed,
         InstallError.RateLimited,
         InstallError.NetworkError,
+        // Raise site names the exhausted local resource and what to do
+        // about it, which the generic summary would only bury.
+        InstallError.LocalResourceExhausted,
         // Raise site prints the actionable "builds from source" line, so
         // the generic dispatch summary stays suppressed.
         InstallError.BuildFromSourceUnsupported,

--- a/src/cli/migrate/keg.zig
+++ b/src/cli/migrate/keg.zig
@@ -598,8 +598,12 @@ fn downloadBottle(
         .func = &migrateBarBridge,
     } else null;
 
-    _ = bottle_mod.download(ctx.io, allocator, ghcr, http, repo, digest, sha256, tmp_dir, progress_cb, null) catch {
-        output.err("    Download failed: {s}", .{name});
+    _ = bottle_mod.download(ctx.io, allocator, ghcr, http, repo, digest, sha256, tmp_dir, progress_cb, null) catch |e| {
+        if (e == bottle_mod.BottleError.DownloadLocalResourceExhausted) {
+            output.err("    Out of local threads or file descriptors: {s}", .{name});
+        } else {
+            output.err("    Download failed: {s}", .{name});
+        }
         atomic.cleanupTempDir(ctx.io, tmp_dir);
         allocator.free(tmp_dir);
         return false;

--- a/src/cli/run.zig
+++ b/src/cli/run.zig
@@ -264,8 +264,12 @@ fn ephemeralRun(
     }
 
     output.info("Downloading {s} {s}...", .{ pkg_name, formula.version });
-    _ = bottle_mod.download(ctx.io, allocator, &ghcr, &http, repo, digest, bottle.sha256, dest_dir, null, null) catch {
-        output.err("Failed to download {s}", .{pkg_name});
+    _ = bottle_mod.download(ctx.io, allocator, &ghcr, &http, repo, digest, bottle.sha256, dest_dir, null, null) catch |e| {
+        if (e == bottle_mod.BottleError.DownloadLocalResourceExhausted) {
+            output.err("Out of local threads or file descriptors while downloading {s} — close other processes and retry.", .{pkg_name});
+        } else {
+            output.err("Failed to download {s}", .{pkg_name});
+        }
         return error.Aborted;
     };
 

--- a/src/core/bottle.zig
+++ b/src/core/bottle.zig
@@ -22,6 +22,36 @@ pub const BottleError = error{
     IoError,
 };
 
+test "a registry download that ran out of local resources keeps its own name" {
+    // The arm this pins sits in front of an `else => DownloadFailed`, which is
+    // exactly how the distinction was lost before: nothing downstream can tell
+    // the machine's fault from the registry's once it collapses.
+    try std.testing.expectEqual(
+        BottleError.DownloadLocalResourceExhausted,
+        bottleErrorFromGhcr(ghcr_mod.GhcrError.DownloadLocalResourceExhausted),
+    );
+    try std.testing.expectEqual(
+        BottleError.DownloadRateLimited,
+        bottleErrorFromGhcr(ghcr_mod.GhcrError.DownloadRateLimited),
+    );
+    try std.testing.expectEqual(
+        BottleError.DownloadFailed,
+        bottleErrorFromGhcr(ghcr_mod.GhcrError.InvalidResponse),
+    );
+}
+
+/// Which registry faults keep their own name on the way up. Everything else
+/// is an ordinary download failure; the named ones each drive a different
+/// decision (no retry, back off, or blame the machine rather than the peer).
+fn bottleErrorFromGhcr(e: ghcr_mod.GhcrError) BottleError {
+    return switch (e) {
+        ghcr_mod.GhcrError.DownloadHttpClientError => BottleError.DownloadPermanent,
+        ghcr_mod.GhcrError.DownloadRateLimited => BottleError.DownloadRateLimited,
+        ghcr_mod.GhcrError.DownloadLocalResourceExhausted => BottleError.DownloadLocalResourceExhausted,
+        else => BottleError.DownloadFailed,
+    };
+}
+
 /// Formats `<dest_dir>/bottle.tar.gz` into `buf`; distinguishes path overflow
 /// from allocation failure so callers can surface a precise message.
 pub fn buildTmpArchivePath(buf: []u8, dest_dir: []const u8) BottleError![]const u8 {
@@ -169,12 +199,7 @@ pub fn download(
     var sink = HashingFileSink.init(io, tmp_file);
     const dl = ghcr.downloadBlob(http, repo, digest, &sink.writer, progress);
     tmp_file.close(io); // fd no longer needed; extract reopens by path
-    dl catch |e| return switch (e) {
-        ghcr_mod.GhcrError.DownloadHttpClientError => BottleError.DownloadPermanent,
-        ghcr_mod.GhcrError.DownloadRateLimited => BottleError.DownloadRateLimited,
-        ghcr_mod.GhcrError.DownloadLocalResourceExhausted => BottleError.DownloadLocalResourceExhausted,
-        else => BottleError.DownloadFailed,
-    };
+    dl catch |e| return bottleErrorFromGhcr(e);
 
     var raw: [32]u8 = undefined;
     sink.hasher.final(&raw);

--- a/src/core/bottle.zig
+++ b/src/core/bottle.zig
@@ -12,6 +12,9 @@ pub const BottleError = error{
     DownloadFailed,
     DownloadPermanent,
     DownloadRateLimited,
+    /// Local threads or file descriptors, not the registry. Retriable, since
+    /// a busy sibling worker freeing capacity is the usual cause.
+    DownloadLocalResourceExhausted,
     Sha256Mismatch,
     ExtractionFailed,
     OutOfMemory,
@@ -169,6 +172,7 @@ pub fn download(
     dl catch |e| return switch (e) {
         ghcr_mod.GhcrError.DownloadHttpClientError => BottleError.DownloadPermanent,
         ghcr_mod.GhcrError.DownloadRateLimited => BottleError.DownloadRateLimited,
+        ghcr_mod.GhcrError.DownloadLocalResourceExhausted => BottleError.DownloadLocalResourceExhausted,
         else => BottleError.DownloadFailed,
     };
 

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -29,6 +29,10 @@ pub const CaskError = error{
     // Also never succeeds on a retry: the manifest asked for a cleartext
     // origin for an artifact it declined to pin.
     InsecureOrigin,
+    // This machine ran out of threads or descriptors; the origin was never
+    // reached, so reporting it as a download failure sends the user to the
+    // wrong place.
+    DownloadLocalResourceExhausted,
     OutOfMemory,
 };
 
@@ -622,6 +626,7 @@ pub const CaskInstaller = struct {
             // A retry re-fetches the same manifest and refuses identically, so
             // this must not reach the user wearing a transient error's name.
             error.InsecureUrlScheme => return CaskError.InsecureOrigin,
+            error.WatchdogSpawnFailed => return CaskError.DownloadLocalResourceExhausted,
             else => return CaskError.DownloadFailed,
         };
         errdefer {

--- a/src/net/client.zig
+++ b/src/net/client.zig
@@ -68,6 +68,10 @@ pub const HeadResolveError = RedirectError || error{
     InsecureUrlScheme,
     HeadTimeout,
     Canceled,
+    /// This machine could not spare a thread or a pipe for the deadline.
+    /// Kept distinct from `RequestFailed` because the peer is fine and the
+    /// user's next move is local - retrying the network is not it.
+    WatchdogSpawnFailed,
 };
 
 /// What still vouches for a payload once the transport does not.
@@ -756,19 +760,12 @@ pub const HttpClient = struct {
                 // watchdog's connection stable by contract, not by stdlib
                 // branch order.
                 .redirect_behavior = .unhandled,
-            }, self.head_timeout_ns, &fired) catch |e| switch (self.headWalkError(&fired, e)) {
-                error.WatchdogSpawnFailed => return error.RequestFailed,
-                else => |mapped| return mapped,
-            };
+            }, self.head_timeout_ns, &fired) catch |e| return self.headWalkError(&fired, e);
             defer req.deinit();
 
             var redirect_buf: [32 * 1024]u8 = undefined;
-            const response = self.receiveHeadDeadlined(&req, &redirect_buf, self.remainingHopBudget(hop_start_ns), &fired) catch |e| switch (self.headWalkError(&fired, e)) {
-                // `HeadResolveError` stays closed: a watchdog that could not
-                // start is one more way the request failed.
-                error.WatchdogSpawnFailed => return error.RequestFailed,
-                else => |mapped| return mapped,
-            };
+            const response = self.receiveHeadDeadlined(&req, &redirect_buf, self.remainingHopBudget(hop_start_ns), &fired) catch |e|
+                return self.headWalkError(&fired, e);
 
             if (resolved.content_disposition == null) {
                 if (response.head.content_disposition) |cd| {

--- a/src/net/ghcr.zig
+++ b/src/net/ghcr.zig
@@ -15,6 +15,10 @@ pub const GhcrError = error{
     DownloadHttpClientError,
     DownloadHttpServerError,
     DownloadRateLimited,
+    /// This machine, not the registry: no thread or pipe was free to arm the
+    /// download's deadline. Distinct so a retry-the-network suggestion is not
+    /// offered for a fault the network cannot fix.
+    DownloadLocalResourceExhausted,
     Unauthorized,
     InvalidResponse,
     OutOfMemory,
@@ -285,10 +289,10 @@ pub const GhcrClient = struct {
                 error.HttpRedirectInvalid,
                 error.ResponseTooLarge,
                 error.ReadFailed,
-                error.WatchdogSpawnFailed,
                 error.HeadTimeout,
                 error.Canceled,
                 => return GhcrError.DownloadFailed,
+                error.WatchdogSpawnFailed => return GhcrError.DownloadLocalResourceExhausted,
             };
 
             if (status == 401) {


### PR DESCRIPTION
## Description

When malt could not spare a thread or a pipe to arm a download's deadline, the failure was reported as a network error - sending the user to debug a connection that was never even reached. It now keeps its own name through every download path, so the message points at the machine and the retry advice matches the actual fault.

## Related Issue

- None

## Notes for Reviewers
- None