### PR TITLE
refactor(update): keep the version notifier free of the UI layer

### DIFF
--- a/src/cli/version_notice.zig
+++ b/src/cli/version_notice.zig
@@ -1,0 +1,104 @@
+//! malt — renders the passive "a newer malt is available" heads-up.
+//!
+//! Lives in `cli/` because it is presentation: `update/notifier` decides
+//! whether a notice is due, this decides what it looks like. Keeping the
+//! ANSI and the stderr writes on this side is what lets the notifier stay a
+//! UI-agnostic leaf.
+
+const std = @import("std");
+
+const color = @import("../ui/color.zig");
+const output = @import("../ui/output.zig");
+const release = @import("../update/release.zig");
+
+/// Headline keeps the violet `notice` palette so an available update reads
+/// as a heads-up, not a warning; the action hint stays dim — reference
+/// material, not the message. Rendered inline (rather than via
+/// `output.notice`/`output.dim`) so the layout can sit flush-left under a
+/// blank-line separator, which reads better at the tail of any subcommand.
+pub fn print(latest_tag: []const u8, current_version: []const u8) void {
+    const latest_no_v = release.stripVPrefix(latest_tag);
+
+    var notice_buf: [4096]u8 = undefined;
+    const notice_msg = std.fmt.bufPrint(
+        &notice_buf,
+        "A newer malt is available: {s} (you're on {s}).",
+        .{ latest_no_v, current_version },
+    ) catch return;
+    const dim_msg = "Run 'mt version update' to upgrade, or set MALT_NO_VERSION_NOTIFIER=1 to silence this.";
+
+    const colorize = color.isColorEnabledForStderr();
+    const emoji = color.isEmojiEnabled();
+    const notice_prefix: []const u8 = if (emoji) "ⓘ " else "i ";
+    const dim_prefix: []const u8 = if (emoji) "▸ " else "> ";
+
+    // Blank line separates the heads-up from whatever the subcommand
+    // printed last. Safe: notifier fires post-dispatch, no other worker
+    // is writing concurrently here.
+    output.writeStderrAll("\n");
+
+    if (colorize) {
+        output.writeStderrAll(color.SemanticStyle.notice.code());
+        output.writeStderrAll(notice_prefix);
+        output.writeStderrAll(color.Style.reset.code());
+    } else {
+        output.writeStderrAll(notice_prefix);
+    }
+    output.writeStderrAll(notice_msg);
+    output.writeStderrAll("\n");
+
+    if (colorize) {
+        output.writeStderrAll(color.SemanticStyle.detail.code());
+        output.writeStderrAll(dim_prefix);
+        output.writeStderrAll(dim_msg);
+        output.writeStderrAll(color.Style.reset.code());
+    } else {
+        output.writeStderrAll(dim_prefix);
+        output.writeStderrAll(dim_msg);
+    }
+    output.writeStderrAll("\n");
+}
+
+// Pins the heads-up layout: blank-line separator + flush-left prefixes
+// in both palettes. The blank line keeps the notice from sticking to a
+// subcommand's last line of output; the flush margin keeps the glyphs
+// aligned with the user's prompt regardless of which subcommand ran.
+test "printNotice: blank-line + flush-left layout, color + emoji on (dark + basic)" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    color.setForTest(true, true);
+    color.setBackgroundForTest(color.Background.dark);
+    color.setTruecolorForTest(false);
+    output.beginStderrCapture(std.testing.allocator, &buf);
+    defer {
+        output.endStderrCapture();
+        color.setForTest(null, null);
+        color.setBackgroundForTest(null);
+        color.setTruecolorForTest(null);
+    }
+
+    print("v0.11.6", "0.11.0");
+
+    const want = "\n" ++
+        "\x1b[35mⓘ \x1b[0mA newer malt is available: 0.11.6 (you're on 0.11.0).\n" ++
+        "\x1b[2m▸ Run 'mt version update' to upgrade, or set MALT_NO_VERSION_NOTIFIER=1 to silence this.\x1b[0m\n";
+    try std.testing.expectEqualStrings(want, buf.items);
+}
+
+test "printNotice: no color, no emoji → flush-left ASCII layout" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    color.setForTest(false, false);
+    output.beginStderrCapture(std.testing.allocator, &buf);
+    defer {
+        output.endStderrCapture();
+        color.setForTest(null, null);
+    }
+
+    print("v0.11.6", "0.11.0");
+
+    const want = "\n" ++
+        "i A newer malt is available: 0.11.6 (you're on 0.11.0).\n" ++
+        "> Run 'mt version update' to upgrade, or set MALT_NO_VERSION_NOTIFIER=1 to silence this.\n";
+    try std.testing.expectEqualStrings(want, buf.items);
+}

--- a/src/cli/version_update.zig
+++ b/src/cli/version_update.zig
@@ -136,7 +136,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         // Nothing strictly newer to install — equal, or an ahead-of-latest
         // dev build. Freshen the passive notifier cache so a manual `--check`
         // stops the next invocation from nagging about an installed release.
-        notifier.markUpdatedTo(ctx, tag, current_version);
+        notifier.markUpdatedTo(ctx.io, ctx.environ, tag, current_version);
         output.info("Already up to date ({s})", .{current_version});
         return;
     }
@@ -288,7 +288,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
             output.info("Finish manually: sudo install -m 0755 -b -B .old {s} {s}", .{ new_binary, tp });
             output.info("Updated to {s} (previous {s} kept at {s}.old)", .{ latest, std.fs.path.basename(self_exe), self_exe });
             // Self is on the new version even though twin lagged — dismiss the nag.
-            notifier.markUpdatedTo(ctx, tag, latest);
+            notifier.markUpdatedTo(ctx.io, ctx.environ, tag, latest);
             return;
         };
         // Collapse the legacy dual-binary layout into the symlink layout
@@ -299,12 +299,12 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         };
 
         output.info("Updated {s} and {s} to {s} (previous kept at *.old)", .{ self_exe, tp, latest });
-        notifier.markUpdatedTo(ctx, tag, latest);
+        notifier.markUpdatedTo(ctx.io, ctx.environ, tag, latest);
         return;
     }
 
     output.info("Updated to {s} (previous kept at {s}.old)", .{ latest, self_exe });
-    notifier.markUpdatedTo(ctx, tag, latest);
+    notifier.markUpdatedTo(ctx.io, ctx.environ, tag, latest);
 }
 
 /// How the previous swap was carried out. Threaded through twin handling

--- a/src/core/json_escape.zig
+++ b/src/core/json_escape.zig
@@ -1,0 +1,76 @@
+//! malt — RFC 8259 string escaping for handwritten JSON output.
+//!
+//! Lives outside `ui/` because the leaves emit JSON too: the version-notifier
+//! cache writes its state file with these, and a leaf reaching into the UI
+//! layer for an escaper is the coupling the modularity constraint forbids.
+
+const std = @import("std");
+
+/// Write `s` to `w` as a JSON string literal — surrounding quotes plus RFC 8259
+/// escapes for `"`, `\`, and control characters. Use this wherever handwritten
+/// JSON output embeds an identifier, tap name, version string, file path, or
+/// anything else that might contain special characters.
+pub fn jsonStr(w: *std.Io.Writer, s: []const u8) !void {
+    try w.writeAll("\"");
+    var start: usize = 0;
+    for (s, 0..) |byte, i| {
+        const escape: ?[]const u8 = switch (byte) {
+            '"' => "\\\"",
+            '\\' => "\\\\",
+            '\n' => "\\n",
+            '\r' => "\\r",
+            '\t' => "\\t",
+            0x08 => "\\b",
+            0x0c => "\\f",
+            else => null,
+        };
+        if (escape) |esc| {
+            if (i > start) try w.writeAll(s[start..i]);
+            try w.writeAll(esc);
+            start = i + 1;
+        } else if (byte < 0x20) {
+            if (i > start) try w.writeAll(s[start..i]);
+            var hex_buf: [6]u8 = undefined;
+            // `\u` + 4 hex digits = 6 bytes exactly; bufPrint cannot overflow a 6-byte buffer.
+            const hex = std.fmt.bufPrint(&hex_buf, "\\u{x:0>4}", .{byte}) catch unreachable;
+            try w.writeAll(hex);
+            start = i + 1;
+        }
+    }
+    if (start < s.len) try w.writeAll(s[start..]);
+    try w.writeAll("\"");
+}
+
+/// Write a `["a","b",...]` JSON array of RFC-8259-escaped strings to `w`.
+pub fn jsonStringArray(w: *std.Io.Writer, items: []const []const u8) !void {
+    try w.writeAll("[");
+    for (items, 0..) |item, i| {
+        if (i != 0) try w.writeAll(",");
+        try jsonStr(w, item);
+    }
+    try w.writeAll("]");
+}
+
+test "jsonStr escapes the characters that would otherwise break the document" {
+    var buf: [128]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+    try jsonStr(&w, "a\"b\\c\nd\te");
+    try std.testing.expectEqualStrings("\"a\\\"b\\\\c\\nd\\te\"", w.buffered());
+}
+
+test "jsonStr escapes the control bytes that have no short form" {
+    // A tap name or path carrying a raw control byte must not be emitted
+    // literally - consumers reject the document, and the value is attacker
+    // influenced on the cask/tap paths.
+    var buf: [128]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+    try jsonStr(&w, "a\x01b");
+    try std.testing.expectEqualStrings("\"a\\u0001b\"", w.buffered());
+}
+
+test "jsonStringArray wraps each escaped element" {
+    var buf: [128]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+    try jsonStringArray(&w, &.{ "one", "t\"wo" });
+    try std.testing.expectEqualStrings("[\"one\",\"t\\\"wo\"]", w.buffered());
+}

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -135,6 +135,7 @@ pub const tui_tab_services = @import("tui/services_tab.zig");
 pub const tui_term = @import("tui/term.zig");
 pub const update_cleanup = @import("update/cleanup.zig");
 pub const update_notifier = @import("update/notifier.zig");
+pub const cli_version_notice = @import("cli/version_notice.zig");
 pub const update_origin = @import("update/origin.zig");
 pub const update_release = @import("update/release.zig");
 pub const update_swap = @import("update/swap.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -666,7 +666,6 @@ pub fn main(init: std.process.Init.Minimal) !void {
         // Best-effort passive notice on successful subcommands. Owns its
         // own suppression list (CI, --quiet/--json/ndjson/--dry-run, env
         // opt-out, non-TTY, brew origin, version/help meta-commands).
-        var notice_tag_buf: [notifier.max_tag_len]u8 = undefined;
         const gates: notifier.Gates = .{
             .quiet = output_mod.isQuiet(),
             .json = output_mod.isJson(),
@@ -681,8 +680,10 @@ pub fn main(init: std.process.Init.Minimal) !void {
             version,
             cmd_str,
             gates,
-            &notice_tag_buf,
-        )) |latest_tag| version_notice.print(latest_tag, version);
+        )) |latest_tag| {
+            defer allocator.free(latest_tag);
+            version_notice.print(latest_tag, version);
+        }
     } else {
         // Unknown command — slug-shaped inputs (`user/repo`,
         // `user/repo/formula`) exit with a malt-native verb hint;

--- a/src/main.zig
+++ b/src/main.zig
@@ -42,6 +42,7 @@ const theme_file = @import("fs/theme_file.zig");
 const output_mod = @import("ui/output.zig");
 const progress_mod = @import("ui/progress.zig");
 const notifier = @import("update/notifier.zig");
+const version_notice = @import("cli/version_notice.zig");
 const version_mod = @import("version.zig");
 const version = version_mod.value;
 
@@ -665,7 +666,23 @@ pub fn main(init: std.process.Init.Minimal) !void {
         // Best-effort passive notice on successful subcommands. Owns its
         // own suppression list (CI, --quiet/--json/ndjson/--dry-run, env
         // opt-out, non-TTY, brew origin, version/help meta-commands).
-        notifier.maybeNotify(&ctx, allocator, version, cmd_str);
+        var notice_tag_buf: [notifier.max_tag_len]u8 = undefined;
+        const gates: notifier.Gates = .{
+            .quiet = output_mod.isQuiet(),
+            .json = output_mod.isJson(),
+            .ndjson = output_mod.isNdjson(),
+            .dry_run = output_mod.isDryRun(),
+        };
+        if (notifier.pendingNotice(
+            ctx.io,
+            ctx.environ,
+            ctx.offline,
+            allocator,
+            version,
+            cmd_str,
+            gates,
+            &notice_tag_buf,
+        )) |latest_tag| version_notice.print(latest_tag, version);
     } else {
         // Unknown command — slug-shaped inputs (`user/repo`,
         // `user/repo/formula`) exit with a malt-native verb hint;

--- a/src/ui/output.zig
+++ b/src/ui/output.zig
@@ -2,6 +2,7 @@
 //! Human + JSON output formatting.
 
 const std = @import("std");
+const json_escape = @import("../core/json_escape.zig");
 /// Process-wide io seeded once from `main` via `setRuntime`. Defaults to
 /// `debug_io` so tests that don't seed see deterministic, allocation-
 /// free behaviour.
@@ -505,50 +506,11 @@ pub fn writeField(
     try w.writeAll("\n");
 }
 
-/// Write `s` to `w` as a JSON string literal — surrounding quotes plus RFC 8259
-/// escapes for `"`, `\`, and control characters. Use this wherever handwritten
-/// JSON output embeds an identifier, tap name, version string, file path, or
-/// anything else that might contain special characters.
-pub fn jsonStr(w: *std.Io.Writer, s: []const u8) !void {
-    try w.writeAll("\"");
-    var start: usize = 0;
-    for (s, 0..) |byte, i| {
-        const escape: ?[]const u8 = switch (byte) {
-            '"' => "\\\"",
-            '\\' => "\\\\",
-            '\n' => "\\n",
-            '\r' => "\\r",
-            '\t' => "\\t",
-            0x08 => "\\b",
-            0x0c => "\\f",
-            else => null,
-        };
-        if (escape) |esc| {
-            if (i > start) try w.writeAll(s[start..i]);
-            try w.writeAll(esc);
-            start = i + 1;
-        } else if (byte < 0x20) {
-            if (i > start) try w.writeAll(s[start..i]);
-            var hex_buf: [6]u8 = undefined;
-            // `\u` + 4 hex digits = 6 bytes exactly; bufPrint cannot overflow a 6-byte buffer.
-            const hex = std.fmt.bufPrint(&hex_buf, "\\u{x:0>4}", .{byte}) catch unreachable;
-            try w.writeAll(hex);
-            start = i + 1;
-        }
-    }
-    if (start < s.len) try w.writeAll(s[start..]);
-    try w.writeAll("\"");
-}
-
-/// Write a `["a","b",...]` JSON array of RFC-8259-escaped strings to `w`.
-pub fn jsonStringArray(w: *std.Io.Writer, items: []const []const u8) !void {
-    try w.writeAll("[");
-    for (items, 0..) |item, i| {
-        if (i != 0) try w.writeAll(",");
-        try jsonStr(w, item);
-    }
-    try w.writeAll("]");
-}
+/// JSON string escaping lives in `core/json_escape.zig` so the leaves can
+/// reach it without importing the UI layer. Re-exported here because every
+/// `--json` emitter in `cli/` already writes through this module.
+pub const jsonStr = json_escape.jsonStr;
+pub const jsonStringArray = json_escape.jsonStringArray;
 
 /// Version stamped on every read command's `--json` root (`list`, `info`,
 /// `outdated`, `services`, `doctor`). Bump when a documented field shape

--- a/src/update/notifier.zig
+++ b/src/update/notifier.zig
@@ -53,7 +53,10 @@ pub const Gates = struct {
 };
 
 /// Bounded so a cache miss can't drag the user's hot path. Fires after
-/// dispatch, so the command's output is already on screen.
+/// dispatch, so the command's output is already on screen. Covers the whole
+/// hop - DNS, connect and TLS included - so a cold handshake on a slow link
+/// can spend it and drop the user into the failure backoff rather than
+/// stalling them.
 pub const network_timeout_ns: u64 = 1_500 * std.time.ns_per_ms;
 
 /// Hold every phase of the probe to the bound above. Connect, head read and
@@ -124,15 +127,10 @@ pub fn markUpdatedTo(io: std.Io, environ: std.process.Environ, latest_tag: []con
     }) catch {};
 }
 
-/// Longest tag the notice will carry back. Releases are short semver tags;
-/// anything longer is a malformed feed, and dropping the notice is the
-/// best-effort answer.
-pub const max_tag_len: usize = 64;
-
 /// Best-effort entrypoint: returns the tag to announce, or null when no
 /// notice is due. `cmd_str` is the canonical subcommand name; `version`/`help`
-/// aliases bypass the notice via the suppression list. The tag is copied into
-/// `tag_buf` because the cache state it comes from is freed on the way out.
+/// aliases bypass the notice via the suppression list. The tag is owned by the
+/// caller: the cache state it is read from is freed on the way out.
 pub fn pendingNotice(
     io: std.Io,
     environ: std.process.Environ,
@@ -141,10 +139,9 @@ pub fn pendingNotice(
     current_version: []const u8,
     cmd_str: []const u8,
     gates: Gates,
-    tag_buf: []u8,
 ) ?[]const u8 {
     if (suppressed(io, environ, cmd_str, gates)) return null;
-    return runNotify(io, environ, offline, allocator, current_version, tag_buf) catch null;
+    return runNotify(io, environ, offline, allocator, current_version) catch null;
 }
 
 fn runNotify(
@@ -153,7 +150,6 @@ fn runNotify(
     offline: bool,
     allocator: std.mem.Allocator,
     current_version: []const u8,
-    tag_buf: []u8,
 ) !?[]const u8 {
     var path_buf: [std.fs.max_path_bytes]u8 = undefined;
     const path = cachePath(environ, &path_buf) orelse return null;
@@ -196,9 +192,9 @@ fn runNotify(
 
     const s = state orelse return null;
     if (!shouldNotify(current_version, s.latest_tag, s.current_seen)) return null;
-    if (s.latest_tag.len > tag_buf.len) return null;
-    @memcpy(tag_buf[0..s.latest_tag.len], s.latest_tag);
-    return tag_buf[0..s.latest_tag.len];
+    // Duped rather than borrowed: `state` is freed on the way out, and a
+    // length cap here would silently drop a notice the old code printed.
+    return try allocator.dupe(u8, s.latest_tag);
 }
 
 /// On network failure `state` is left untouched so the caller's old

--- a/src/update/notifier.zig
+++ b/src/update/notifier.zig
@@ -7,11 +7,8 @@
 
 const std = @import("std");
 
-const AppCtx = @import("../app_ctx.zig").AppCtx;
 const signals = @import("../core/signals.zig");
 const client_mod = @import("../net/client.zig");
-const color = @import("../ui/color.zig");
-const output = @import("../ui/output.zig");
 const origin_mod = @import("origin.zig");
 const release = @import("release.zig");
 const cache = @import("notifier/cache.zig");
@@ -41,6 +38,20 @@ pub const freeState = cache.freeState;
 pub const readCache = cache.readCache;
 pub const writeCache = cache.writeCache;
 
+/// Output modes that suppress the notice. They are CLI-layer process state,
+/// so the caller reads them and hands the answer down rather than the leaf
+/// reaching back into the UI it must not know about.
+pub const Gates = struct {
+    quiet: bool = false,
+    json: bool = false,
+    ndjson: bool = false,
+    dry_run: bool = false,
+
+    pub fn anySuppress(self: Gates) bool {
+        return self.quiet or self.json or self.ndjson or self.dry_run;
+    }
+};
+
 /// Bounded so a cache miss can't drag the user's hot path. Fires after
 /// dispatch, so the command's output is already on screen.
 pub const network_timeout_ns: u64 = 1_500 * std.time.ns_per_ms;
@@ -55,13 +66,13 @@ pub fn applyProbeBudget(http: *client_mod.HttpClient) void {
     http.retry_backoff_ms = &.{};
 }
 
-fn fetchLatestTag(ctx: *const AppCtx, allocator: std.mem.Allocator) ![]u8 {
-    var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);
+fn fetchLatestTag(io: std.Io, environ: std.process.Environ, offline: bool, allocator: std.mem.Allocator) ![]u8 {
+    var http = client_mod.HttpClient.init(io, environ, allocator);
     applyProbeBudget(&http);
     // SIGINT on the prompt-after-success window collapses the probe
     // instead of stalling the user behind the 1.5 s deadline.
     http.cancel = signals.isInterrupted;
-    http.offline = ctx.offline;
+    http.offline = offline;
     defer http.deinit();
     var resp = try http.get(release.releases_latest_url);
     defer resp.deinit();
@@ -88,9 +99,9 @@ fn originIsHomebrew(io: std.Io) bool {
 /// Cheapest checks first. `originIsHomebrew` is deliberately not here —
 /// the `executablePath` + `realpath` pair is deferred to `runNotify` so
 /// the cache-fresh hot path skips it entirely.
-fn suppressed(io: std.Io, environ: std.process.Environ, cmd_str: []const u8) bool {
+fn suppressed(io: std.Io, environ: std.process.Environ, cmd_str: []const u8, gates: Gates) bool {
     if (policy.isSkippedCommand(cmd_str)) return true;
-    if (output.isQuiet() or output.isJson() or output.isNdjson() or output.isDryRun()) return true;
+    if (gates.anySuppress()) return true;
     if (policy.notifierDisabled(environ)) return true;
     if (policy.isCi(environ)) return true;
     // The assume-TTY seam lets scripted runs exercise the notice without a
@@ -101,81 +112,56 @@ fn suppressed(io: std.Io, environ: std.process.Environ, cmd_str: []const u8) boo
     return false;
 }
 
-/// Headline keeps the violet `notice` palette so an available update reads
-/// as a heads-up, not a warning; the action hint stays dim — reference
-/// material, not the message. Rendered inline (rather than via
-/// `output.notice`/`output.dim`) so the layout can sit flush-left under a
-/// blank-line separator, which reads better at the tail of any subcommand.
-fn printNotice(latest_tag: []const u8, current_version: []const u8) void {
-    const latest_no_v = release.stripVPrefix(latest_tag);
-
-    var notice_buf: [4096]u8 = undefined;
-    const notice_msg = std.fmt.bufPrint(
-        &notice_buf,
-        "A newer malt is available: {s} (you're on {s}).",
-        .{ latest_no_v, current_version },
-    ) catch return;
-    const dim_msg = "Run 'mt version update' to upgrade, or set MALT_NO_VERSION_NOTIFIER=1 to silence this.";
-
-    const colorize = color.isColorEnabledForStderr();
-    const emoji = color.isEmojiEnabled();
-    const notice_prefix: []const u8 = if (emoji) "ⓘ " else "i ";
-    const dim_prefix: []const u8 = if (emoji) "▸ " else "> ";
-
-    // Blank line separates the heads-up from whatever the subcommand
-    // printed last. Safe: notifier fires post-dispatch, no other worker
-    // is writing concurrently here.
-    output.writeStderrAll("\n");
-
-    if (colorize) {
-        output.writeStderrAll(color.SemanticStyle.notice.code());
-        output.writeStderrAll(notice_prefix);
-        output.writeStderrAll(color.Style.reset.code());
-    } else {
-        output.writeStderrAll(notice_prefix);
-    }
-    output.writeStderrAll(notice_msg);
-    output.writeStderrAll("\n");
-
-    if (colorize) {
-        output.writeStderrAll(color.SemanticStyle.detail.code());
-        output.writeStderrAll(dim_prefix);
-        output.writeStderrAll(dim_msg);
-        output.writeStderrAll(color.Style.reset.code());
-    } else {
-        output.writeStderrAll(dim_prefix);
-        output.writeStderrAll(dim_msg);
-    }
-    output.writeStderrAll("\n");
-}
-
 /// Best-effort cache write so a successful self-update silences the
 /// nag immediately, not on the next 24h refresh.
-pub fn markUpdatedTo(ctx: *const AppCtx, latest_tag: []const u8, current_version: []const u8) void {
+pub fn markUpdatedTo(io: std.Io, environ: std.process.Environ, latest_tag: []const u8, current_version: []const u8) void {
     var path_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const path = cachePath(ctx.environ, &path_buf) orelse return;
-    writeCache(ctx.io, path, .{
-        .checked_at = std.Io.Clock.real.now(ctx.io).toSeconds(),
+    const path = cachePath(environ, &path_buf) orelse return;
+    writeCache(io, path, .{
+        .checked_at = std.Io.Clock.real.now(io).toSeconds(),
         .latest_tag = latest_tag,
         .current_seen = current_version,
     }) catch {};
 }
 
-/// Best-effort entrypoint. `cmd_str` is the canonical subcommand name;
-/// `version`/`help` aliases bypass the notice via the suppression list.
-pub fn maybeNotify(ctx: *const AppCtx, allocator: std.mem.Allocator, current_version: []const u8, cmd_str: []const u8) void {
-    if (suppressed(ctx.io, ctx.environ, cmd_str)) return;
-    runNotify(ctx, allocator, current_version) catch {};
+/// Longest tag the notice will carry back. Releases are short semver tags;
+/// anything longer is a malformed feed, and dropping the notice is the
+/// best-effort answer.
+pub const max_tag_len: usize = 64;
+
+/// Best-effort entrypoint: returns the tag to announce, or null when no
+/// notice is due. `cmd_str` is the canonical subcommand name; `version`/`help`
+/// aliases bypass the notice via the suppression list. The tag is copied into
+/// `tag_buf` because the cache state it comes from is freed on the way out.
+pub fn pendingNotice(
+    io: std.Io,
+    environ: std.process.Environ,
+    offline: bool,
+    allocator: std.mem.Allocator,
+    current_version: []const u8,
+    cmd_str: []const u8,
+    gates: Gates,
+    tag_buf: []u8,
+) ?[]const u8 {
+    if (suppressed(io, environ, cmd_str, gates)) return null;
+    return runNotify(io, environ, offline, allocator, current_version, tag_buf) catch null;
 }
 
-fn runNotify(ctx: *const AppCtx, allocator: std.mem.Allocator, current_version: []const u8) !void {
+fn runNotify(
+    io: std.Io,
+    environ: std.process.Environ,
+    offline: bool,
+    allocator: std.mem.Allocator,
+    current_version: []const u8,
+    tag_buf: []u8,
+) !?[]const u8 {
     var path_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const path = cachePath(ctx.environ, &path_buf) orelse return;
+    const path = cachePath(environ, &path_buf) orelse return null;
 
-    var state: ?State = readCache(ctx.io, allocator, path) catch null;
+    var state: ?State = readCache(io, allocator, path) catch null;
     defer if (state) |s| freeState(allocator, s);
 
-    const now = std.Io.Clock.real.now(ctx.io).toSeconds();
+    const now = std.Io.Clock.real.now(io).toSeconds();
 
     // Whether the cached view already says the user is behind. Computed
     // first so a behind state can shorten the refresh window below — a
@@ -194,23 +180,25 @@ fn runNotify(ctx: *const AppCtx, allocator: std.mem.Allocator, current_version: 
     // The 33%-savings clause: cache fresh + no notice due → return without
     // touching `executablePath`/`realpath`. The dominant path on a healthy
     // workstation between refresh windows.
-    if (!need_refresh and !wants_print) return;
+    if (!need_refresh and !wants_print) return null;
 
     // Brew installs are owned by `brew upgrade --cask malt`; refresh and
     // print both make no sense for them. Origin check is a 2-syscall
     // executablePath + realpath, paid only on this rare-action path.
-    if (originIsHomebrew(ctx.io)) return;
+    if (originIsHomebrew(io)) return null;
 
     if (need_refresh) {
         // Don't make the user wait out a 1.5s HTTP timeout after Ctrl-C.
         // Same convention as `cli/install.zig` and `cli/migrate.zig`.
-        if (signals.isInterrupted()) return;
-        refreshOnce(ctx, allocator, path, &state, now, current_version) catch {};
+        if (signals.isInterrupted()) return null;
+        refreshOnce(io, environ, offline, allocator, path, &state, now, current_version) catch {};
     }
 
-    const s = state orelse return;
-    if (!shouldNotify(current_version, s.latest_tag, s.current_seen)) return;
-    printNotice(s.latest_tag, current_version);
+    const s = state orelse return null;
+    if (!shouldNotify(current_version, s.latest_tag, s.current_seen)) return null;
+    if (s.latest_tag.len > tag_buf.len) return null;
+    @memcpy(tag_buf[0..s.latest_tag.len], s.latest_tag);
+    return tag_buf[0..s.latest_tag.len];
 }
 
 /// On network failure `state` is left untouched so the caller's old
@@ -218,15 +206,17 @@ fn runNotify(ctx: *const AppCtx, allocator: std.mem.Allocator, current_version: 
 /// `last_attempt` marker so the next invocation skips the probe until
 /// `failure_backoff_secs` has elapsed.
 fn refreshOnce(
-    ctx: *const AppCtx,
+    io: std.Io,
+    environ: std.process.Environ,
+    offline: bool,
     allocator: std.mem.Allocator,
     path: []const u8,
     state: *?State,
     now: i64,
     current_version: []const u8,
 ) !void {
-    const tag = fetchLatestTag(ctx, allocator) catch |err| {
-        writeFailureMarker(ctx.io, path, state.*, now, current_version);
+    const tag = fetchLatestTag(io, environ, offline, allocator) catch |err| {
+        writeFailureMarker(io, path, state.*, now, current_version);
         return err;
     };
     errdefer allocator.free(tag);
@@ -237,7 +227,7 @@ fn refreshOnce(
     const seen_dup = try allocator.dupe(u8, prior_seen);
     errdefer allocator.free(seen_dup);
 
-    writeCache(ctx.io, path, .{
+    writeCache(io, path, .{
         .checked_at = now,
         .latest_tag = tag,
         .current_seen = prior_seen,
@@ -296,50 +286,6 @@ test "applyProbeBudget: the probe does not retry" {
     applyProbeBudget(&http);
 
     try std.testing.expectEqual(@as(usize, 0), http.retry_backoff_ms.len);
-}
-
-// Pins the heads-up layout: blank-line separator + flush-left prefixes
-// in both palettes. The blank line keeps the notice from sticking to a
-// subcommand's last line of output; the flush margin keeps the glyphs
-// aligned with the user's prompt regardless of which subcommand ran.
-test "printNotice: blank-line + flush-left layout, color + emoji on (dark + basic)" {
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(std.testing.allocator);
-    color.setForTest(true, true);
-    color.setBackgroundForTest(color.Background.dark);
-    color.setTruecolorForTest(false);
-    output.beginStderrCapture(std.testing.allocator, &buf);
-    defer {
-        output.endStderrCapture();
-        color.setForTest(null, null);
-        color.setBackgroundForTest(null);
-        color.setTruecolorForTest(null);
-    }
-
-    printNotice("v0.11.6", "0.11.0");
-
-    const want = "\n" ++
-        "\x1b[35mⓘ \x1b[0mA newer malt is available: 0.11.6 (you're on 0.11.0).\n" ++
-        "\x1b[2m▸ Run 'mt version update' to upgrade, or set MALT_NO_VERSION_NOTIFIER=1 to silence this.\x1b[0m\n";
-    try std.testing.expectEqualStrings(want, buf.items);
-}
-
-test "printNotice: no color, no emoji → flush-left ASCII layout" {
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(std.testing.allocator);
-    color.setForTest(false, false);
-    output.beginStderrCapture(std.testing.allocator, &buf);
-    defer {
-        output.endStderrCapture();
-        color.setForTest(null, null);
-    }
-
-    printNotice("v0.11.6", "0.11.0");
-
-    const want = "\n" ++
-        "i A newer malt is available: 0.11.6 (you're on 0.11.0).\n" ++
-        "> Run 'mt version update' to upgrade, or set MALT_NO_VERSION_NOTIFIER=1 to silence this.\n";
-    try std.testing.expectEqualStrings(want, buf.items);
 }
 
 // Submodules carry their own inline tests; pulling them in here keeps the

--- a/src/update/notifier/cache.zig
+++ b/src/update/notifier/cache.zig
@@ -7,7 +7,7 @@ const std = @import("std");
 
 const atomic = @import("../../fs/atomic.zig");
 const read = @import("../../fs/read.zig");
-const output = @import("../../ui/output.zig");
+const json_escape = @import("../../core/json_escape.zig");
 
 const cache_filename = "version-notify.json";
 
@@ -71,9 +71,9 @@ pub fn encodeState(buf: []u8, state: State) ![]u8 {
     const num = try std.fmt.bufPrint(&num_buf, "{d}", .{state.checked_at});
     try w.writeAll(num);
     try w.writeAll(",\"latest_tag\":");
-    try output.jsonStr(&w, state.latest_tag);
+    try json_escape.jsonStr(&w, state.latest_tag);
     try w.writeAll(",\"current_seen\":");
-    try output.jsonStr(&w, state.current_seen);
+    try json_escape.jsonStr(&w, state.current_seen);
     try w.writeAll(",\"last_attempt\":");
     const att = try std.fmt.bufPrint(&num_buf, "{d}", .{state.last_attempt});
     try w.writeAll(att);

--- a/tests/version_notify_test.zig
+++ b/tests/version_notify_test.zig
@@ -367,3 +367,136 @@ test "readCache: corrupt file surfaces InvalidPayload (caller can choose to igno
 
     try testing.expectError(error.InvalidPayload, notifier.readCache(io, testing.allocator, path));
 }
+
+// `pendingNotice` is the seam the CLI actually calls, and nothing exercised it
+// before or after the rendering split. These drive it against a seeded cache
+// so the decision half is pinned without touching the network: the cache is
+// fresh, so no refresh is attempted.
+fn seedFreshCache(io: std.Io, path: []const u8, now: i64, latest: []const u8, seen: []const u8) !void {
+    try notifier.writeCache(io, path, .{
+        .checked_at = now,
+        .latest_tag = latest,
+        .current_seen = seen,
+        .last_attempt = now,
+    });
+}
+
+test "pendingNotice hands back the tag to announce when the user is behind" {
+    const allocator = testing.allocator;
+    const io = std.Options.debug_io;
+
+    const dir_base = try test_io.uniqueTempPath(allocator, "notify", "pending");
+    defer allocator.free(dir_base);
+    const dir = try std.fmt.allocPrintSentinel(allocator, "{s}", .{dir_base}, 0);
+    defer allocator.free(dir);
+    fs_compat.deleteTreeAbsolute(io, dir) catch {};
+    try fs_compat.makeDirAbsolute(io, dir);
+    defer fs_compat.deleteTreeAbsolute(io, dir) catch {};
+
+    _ = c_env.setenv("MALT_CACHE", dir.ptr, 1);
+    defer _ = c_env.unsetenv("MALT_CACHE");
+    // The notice is stderr-gated on a TTY, which a test run does not have.
+    _ = c_env.setenv("MALT_VERSION_NOTIFIER_ASSUME_TTY", "1", 1);
+    defer _ = c_env.unsetenv("MALT_VERSION_NOTIFIER_ASSUME_TTY");
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, "{s}/version-notify.json", .{dir});
+    const now = std.Io.Clock.real.now(io).toSeconds();
+    try seedFreshCache(io, path, now, "v0.99.0", "0.10.0");
+
+    const tag = notifier.pendingNotice(
+        io,
+        app_ctx.processEnviron(),
+        false,
+        allocator,
+        "0.10.0",
+        "install",
+        .{},
+    ) orelse return error.TestExpectedNonNull;
+    defer allocator.free(tag);
+
+    try testing.expectEqualStrings("v0.99.0", tag);
+}
+
+test "pendingNotice stays silent when the output mode suppresses it" {
+    // `--json` and friends are machine-readable surfaces; a heads-up on stderr
+    // is noise there, and the gate now lives with the caller that owns it.
+    const allocator = testing.allocator;
+    const io = std.Options.debug_io;
+
+    const dir_base = try test_io.uniqueTempPath(allocator, "notify", "gated");
+    defer allocator.free(dir_base);
+    const dir = try std.fmt.allocPrintSentinel(allocator, "{s}", .{dir_base}, 0);
+    defer allocator.free(dir);
+    fs_compat.deleteTreeAbsolute(io, dir) catch {};
+    try fs_compat.makeDirAbsolute(io, dir);
+    defer fs_compat.deleteTreeAbsolute(io, dir) catch {};
+
+    _ = c_env.setenv("MALT_CACHE", dir.ptr, 1);
+    defer _ = c_env.unsetenv("MALT_CACHE");
+    _ = c_env.setenv("MALT_VERSION_NOTIFIER_ASSUME_TTY", "1", 1);
+    defer _ = c_env.unsetenv("MALT_VERSION_NOTIFIER_ASSUME_TTY");
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, "{s}/version-notify.json", .{dir});
+    const now = std.Io.Clock.real.now(io).toSeconds();
+    try seedFreshCache(io, path, now, "v0.99.0", "0.10.0");
+
+    inline for (.{
+        notifier.Gates{ .json = true },
+        notifier.Gates{ .quiet = true },
+        notifier.Gates{ .ndjson = true },
+        notifier.Gates{ .dry_run = true },
+    }) |gates| {
+        const tag = notifier.pendingNotice(
+            io,
+            app_ctx.processEnviron(),
+            false,
+            allocator,
+            "0.10.0",
+            "install",
+            gates,
+        );
+        if (tag) |t| {
+            allocator.free(t);
+            return error.TestUnexpectedResult;
+        }
+    }
+}
+
+test "pendingNotice stays silent on a command that never carries the notice" {
+    const allocator = testing.allocator;
+    const io = std.Options.debug_io;
+
+    const dir_base = try test_io.uniqueTempPath(allocator, "notify", "skipcmd");
+    defer allocator.free(dir_base);
+    const dir = try std.fmt.allocPrintSentinel(allocator, "{s}", .{dir_base}, 0);
+    defer allocator.free(dir);
+    fs_compat.deleteTreeAbsolute(io, dir) catch {};
+    try fs_compat.makeDirAbsolute(io, dir);
+    defer fs_compat.deleteTreeAbsolute(io, dir) catch {};
+
+    _ = c_env.setenv("MALT_CACHE", dir.ptr, 1);
+    defer _ = c_env.unsetenv("MALT_CACHE");
+    _ = c_env.setenv("MALT_VERSION_NOTIFIER_ASSUME_TTY", "1", 1);
+    defer _ = c_env.unsetenv("MALT_VERSION_NOTIFIER_ASSUME_TTY");
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, "{s}/version-notify.json", .{dir});
+    const now = std.Io.Clock.real.now(io).toSeconds();
+    try seedFreshCache(io, path, now, "v0.99.0", "0.10.0");
+
+    const tag = notifier.pendingNotice(
+        io,
+        app_ctx.processEnviron(),
+        false,
+        allocator,
+        "0.10.0",
+        "version",
+        .{},
+    );
+    if (tag) |t| {
+        allocator.free(t);
+        return error.TestUnexpectedResult;
+    }
+}

--- a/tests/version_notify_test.zig
+++ b/tests/version_notify_test.zig
@@ -381,6 +381,14 @@ fn seedFreshCache(io: std.Io, path: []const u8, now: i64, latest: []const u8, se
     });
 }
 
+/// `pendingNotice` reads every variable it consults through its `environ`
+/// argument, so these tests hand it one they own. The host's would carry `CI`
+/// on a runner, which the notifier treats as a hard suppressor — the notice
+/// would vanish for a reason none of these tests are about.
+fn fixtureEnviron(entries: [:null]const ?[*:0]const u8) std.process.Environ {
+    return .{ .block = .{ .slice = entries } };
+}
+
 test "pendingNotice hands back the tag to announce when the user is behind" {
     const allocator = testing.allocator;
     const io = std.Options.debug_io;
@@ -393,11 +401,10 @@ test "pendingNotice hands back the tag to announce when the user is behind" {
     try fs_compat.makeDirAbsolute(io, dir);
     defer fs_compat.deleteTreeAbsolute(io, dir) catch {};
 
-    _ = c_env.setenv("MALT_CACHE", dir.ptr, 1);
-    defer _ = c_env.unsetenv("MALT_CACHE");
+    const cache_var = try std.fmt.allocPrintSentinel(allocator, "MALT_CACHE={s}", .{dir}, 0);
+    defer allocator.free(cache_var);
     // The notice is stderr-gated on a TTY, which a test run does not have.
-    _ = c_env.setenv("MALT_VERSION_NOTIFIER_ASSUME_TTY", "1", 1);
-    defer _ = c_env.unsetenv("MALT_VERSION_NOTIFIER_ASSUME_TTY");
+    const entries = [_:null]?[*:0]const u8{ cache_var.ptr, "MALT_VERSION_NOTIFIER_ASSUME_TTY=1" };
 
     var path_buf: [std.fs.max_path_bytes]u8 = undefined;
     const path = try std.fmt.bufPrint(&path_buf, "{s}/version-notify.json", .{dir});
@@ -406,7 +413,7 @@ test "pendingNotice hands back the tag to announce when the user is behind" {
 
     const tag = notifier.pendingNotice(
         io,
-        app_ctx.processEnviron(),
+        fixtureEnviron(&entries),
         false,
         allocator,
         "0.10.0",
@@ -432,10 +439,9 @@ test "pendingNotice stays silent when the output mode suppresses it" {
     try fs_compat.makeDirAbsolute(io, dir);
     defer fs_compat.deleteTreeAbsolute(io, dir) catch {};
 
-    _ = c_env.setenv("MALT_CACHE", dir.ptr, 1);
-    defer _ = c_env.unsetenv("MALT_CACHE");
-    _ = c_env.setenv("MALT_VERSION_NOTIFIER_ASSUME_TTY", "1", 1);
-    defer _ = c_env.unsetenv("MALT_VERSION_NOTIFIER_ASSUME_TTY");
+    const cache_var = try std.fmt.allocPrintSentinel(allocator, "MALT_CACHE={s}", .{dir}, 0);
+    defer allocator.free(cache_var);
+    const entries = [_:null]?[*:0]const u8{ cache_var.ptr, "MALT_VERSION_NOTIFIER_ASSUME_TTY=1" };
 
     var path_buf: [std.fs.max_path_bytes]u8 = undefined;
     const path = try std.fmt.bufPrint(&path_buf, "{s}/version-notify.json", .{dir});
@@ -450,7 +456,7 @@ test "pendingNotice stays silent when the output mode suppresses it" {
     }) |gates| {
         const tag = notifier.pendingNotice(
             io,
-            app_ctx.processEnviron(),
+            fixtureEnviron(&entries),
             false,
             allocator,
             "0.10.0",
@@ -476,10 +482,9 @@ test "pendingNotice stays silent on a command that never carries the notice" {
     try fs_compat.makeDirAbsolute(io, dir);
     defer fs_compat.deleteTreeAbsolute(io, dir) catch {};
 
-    _ = c_env.setenv("MALT_CACHE", dir.ptr, 1);
-    defer _ = c_env.unsetenv("MALT_CACHE");
-    _ = c_env.setenv("MALT_VERSION_NOTIFIER_ASSUME_TTY", "1", 1);
-    defer _ = c_env.unsetenv("MALT_VERSION_NOTIFIER_ASSUME_TTY");
+    const cache_var = try std.fmt.allocPrintSentinel(allocator, "MALT_CACHE={s}", .{dir}, 0);
+    defer allocator.free(cache_var);
+    const entries = [_:null]?[*:0]const u8{ cache_var.ptr, "MALT_VERSION_NOTIFIER_ASSUME_TTY=1" };
 
     var path_buf: [std.fs.max_path_bytes]u8 = undefined;
     const path = try std.fmt.bufPrint(&path_buf, "{s}/version-notify.json", .{dir});
@@ -488,7 +493,7 @@ test "pendingNotice stays silent on a command that never carries the notice" {
 
     const tag = notifier.pendingNotice(
         io,
-        app_ctx.processEnviron(),
+        fixtureEnviron(&entries),
         false,
         allocator,
         "0.10.0",

--- a/tests/version_notify_test.zig
+++ b/tests/version_notify_test.zig
@@ -246,8 +246,7 @@ test "markUpdatedTo bumps current_seen so a manual --check stops the nag" {
     });
 
     // Snapshot the live env so cachePath sees MALT_CACHE.
-    const ctx: app_ctx.AppCtx = .{ .io = io, .environ = app_ctx.processEnviron() };
-    notifier.markUpdatedTo(&ctx, "v0.10.1", "0.10.1");
+    notifier.markUpdatedTo(io, app_ctx.processEnviron(), "v0.10.1", "0.10.1");
 
     const got = (try notifier.readCache(io, allocator, path)) orelse return error.TestExpectedNonNull;
     defer notifier.freeState(allocator, got);


### PR DESCRIPTION
## Description

`update/` is a contract leaf, but the notifier rendered ANSI, wrote stderr and took the CLI's `AppCtx`, and its cache pulled a JSON escaper out of `ui/`. That is the coupling the modularity constraint exists to prevent, and it made the decision half untestable without the UI.

The notifier now decides and returns; `cli/` renders. No import from `update/` reaches `ui/` or `AppCtx` any more.

## Related Issue

- None

## Notes for Reviewers

- Behaviour is preserved: same suppression order, same render bytes, same point   in the command's lifecycle.
- `jsonStr` moved to `core/json_escape.zig`; `ui/output` re-exports it so the existing `--json` call sites are untouched.