### PR TITLE
fix(net): survive a peer that lies about its download size

### DIFF
--- a/scripts/regressions/scaled-timeout-clamp-scaled-timeout-overflow-on-content-length.sh
+++ b/scripts/regressions/scaled-timeout-clamp-scaled-timeout-overflow-on-content-length.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Regression: the whole-transfer deadline is derived from the peer's declared
+# Content-Length. That value is attacker-controlled, and the ns multiply used to
+# turn it into a deadline overflows u64 past ~1.2e15 - a checked-arithmetic
+# panic that aborts the whole `mt` process in a safe build before a single body
+# byte is read. The deadline must clamp to the largest transfer the client would
+# ever accept instead.
+#
+# A real overflow panic kills the test runner by signal, so the assertion lives
+# in a standalone ReleaseSafe `zig test` harness whose death-by-signal is itself
+# the failure signal.
+#
+# Exits 0 when the bug is absent, non-zero (with a clear message) when present.
+# No network required; finishes well under 30s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+
+# The harness imports the client via a repo-relative path, so it must sit at the
+# repo root for that path to resolve.
+HARNESS="$ROOT/.scaled-timeout-clamp-regression.zig"
+trap 'rm -f "$HARNESS"' EXIT
+
+cat >"$HARNESS" <<'ZIG'
+const std = @import("std");
+const client = @import("src/net/client.zig");
+
+test "scaledTimeoutNs clamps a hostile Content-Length" {
+    // Old code panicked here; new code returns the 2 GiB-at-64 KiB/s ceiling.
+    const ceiling = client.scaledTimeoutNs(std.math.maxInt(u64));
+    try std.testing.expectEqual(@as(u64, 32768) * std.time.ns_per_s, ceiling);
+
+    // The exact pre-fix overflow threshold and a plausible hostile header.
+    try std.testing.expectEqual(ceiling, client.scaledTimeoutNs(1_208_925_819_568_128));
+    try std.testing.expectEqual(ceiling, client.scaledTimeoutNs(2_000_000_000_000_000));
+
+    // The honest range must still scale, not flatten to the ceiling.
+    try std.testing.expect(client.scaledTimeoutNs(500 * 1024 * 1024) < ceiling);
+}
+ZIG
+
+if (cd "$ROOT" && zig test -OReleaseSafe "$HARNESS") >/dev/null 2>&1; then
+  echo "PASS: scaledTimeoutNs clamps a hostile Content-Length"
+else
+  echo "FAIL: scaledTimeoutNs overflowed on a hostile Content-Length" >&2
+  exit 1
+fi

--- a/src/net/client.zig
+++ b/src/net/client.zig
@@ -130,11 +130,14 @@ pub fn isTransientError(err: DownloadError) bool {
 }
 
 /// Read-timeout in ns scaled by Content-Length; floor 30 s at 64 KiB/s.
+/// Content-Length is peer-supplied and clamped to the blob cap: a larger
+/// transfer is refused mid-stream, so a longer deadline only serves a liar.
 pub fn scaledTimeoutNs(content_length: ?u64) u64 {
     const floor_ns: u64 = 30 * std.time.ns_per_s;
     const cl = content_length orelse return floor_ns;
     const min_bandwidth: u64 = 64 * 1024; // 64 KiB/s
-    const transfer_ns = (cl / min_bandwidth) * std.time.ns_per_s;
+    const capped = @min(cl, HttpClient.max_blob_bytes);
+    const transfer_ns = (capped / min_bandwidth) *| std.time.ns_per_s;
     return @max(floor_ns, transfer_ns);
 }
 

--- a/tests/net_client_test.zig
+++ b/tests/net_client_test.zig
@@ -237,6 +237,39 @@ test "scaledTimeoutNs: 0-length file returns floor" {
     try testing.expectEqual(@as(u64, 30 * std.time.ns_per_s), client.scaledTimeoutNs(0));
 }
 
+// The ceiling: 2 GiB (the mid-stream blob cap) at 64 KiB/s.
+const clamp_ceiling_ns: u64 = 32768 * std.time.ns_per_s;
+
+test "scaledTimeoutNs: maxInt content_length clamps instead of overflowing" {
+    try testing.expectEqual(clamp_ceiling_ns, client.scaledTimeoutNs(std.math.maxInt(u64)));
+}
+
+test "scaledTimeoutNs: pre-clamp overflow threshold returns the ceiling" {
+    // The exact value the old unchecked multiply wrapped just past.
+    try testing.expectEqual(clamp_ceiling_ns, client.scaledTimeoutNs(1_208_925_819_568_128));
+}
+
+test "scaledTimeoutNs: a hostile Content-Length buys no extra deadline" {
+    try testing.expectEqual(clamp_ceiling_ns, client.scaledTimeoutNs(2_000_000_000_000_000));
+}
+
+test "scaledTimeoutNs: honest sizes below the cap still scale linearly" {
+    const cl: u64 = 1024 * 1024 * 1024; // 1 GiB at 64 KiB/s = 16384 s
+    const result = client.scaledTimeoutNs(cl);
+    try testing.expectEqual(@as(u64, 16384 * std.time.ns_per_s), result);
+    try testing.expect(result < clamp_ceiling_ns);
+}
+
+test "scaledTimeoutNs: the blob cap itself lands exactly on the ceiling" {
+    try testing.expectEqual(clamp_ceiling_ns, client.scaledTimeoutNs(2 * 1024 * 1024 * 1024));
+}
+
+test "scaledTimeoutNs: one byte past the blob cap is already clamped" {
+    // The boundary the clamp introduces; anything past the cap is refused
+    // mid-stream, so it must not buy a longer deadline.
+    try testing.expectEqual(clamp_ceiling_ns, client.scaledTimeoutNs(2 * 1024 * 1024 * 1024 + 1));
+}
+
 test "scaledTimeoutNs: null combined with blob_timeout_ns keeps 10-min minimum" {
     // Blob downloads use @max(blob_timeout_ns, scaledTimeoutNs(cl)).
     // When Content-Length is null (chunked), scaledTimeoutNs returns 30s,


### PR DESCRIPTION
## Description

A download's overall deadline was derived from the size the server claimed to be sending. A server claiming an absurd size crashed `mt` outright before a single byte arrived, and any inflated claim bought itself an arbitrarily long deadline. The deadline is now capped at the largest download malt would accept anyway, so a dishonest size buys nothing.

## Related Issue

- None

## Notes for Reviewers

- None