### PR TITLE
perf(install): ask the system trust store directly instead of once per process

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -39,7 +39,36 @@ fn addTranslatedCModules(
     };
 }
 
+/// Security.framework backs the in-process trust evaluation in
+/// `core/ca_bundle.zig`; CoreFoundation carries its object types. Every
+/// artifact that compiles that file needs the link, so they all route here.
+fn linkTrustFrameworks(b: *std.Build, m: *std.Build.Module) void {
+    m.linkFramework("Security", .{});
+    m.linkFramework("CoreFoundation", .{});
+
+    // Named explicitly rather than left to the compiler's SDK detection,
+    // because the sysroot below suppresses that detection and the universal
+    // step's targets never had it: naming an arch makes a target cross even
+    // on macOS. Without this the link finds no frameworks at all.
+    m.addSystemFrameworkPath(.{
+        .cwd_relative = b.pathJoin(&.{ b.sysroot.?, "System", "Library", "Frameworks" }),
+    });
+}
+
 pub fn build(b: *std.Build) void {
+    // Whole-build setting, so it is decided here rather than wherever it is
+    // first needed. The cross-compiled halves of the universal binary link
+    // frameworks, and CoreFoundation re-exports /usr/lib/libobjc.A.dylib - an
+    // absolute path that is no longer a file on disk, it lives in the dyld
+    // shared cache. Only a sysroot makes the linker resolve that name inside
+    // the SDK. This is the SDK a native build picks by itself, so native
+    // builds see no change.
+    if (b.sysroot == null) b.sysroot = std.zig.system.darwin.getSdk(
+        b.allocator,
+        b.graph.io,
+        &b.graph.host.result,
+    ) orelse std.debug.panic("no macOS SDK found; install the Command Line Tools", .{});
+
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
@@ -69,6 +98,7 @@ pub fn build(b: *std.Build) void {
             .strip = strip,
         }),
     });
+    linkTrustFrameworks(b, exe.root_module);
     exe.root_module.addOptions("version_string", version_options);
     exe.root_module.addImport("c_sqlite", host_c_mods.c_sqlite);
     exe.root_module.addImport("c_clonefile", host_c_mods.c_clonefile);
@@ -287,6 +317,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .link_libc = true,
     });
+    linkTrustFrameworks(b, malt_lib);
     malt_lib.addCSourceFile(.{
         .file = b.path("vendor/sqlite3.c"),
         .flags = &.{
@@ -330,6 +361,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .link_libc = true,
     });
+    linkTrustFrameworks(b, lib_test_module);
     lib_test_module.addCSourceFile(.{
         .file = b.path("vendor/sqlite3.c"),
         .flags = &.{
@@ -475,6 +507,7 @@ pub fn build(b: *std.Build) void {
     arm64_exe.root_module.addIncludePath(b.path("vendor/"));
     arm64_exe.root_module.addIncludePath(b.path("c/"));
     arm64_exe.root_module.addOptions("version_string", version_options);
+    linkTrustFrameworks(b, arm64_exe.root_module);
     arm64_exe.root_module.addImport("c_sqlite", arm64_c_mods.c_sqlite);
     arm64_exe.root_module.addImport("c_clonefile", arm64_c_mods.c_clonefile);
     arm64_exe.root_module.addImport("c_mount", arm64_c_mods.c_mount);
@@ -496,6 +529,7 @@ pub fn build(b: *std.Build) void {
     x86_exe.root_module.addIncludePath(b.path("vendor/"));
     x86_exe.root_module.addIncludePath(b.path("c/"));
     x86_exe.root_module.addOptions("version_string", version_options);
+    linkTrustFrameworks(b, x86_exe.root_module);
     x86_exe.root_module.addImport("c_sqlite", x86_c_mods.c_sqlite);
     x86_exe.root_module.addImport("c_clonefile", x86_c_mods.c_clonefile);
     x86_exe.root_module.addImport("c_mount", x86_c_mods.c_mount);

--- a/scripts/regressions/native-ca-bundle-argv-confinement.sh
+++ b/scripts/regressions/native-ca-bundle-argv-confinement.sh
@@ -138,7 +138,9 @@ zig translate-c -I "$ROOT/vendor/" "$ROOT/c/sqlite.h" >"$TMP/c_sqlite.zig" 2>/de
 zig translate-c "$ROOT/c/clonefile.h" >"$TMP/c_clonefile.zig" 2>/dev/null
 zig translate-c "$ROOT/c/mount.h" >"$TMP/c_mount.zig" 2>/dev/null
 
-(cd "$ROOT" && zig test -OReleaseSafe \
+# ca_bundle.zig evaluates trust in-process; the module graph needs the same
+# frameworks build.zig links.
+(cd "$ROOT" && zig test -OReleaseSafe -framework Security -framework CoreFoundation \
   --dep malt -Mroot="$HARNESS" \
   --dep c_sqlite --dep c_clonefile --dep c_mount \
   -Mmalt="$ROOT/src/lib.zig" -lc -I "$ROOT/vendor/" -I "$ROOT/c/" \

--- a/scripts/regressions/native-ca-bundle-matches-upstream.sh
+++ b/scripts/regressions/native-ca-bundle-matches-upstream.sh
@@ -59,7 +59,7 @@ SOURCE="$KEG/share/ca-certificates/cacert.pem"
 [[ -f "$SCRIPT" && -f "$SOURCE" ]] || fail "keg is missing the post-install script or its source bundle"
 
 # ── the recognition digest still matches the shipped script ───────────
-want=$(rg -o '"[0-9a-f]{64}"' "$ROOT/src/core/ca_bundle.zig" | head -1 | tr -d '"')
+want=$(grep -oE '"[0-9a-f]{64}"' "$ROOT/src/core/ca_bundle.zig" | head -1 | tr -d '"')
 got=$(shasum -a 256 "$SCRIPT" | cut -d' ' -f1)
 if [[ "$want" != "$got" ]]; then
   echo "  upstream script digest: $got" >&2
@@ -70,6 +70,16 @@ fi
 # ── malt's bundle, written by the install above ───────────────────────
 NATIVE="$PREFIX/etc/ca-certificates/cert.pem"
 [[ -s "$NATIVE" ]] || fail "install left no bundle at $NATIVE"
+
+# ── the native path must actually have been used ───────────────────────
+# Comparing the bundle against the script cannot show this: when the native
+# path declines, the script produced the bundle, so the two agree perfectly
+# and every other check here passes while the optimisation is silently gone.
+# The decline note is the only evidence, so its absence is the assertion.
+if grep -q "native trust-store build declined" "$WORK/install.log"; then
+  grep "native trust-store build declined" "$WORK/install.log" | sed 's/^/  /' >&2
+  fail "the native builder declined; the shipped script did the work"
+fi
 
 # ── the bundle must stay world-readable, as the script's chmod makes it ──
 # open(2) masks the mode with the caller's umask, so a native write that only

--- a/scripts/regressions/post-install-native-spawns-inherit-full-environment.sh
+++ b/scripts/regressions/post-install-native-spawns-inherit-full-environment.sh
@@ -27,7 +27,7 @@ STUBS=$(mktemp -d)
 # The harness imports the executor via a repo-relative path, so it must sit at
 # the repo root: the module's sibling imports (`dsl/sandbox.zig`,
 # `../fs/atomic.zig`) only resolve from inside the source tree.
-HARNESS="$ROOT/.post-install-env-scrub-regression.zig"
+HARNESS="$ROOT/.post-install-env-scrub-regression.$$.zig"
 trap 'rm -rf "$STUBS" "$HARNESS"' EXIT
 
 # The executor's module graph reaches the clonefile/statfs bindings that
@@ -131,7 +131,9 @@ test "a run step's child cannot see malt's own environment" {
 ZIG
 
 run_harness() {
-  (cd "$ROOT" && zig test -lc \
+  # ca_bundle.zig evaluates trust in-process; the module graph needs the
+  # same frameworks build.zig links.
+  (cd "$ROOT" && zig test -lc -framework Security -framework CoreFoundation \
     --dep c_clonefile --dep c_mount \
     -Mroot="$HARNESS" \
     -Mc_clonefile="$STUBS/c_clonefile.zig" \

--- a/scripts/regressions/post-install-run-step-gh804.sh
+++ b/scripts/regressions/post-install-run-step-gh804.sh
@@ -25,7 +25,7 @@ STUBS=$(mktemp -d)
 # The harness imports the executor via a repo-relative path, so it must sit at
 # the repo root: the module's sibling imports (`dsl/sandbox.zig`,
 # `../fs/atomic.zig`) only resolve from inside the source tree.
-HARNESS="$ROOT/.post-install-run-step-regression.zig"
+HARNESS="$ROOT/.post-install-run-step-regression.$$.zig"
 trap 'rm -rf "$STUBS" "$HARNESS"' EXIT
 
 # The executor's module graph reaches the clonefile/statfs bindings that
@@ -113,7 +113,9 @@ test "a run step executes the command with its templates expanded" {
 ZIG
 
 run_harness() {
-  (cd "$ROOT" && zig test -lc \
+  # ca_bundle.zig evaluates trust in-process; the module graph needs the
+  # same frameworks build.zig links.
+  (cd "$ROOT" && zig test -lc -framework Security -framework CoreFoundation \
     --dep c_clonefile --dep c_mount \
     -Mroot="$HARNESS" \
     -Mc_clonefile="$STUBS/c_clonefile.zig" \

--- a/src/core/ca_bundle.zig
+++ b/src/core/ca_bundle.zig
@@ -98,6 +98,13 @@ pub fn buildFrom(
     var blocks: std.ArrayList([]const u8) = .empty;
     defer blocks.deinit(gpa);
 
+    // A wedged trust daemon answers "no" to everything, which would read as
+    // "no root is trusted" and write a bundle missing all of them. One "yes"
+    // proves the store is answering, and that holds whatever reason codes a
+    // given macOS version happens to use.
+    var consulted: usize = 0;
+    var trusted: usize = 0;
+
     for (sources) |source| {
         blocks.clearRetainingCapacity();
         var it: PemIter = .{ .src = source.pem };
@@ -128,10 +135,11 @@ pub fn buildFrom(
                     .not_ca => continue,
                     .ca => {},
                 }
+                consulted += 1;
                 switch (verifier.call(verifier.ctx, der_bytes, purpose)) {
                     .rejected => continue,
                     .undetermined => return error.TrustEvaluationFailed,
-                    .trusted => {},
+                    .trusted => trusted += 1,
                 }
             }
 
@@ -142,6 +150,8 @@ pub fn buildFrom(
             try out.append(gpa, '\n');
         }
     }
+    // Asked, and never once told yes: the store is not answering.
+    if (consulted > 0 and trusted == 0) return error.TrustEvaluationFailed;
     return out.toOwnedSlice(gpa);
 }
 
@@ -537,12 +547,6 @@ extern "c" fn SecTrustCreateWithCertificates(certs: ?*SecCertificate, policies: 
 extern "c" fn SecTrustSetOptions(trust: ?*SecTrust, options: usize) i32;
 extern "c" fn SecTrustSetNetworkFetchAllowed(trust: ?*SecTrust, allow: u8) i32;
 extern "c" fn SecTrustEvaluateWithError(trust: ?*SecTrust, err: *?*CFError) u8;
-extern "c" fn CFErrorGetCode(err: ?*CFError) isize;
-extern "c" fn CFErrorGetDomain(err: ?*CFError) ?*CFString;
-extern "c" fn CFEqual(a: ?*anyopaque, b: ?*anyopaque) u8;
-/// The domain the codes above are numbered in. A code from any other domain
-/// means something else entirely, however familiar the number looks.
-extern const kCFErrorDomainOSStatus: ?*CFString;
 
 /// `CFRelease` takes any CoreFoundation handle; binding it once and casting
 /// here keeps the distinct pointer types at every other call site. Null is
@@ -560,21 +564,6 @@ fn cfRelease(handle: anytype) void {
 /// leaf-must-not-be-a-CA rule any more, so this changes no verdict today -
 /// it is set to keep the two invocations aligned if that ever returns.
 const leaf_is_ca: usize = 0x02;
-
-/// Codes the trust store returns when it has actually judged a certificate and
-/// said no. Observed across every root on a real machine under both policies,
-/// then checked against `Security/SecBase.h` for what each one means.
-///
-/// Deliberately an allowlist, and only within the OSStatus error domain.
-/// Anything else — a wedged trust daemon, an unreachable keychain — is the
-/// question going unanswered, and reading that as "untrusted" would write a
-/// bundle missing roots. An unlisted genuine rejection only costs speed: the
-/// build aborts and the shipped script runs.
-const rejection_codes = [_]isize{
-    -67843, // errSecNotTrusted
-    -67901, // errSecCertificateValidityPeriodTooLong
-    -67609, // errSecInvalidExtendedKeyUsage
-};
 
 /// Evaluate `der_bytes` against the system trust store, mirroring
 /// `verify-cert -l -L -p <policy> -R offline`. Anything that stops the
@@ -604,21 +593,13 @@ fn evaluateTrust(der_bytes: []const u8, purpose: Purpose) Verdict {
     if (SecTrustSetNetworkFetchAllowed(trust, 0) != 0) return .undetermined;
 
     var err: ?*CFError = null;
-    if (SecTrustEvaluateWithError(trust, &err) != 0) {
-        if (err) |e| cfRelease(e);
-        return .trusted;
-    }
-    // A `false` with no error, or with any other code, means the evaluation
-    // did not reach a verdict — a wedged trust daemon would otherwise read as
-    // "every root is untrusted" and write a bundle missing all of them.
-    const e = err orelse return .undetermined;
-    defer cfRelease(e);
-    if (CFEqual(CFErrorGetDomain(e), kCFErrorDomainOSStatus) == 0) return .undetermined;
-    const code = CFErrorGetCode(e);
-    return if (std.mem.indexOfScalar(isize, &rejection_codes, code) != null)
-        .rejected
-    else
-        .undetermined;
+    const ok = SecTrustEvaluateWithError(trust, &err) != 0;
+    if (err) |e| cfRelease(e);
+    // The reason for a "no" is not classified here: the codes vary by macOS
+    // version and keychain contents, so an allowlist of them silently turns
+    // the whole build off on any machine outside the set it was measured on.
+    // `buildFrom` decides instead, from whether the store answered at all.
+    return if (ok) .trusted else .rejected;
 }
 
 /// Production verifier. Holds no state: the trust store is the system's.
@@ -998,15 +979,52 @@ test "a certificate past its notAfter is dropped without consulting trust" {
     try testing.expectEqualStrings("", out);
 }
 
+/// Trusts the first certificate it is asked about and rejects the rest, so a
+/// rejection can be tested while the store is demonstrably still answering.
+const TrustFirstOnly = struct {
+    calls: usize = 0,
+
+    fn call(ctx: ?*anyopaque, _: []const u8, _: Purpose) Verdict {
+        const self: *TrustFirstOnly = @ptrCast(@alignCast(ctx));
+        self.calls += 1;
+        return if (self.calls == 1) .trusted else .rejected;
+    }
+};
+
 test "a keychain certificate the trust store rejects is left out" {
+    var stub: TrustFirstOnly = .{};
     const out = try buildFrom(
+        testing.allocator,
+        &.{
+            .{ .pem = ca_pem, .purpose = .basic },
+            .{ .pem = ca_pem_rewrapped, .purpose = .basic },
+        },
+        .{ .ctx = &stub, .call = TrustFirstOnly.call },
+        now_valid,
+    );
+    defer testing.allocator.free(out);
+    try testing.expectEqual(@as(usize, 2), stub.calls);
+    // The rejected one is dropped; the trusted one stays.
+    try testing.expectEqualStrings(ca_pem ++ "\n", out);
+}
+
+// The reason codes behind a "no" vary by macOS version and keychain, so they
+// cannot be enumerated. What can be relied on is that a store which has said
+// yes even once is answering — and one that never does is not.
+test "a store that never says yes aborts instead of emptying the bundle" {
+    try testing.expectError(error.TrustEvaluationFailed, buildFrom(
         testing.allocator,
         &.{.{ .pem = ca_pem, .purpose = .basic }},
         .{ .call = denyAll },
         now_valid,
-    );
+    ));
+}
+
+test "a source with nothing to ask about does not trip the health check" {
+    // No purpose means no trust evaluation, so there is no "yes" to expect.
+    const out = try buildFrom(testing.allocator, &.{.{ .pem = ca_pem }}, .{ .call = denyAll }, now_valid);
     defer testing.allocator.free(out);
-    try testing.expectEqualStrings("", out);
+    try testing.expectEqualStrings(ca_pem ++ "\n", out);
 }
 
 test "a non-CA keychain certificate is dropped before the trust evaluation" {

--- a/src/core/ca_bundle.zig
+++ b/src/core/ca_bundle.zig
@@ -104,6 +104,15 @@ pub fn buildFrom(
     // given macOS version happens to use.
     var consulted: usize = 0;
     var trusted: usize = 0;
+    // A store that stops answering part-way through still leaves `trusted`
+    // above zero, so the count alone cannot see it. Keep the first
+    // certificate it accepted and put the same question again at the end: a
+    // different answer means the store was restarted or replaced mid-build,
+    // and what got written is short of roots rather than legitimately
+    // excluding them.
+    var canary: [max_der_bytes]u8 = undefined;
+    var canary_len: usize = 0;
+    var canary_purpose: Purpose = .basic;
 
     for (sources) |source| {
         blocks.clearRetainingCapacity();
@@ -139,7 +148,14 @@ pub fn buildFrom(
                 switch (verifier.call(verifier.ctx, der_bytes, purpose)) {
                     .rejected => continue,
                     .undetermined => return error.TrustEvaluationFailed,
-                    .trusted => trusted += 1,
+                    .trusted => {
+                        trusted += 1;
+                        if (canary_len == 0) {
+                            @memcpy(canary[0..der_bytes.len], der_bytes);
+                            canary_len = der_bytes.len;
+                            canary_purpose = purpose;
+                        }
+                    },
                 }
             }
 
@@ -152,6 +168,9 @@ pub fn buildFrom(
     }
     // Asked, and never once told yes: the store is not answering.
     if (consulted > 0 and trusted == 0) return error.TrustEvaluationFailed;
+    if (canary_len > 0 and
+        verifier.call(verifier.ctx, canary[0..canary_len], canary_purpose) != .trusted)
+        return error.TrustEvaluationFailed;
     return out.toOwnedSlice(gpa);
 }
 
@@ -348,6 +367,16 @@ fn checkedElement(bytes: []const u8, pos: usize) !der.Element {
     return der.Element.parse(bytes, std.math.cast(u32, pos) orelse return error.MalformedDer);
 }
 
+/// `checkedElement`, but refusing an element whose content runs past `end`.
+/// An extension payload is an OCTET STRING and `derStructureOk` never
+/// descends into a primitive, so the DER nested inside one reaches here
+/// unvalidated. Bounding each element to its container keeps a declared
+/// length from being read out of the certificate bytes that follow it.
+fn checkedElementWithin(bytes: []const u8, pos: usize, end: usize) !der.Element {
+    if (end > bytes.len or pos >= end) return error.MalformedDer;
+    return checkedElement(bytes[0..end], pos);
+}
+
 /// DER gives these a minimum content length, and `std`'s reader trusts it: it
 /// indexes a BIT STRING's first byte without checking there is one, so an
 /// empty one panics rather than erroring. Structural nesting alone does not
@@ -394,6 +423,8 @@ fn wellFormedCertificate(bytes: []const u8) bool {
 
 const Class = enum { ca, not_ca };
 
+/// Context-specific, constructed, number 3: TBSCertificate's `extensions`.
+const extensions_tag: u8 = 0xa3;
 const oid_basic_constraints = [_]u8{ 0x55, 0x1D, 0x13 };
 const oid_key_usage = [_]u8{ 0x55, 0x1D, 0x0F };
 const oid_ext_key_usage = [_]u8{ 0x55, 0x1D, 0x25 };
@@ -444,37 +475,50 @@ fn readExtensions(cert: Certificate) !Extensions {
     const validity = try checkedElement(bytes, issuer.slice.end);
     const subject = try checkedElement(bytes, validity.slice.end);
     const pub_key_info = try checkedElement(bytes, subject.slice.end);
-    if (pub_key_info.slice.end >= tbs.slice.end) return out;
 
-    const outer = try checkedElement(bytes, pub_key_info.slice.end);
-    if (outer.identifier.tag != .bitstring) return out;
-    const extensions = try checkedElement(bytes, outer.slice.start);
+    // issuerUniqueID [1] and subjectUniqueID [2] may sit between the public
+    // key and the extensions, so walk past whatever is there rather than
+    // giving up on the first element that is not [3] - a certificate carrying
+    // one would otherwise report no extensions at all, and `classify` turns
+    // that into `Unclassifiable`, which aborts the whole build. Match on the
+    // entire identifier byte too: as a tag *number*, 3 is also BIT STRING.
+    var pos = pub_key_info.slice.end;
+    const outer = while (pos < tbs.slice.end) {
+        const elem = try checkedElementWithin(bytes, pos, tbs.slice.end);
+        if (@as(u8, @bitCast(elem.identifier)) == extensions_tag) break elem;
+        pos = elem.slice.end;
+    } else return out;
+    const extensions = try checkedElementWithin(bytes, outer.slice.start, outer.slice.end);
 
     var i = extensions.slice.start;
     while (i < extensions.slice.end) {
-        const extension = try checkedElement(bytes, i);
+        const extension = try checkedElementWithin(bytes, i, extensions.slice.end);
         i = extension.slice.end;
-        const oid = try checkedElement(bytes, extension.slice.start);
-        const critical = try checkedElement(bytes, oid.slice.end);
+        const oid = try checkedElementWithin(bytes, extension.slice.start, extension.slice.end);
+        const critical = try checkedElementWithin(bytes, oid.slice.end, extension.slice.end);
         const payload = if (critical.identifier.tag != .boolean)
             critical
         else
-            try checkedElement(bytes, critical.slice.end);
+            try checkedElementWithin(bytes, critical.slice.end, extension.slice.end);
         const oid_bytes = bytes[oid.slice.start..oid.slice.end];
+        const payload_end = payload.slice.end;
 
         if (std.mem.eql(u8, oid_bytes, &oid_basic_constraints)) {
             out.basic_constraints_present = true;
-            const constraints = try checkedElement(bytes, payload.slice.start);
+            const constraints = try checkedElementWithin(bytes, payload.slice.start, payload_end);
             if (constraints.slice.start < constraints.slice.end) {
-                const ca = try checkedElement(bytes, constraints.slice.start);
-                if (ca.identifier.tag == .boolean) out.is_ca = bytes[ca.slice.start] != 0;
+                const ca = try checkedElementWithin(bytes, constraints.slice.start, constraints.slice.end);
+                // A zero-length BOOLEAN carries no byte to read; without the
+                // emptiness test this would take the one after the element.
+                if (ca.identifier.tag == .boolean and ca.slice.start < ca.slice.end)
+                    out.is_ca = bytes[ca.slice.start] != 0;
             }
         } else if (std.mem.eql(u8, oid_bytes, &oid_ext_key_usage)) {
             out.ext_key_usage_present = true;
-            const usages = try checkedElement(bytes, payload.slice.start);
+            const usages = try checkedElementWithin(bytes, payload.slice.start, payload_end);
             var u = usages.slice.start;
             while (u < usages.slice.end) {
-                const usage = try checkedElement(bytes, u);
+                const usage = try checkedElementWithin(bytes, u, usages.slice.end);
                 u = usage.slice.end;
                 const id = bytes[usage.slice.start..usage.slice.end];
                 if (std.mem.eql(u8, id, &oid_server_auth) or
@@ -483,7 +527,7 @@ fn readExtensions(cert: Certificate) !Extensions {
             }
         } else if (std.mem.eql(u8, oid_bytes, &oid_key_usage)) {
             out.key_usage_present = true;
-            const bits = try checkedElement(bytes, payload.slice.start);
+            const bits = try checkedElementWithin(bytes, payload.slice.start, payload_end);
             const data = bytes[bits.slice.start..bits.slice.end];
             // BIT STRING content leads with the unused-bit count; keyCertSign
             // is bit 5, i.e. 0x04 of the first data byte.
@@ -614,6 +658,203 @@ const SystemVerifier = struct {
 };
 
 // --- tests -----------------------------------------------------------
+
+/// Minimal DER writer, enough to shape a TBSCertificate for the extension
+/// walk. Lengths stay short-form, which every element these tests build fits.
+const DerBuf = struct {
+    bytes: std.ArrayList(u8) = .empty,
+
+    fn deinit(self: *DerBuf, gpa: std.mem.Allocator) void {
+        self.bytes.deinit(gpa);
+    }
+    fn prim(self: *DerBuf, gpa: std.mem.Allocator, tag: u8, content: []const u8) !void {
+        try self.bytes.appendSlice(gpa, &.{ tag, @intCast(content.len) });
+        try self.bytes.appendSlice(gpa, content);
+    }
+    fn wrap(gpa: std.mem.Allocator, tag: u8, content: []const u8) ![]u8 {
+        var o: std.ArrayList(u8) = .empty;
+        try o.appendSlice(gpa, &.{ tag, @intCast(content.len) });
+        try o.appendSlice(gpa, content);
+        return o.toOwnedSlice(gpa);
+    }
+};
+
+/// The seven TBSCertificate fields ahead of the unique IDs and extensions.
+fn tbsPreamble(gpa: std.mem.Allocator) ![]u8 {
+    var b: DerBuf = .{};
+    defer b.deinit(gpa);
+    try b.prim(gpa, 0xa0, &.{ 0x02, 0x01, 0x02 }); // [0] version v3
+    try b.prim(gpa, 0x02, &.{0x01}); // serialNumber
+    try b.prim(gpa, 0x30, &.{}); // signature
+    try b.prim(gpa, 0x30, &.{}); // issuer
+    try b.prim(gpa, 0x30, &.{}); // validity
+    try b.prim(gpa, 0x30, &.{}); // subject
+    try b.prim(gpa, 0x30, &.{}); // subjectPublicKeyInfo
+    return gpa.dupe(u8, b.bytes.items);
+}
+
+/// A certificate whose only extension is basicConstraints with `cA` set,
+/// preceded by whatever `before_extensions` puts after the public key.
+fn certWithBasicConstraints(gpa: std.mem.Allocator, before_extensions: []const u8) ![]u8 {
+    const bc_payload = try DerBuf.wrap(gpa, 0x30, &.{ 0x01, 0x01, 0xff }); // SEQUENCE { BOOLEAN TRUE }
+    defer gpa.free(bc_payload);
+    const octets = try DerBuf.wrap(gpa, 0x04, bc_payload);
+    defer gpa.free(octets);
+
+    var ext: std.ArrayList(u8) = .empty;
+    defer ext.deinit(gpa);
+    try ext.appendSlice(gpa, &.{ 0x06, oid_basic_constraints.len });
+    try ext.appendSlice(gpa, &oid_basic_constraints);
+    try ext.appendSlice(gpa, octets);
+
+    const one = try DerBuf.wrap(gpa, 0x30, ext.items);
+    defer gpa.free(one);
+    const seq = try DerBuf.wrap(gpa, 0x30, one);
+    defer gpa.free(seq);
+    const tagged = try DerBuf.wrap(gpa, extensions_tag, seq);
+    defer gpa.free(tagged);
+
+    const preamble = try tbsPreamble(gpa);
+    defer gpa.free(preamble);
+    var tbs_body: std.ArrayList(u8) = .empty;
+    defer tbs_body.deinit(gpa);
+    try tbs_body.appendSlice(gpa, preamble);
+    try tbs_body.appendSlice(gpa, before_extensions);
+    try tbs_body.appendSlice(gpa, tagged);
+
+    const tbs = try DerBuf.wrap(gpa, 0x30, tbs_body.items);
+    defer gpa.free(tbs);
+    return DerBuf.wrap(gpa, 0x30, tbs);
+}
+
+test "a store that stops answering part-way aborts the build" {
+    // The health check on its own only sees a store that never said yes.
+    // This one says yes once and then goes away, which leaves `trusted`
+    // above zero while every root after the first is dropped - the silent
+    // half-bundle the closing re-ask exists to catch.
+    var stub: TrustThenQuit = .{ .fail_after = 1 };
+    try testing.expectError(error.TrustEvaluationFailed, buildFrom(
+        testing.allocator,
+        &.{
+            .{ .pem = ca_pem, .purpose = .basic },
+            .{ .pem = ca_pem_rewrapped, .purpose = .basic },
+        },
+        .{ .ctx = &stub, .call = TrustThenQuit.call },
+        now_valid,
+    ));
+}
+
+test "extensions are found past an issuerUniqueID" {
+    const gpa = testing.allocator;
+    // [1] IMPLICIT UniqueIdentifier, the field RFC 5280 allows between the
+    // public key and the extensions. Stopping here would report no
+    // extensions, and no basicConstraints aborts the entire build.
+    const issuer_unique_id = [_]u8{ 0x81, 0x02, 0x00, 0x01 };
+    const cert = try certWithBasicConstraints(gpa, &issuer_unique_id);
+    defer gpa.free(cert);
+
+    try testing.expect(wellFormedCertificate(cert));
+    const exts = try readExtensions(.{ .buffer = cert, .index = 0 });
+    try testing.expect(exts.basic_constraints_present);
+    try testing.expect(exts.is_ca);
+}
+
+test "extensions are found past both unique IDs" {
+    const gpa = testing.allocator;
+    const both = [_]u8{ 0x81, 0x02, 0x00, 0x01, 0x82, 0x02, 0x00, 0x02 };
+    const cert = try certWithBasicConstraints(gpa, &both);
+    defer gpa.free(cert);
+
+    const exts = try readExtensions(.{ .buffer = cert, .index = 0 });
+    try testing.expect(exts.basic_constraints_present);
+    try testing.expect(exts.is_ca);
+}
+
+test "a universal BIT STRING is not mistaken for the extensions tag" {
+    const gpa = testing.allocator;
+    // Tag *number* 3 in the universal class. Comparing the number alone would
+    // take this for `extensions [3]` and walk its contents as extensions.
+    const bit_string = [_]u8{ 0x03, 0x02, 0x00, 0x7f };
+    const cert = try certWithBasicConstraints(gpa, &bit_string);
+    defer gpa.free(cert);
+
+    const exts = try readExtensions(.{ .buffer = cert, .index = 0 });
+    try testing.expect(exts.basic_constraints_present);
+    try testing.expect(exts.is_ca);
+}
+
+test "an extension payload cannot reach past itself" {
+    const gpa = testing.allocator;
+    // basicConstraints whose OCTET STRING holds a SEQUENCE declaring three
+    // bytes of content it does not contain. The three bytes that follow it in
+    // the certificate are a well-formed BOOLEAN TRUE, so an unbounded walk
+    // reads them and calls this a CA; bounded, the SEQUENCE is malformed.
+    var ext: std.ArrayList(u8) = .empty;
+    defer ext.deinit(gpa);
+    try ext.appendSlice(gpa, &.{ 0x06, oid_basic_constraints.len });
+    try ext.appendSlice(gpa, &oid_basic_constraints);
+    try ext.appendSlice(gpa, &.{ 0x04, 0x02, 0x30, 0x03 });
+    try ext.appendSlice(gpa, &.{ 0x01, 0x01, 0xff });
+
+    const one = try DerBuf.wrap(gpa, 0x30, ext.items);
+    defer gpa.free(one);
+    const seq = try DerBuf.wrap(gpa, 0x30, one);
+    defer gpa.free(seq);
+    const tagged = try DerBuf.wrap(gpa, extensions_tag, seq);
+    defer gpa.free(tagged);
+    const preamble = try tbsPreamble(gpa);
+    defer gpa.free(preamble);
+
+    var tbs_body: std.ArrayList(u8) = .empty;
+    defer tbs_body.deinit(gpa);
+    try tbs_body.appendSlice(gpa, preamble);
+    try tbs_body.appendSlice(gpa, tagged);
+    const tbs = try DerBuf.wrap(gpa, 0x30, tbs_body.items);
+    defer gpa.free(tbs);
+    const cert = try DerBuf.wrap(gpa, 0x30, tbs);
+    defer gpa.free(cert);
+
+    try testing.expect(wellFormedCertificate(cert));
+    try testing.expectError(error.MalformedDer, readExtensions(.{ .buffer = cert, .index = 0 }));
+}
+
+test "a zero-length cA BOOLEAN does not read the byte after it" {
+    const gpa = testing.allocator;
+    // BOOLEAN with no content byte. Reading `bytes[start]` regardless would
+    // take whatever follows the element and call the certificate a CA.
+    const bc_payload = try DerBuf.wrap(gpa, 0x30, &.{ 0x01, 0x00 });
+    defer gpa.free(bc_payload);
+    const octets = try DerBuf.wrap(gpa, 0x04, bc_payload);
+    defer gpa.free(octets);
+
+    var ext: std.ArrayList(u8) = .empty;
+    defer ext.deinit(gpa);
+    try ext.appendSlice(gpa, &.{ 0x06, oid_basic_constraints.len });
+    try ext.appendSlice(gpa, &oid_basic_constraints);
+    try ext.appendSlice(gpa, octets);
+
+    const one = try DerBuf.wrap(gpa, 0x30, ext.items);
+    defer gpa.free(one);
+    const seq = try DerBuf.wrap(gpa, 0x30, one);
+    defer gpa.free(seq);
+    const tagged = try DerBuf.wrap(gpa, extensions_tag, seq);
+    defer gpa.free(tagged);
+    const preamble = try tbsPreamble(gpa);
+    defer gpa.free(preamble);
+
+    var tbs_body: std.ArrayList(u8) = .empty;
+    defer tbs_body.deinit(gpa);
+    try tbs_body.appendSlice(gpa, preamble);
+    try tbs_body.appendSlice(gpa, tagged);
+    const tbs = try DerBuf.wrap(gpa, 0x30, tbs_body.items);
+    defer gpa.free(tbs);
+    const cert = try DerBuf.wrap(gpa, 0x30, tbs);
+    defer gpa.free(cert);
+
+    const exts = try readExtensions(.{ .buffer = cert, .index = 0 });
+    try testing.expect(exts.basic_constraints_present);
+    try testing.expect(!exts.is_ca);
+}
 
 const testing = std.testing;
 
@@ -981,13 +1222,33 @@ test "a certificate past its notAfter is dropped without consulting trust" {
 
 /// Trusts the first certificate it is asked about and rejects the rest, so a
 /// rejection can be tested while the store is demonstrably still answering.
+/// Trusts the first certificate it is shown and nothing else, keyed on the
+/// certificate rather than the call count - a real store answers the same
+/// question the same way twice, and `buildFrom` asks one of them twice.
 const TrustFirstOnly = struct {
+    first: ?Fingerprint = null,
+    calls: usize = 0,
+
+    fn call(ctx: ?*anyopaque, der_bytes: []const u8, _: Purpose) Verdict {
+        const self: *TrustFirstOnly = @ptrCast(@alignCast(ctx));
+        self.calls += 1;
+        var fp: Fingerprint = undefined;
+        Sha256.hash(der_bytes, &fp, .{});
+        if (self.first == null) self.first = fp;
+        return if (std.mem.eql(u8, &self.first.?, &fp)) .trusted else .rejected;
+    }
+};
+
+/// Answers yes until `fail_after` certificates have been accepted, then no -
+/// a trust daemon that goes away part-way through the build.
+const TrustThenQuit = struct {
+    fail_after: usize,
     calls: usize = 0,
 
     fn call(ctx: ?*anyopaque, _: []const u8, _: Purpose) Verdict {
-        const self: *TrustFirstOnly = @ptrCast(@alignCast(ctx));
+        const self: *TrustThenQuit = @ptrCast(@alignCast(ctx));
         self.calls += 1;
-        return if (self.calls == 1) .trusted else .rejected;
+        return if (self.calls <= self.fail_after) .trusted else .rejected;
     }
 };
 
@@ -1003,7 +1264,8 @@ test "a keychain certificate the trust store rejects is left out" {
         now_valid,
     );
     defer testing.allocator.free(out);
-    try testing.expectEqual(@as(usize, 2), stub.calls);
+    // two certificates, plus the closing re-ask of the accepted one
+    try testing.expectEqual(@as(usize, 3), stub.calls);
     // The rejected one is dropped; the trusted one stays.
     try testing.expectEqualStrings(ca_pem ++ "\n", out);
 }

--- a/src/core/ca_bundle.zig
+++ b/src/core/ca_bundle.zig
@@ -1,26 +1,23 @@
 //! malt — native build of the merged CA trust bundle.
 //!
-//! `ca-certificates` ships a `post-install` script that merges the live
-//! macOS keychains with the Mozilla roots it carries. It is correct, and it
-//! forks `openssl` and `security` once per certificate — roughly 800
-//! processes, ~5 s — which lands on every cold install whose closure reaches
-//! `openssl@3`. Everything but the trust evaluation is certificate parsing
-//! and hashing that `std.crypto` does in-process in milliseconds.
+//! `ca-certificates` ships a `post-install` script that merges the live macOS
+//! keychains with the Mozilla roots it carries. It is correct, and it forks
+//! `openssl` and `security` once per certificate — roughly 800 processes,
+//! several seconds on every cold install whose closure reaches `openssl@3`.
+//! The same work is `std.crypto` parsing plus one Security.framework call per
+//! certificate, all in-process.
 //!
-//! This builds the same bundle natively. The contract is the trusted set:
+//! The contract is the trusted *set*, not the bytes:
 //! `scripts/regressions/native-ca-bundle-matches-upstream.sh` runs the real
-//! script on the real machine and fails if the two disagree about which
-//! certificates to trust. Anything this builder cannot classify with
-//! certainty aborts it, so the script runs rather than a subtly-wrong trust
-//! store being written, and substitution only happens for a script whose
-//! bytes it recognises.
+//! script on the real machine and fails if the two disagree about what to
+//! trust. Byte layout cannot be part of it — macOS ships LibreSSL, whose
+//! `-checkend` misreads a GeneralizedTime validity, so the script drops such a
+//! certificate from the keychain pass and recovers it from the Mozilla bundle
+//! lower down. Same set, different order.
 //!
-//! Byte layout is not part of the contract, and cannot be: macOS ships
-//! LibreSSL as `/usr/bin/openssl`, whose `-checkend` misreads a validity
-//! encoded as GeneralizedTime. The script therefore drops such a certificate
-//! from the keychain pass and recovers it from the Mozilla bundle further
-//! down. The set is unchanged; the ordering is not. malt reads the date
-//! correctly rather than reproducing that.
+//! Substitution only happens for a script whose bytes this recognises, and
+//! anything it cannot decide aborts the whole attempt, so the shipped script
+//! runs rather than a subtly-wrong trust store being written.
 
 const std = @import("std");
 
@@ -29,7 +26,6 @@ const der = Certificate.der;
 const Sha256 = std.crypto.hash.sha2.Sha256;
 
 const child = @import("child.zig");
-const atomic = @import("../fs/atomic.zig");
 const sandbox = @import("dsl/sandbox.zig");
 
 pub const BuildError = error{
@@ -79,10 +75,10 @@ pub const Fence = struct {
 pub const Verdict = enum { trusted, rejected, undetermined };
 
 /// Injected so unit tests can drive classification without the machine's
-/// real trust store. Production wiring forks `security verify-cert`.
+/// real trust store. Production asks Security.framework in-process.
 pub const Verifier = struct {
     ctx: ?*anyopaque = null,
-    call: *const fn (ctx: ?*anyopaque, pem: []const u8, purpose: Purpose) Verdict,
+    call: *const fn (ctx: ?*anyopaque, der_bytes: []const u8, purpose: Purpose) Verdict,
 };
 
 const Fingerprint = [Sha256.digest_length]u8;
@@ -132,7 +128,7 @@ pub fn buildFrom(
                     .not_ca => continue,
                     .ca => {},
                 }
-                switch (verifier.call(verifier.ctx, block, purpose)) {
+                switch (verifier.call(verifier.ctx, der_bytes, purpose)) {
                     .rejected => continue,
                     .undetermined => return error.TrustEvaluationFailed,
                     .trusted => {},
@@ -166,6 +162,14 @@ pub fn wouldTrustAsCa(pem_block: []const u8) BuildError!bool {
     return (try classify(cert)) == .ca;
 }
 
+/// The trust verdict this builder would reach for one PEM block. Public so
+/// the equivalence test can hold it against `security verify-cert`.
+pub fn wouldTrust(pem_block: []const u8, purpose: Purpose) Verdict {
+    var buf: [max_der_bytes]u8 = undefined;
+    const der_bytes = derFromPem(&buf, pem_block) catch return .undetermined;
+    return evaluateTrust(der_bytes, purpose);
+}
+
 /// Split `pem` into its certificate blocks. Public for the same reason.
 pub fn eachCertificate(pem: []const u8) PemIter {
     return .{ .src = pem };
@@ -193,17 +197,11 @@ pub fn build(
     const roots = try readKeychain(io, gpa, root_keychain, fence);
     defer gpa.free(roots);
 
-    const dir = atomic.createTempDir(io, gpa, "ca-verify") catch return error.KeychainUnreadable;
-    defer {
-        atomic.cleanupTempDir(io, dir);
-        gpa.free(dir);
-    }
-    var fork_verifier: ForkVerifier = .{ .io = io, .gpa = gpa, .dir = dir, .fence = fence };
     return buildFrom(gpa, &.{
         .{ .pem = system, .purpose = .ssl },
         .{ .pem = roots, .purpose = .basic },
         .{ .pem = mozilla_pem },
-    }, fork_verifier.verifier(), now_sec);
+    }, SystemVerifier.verifier(), now_sec);
 }
 
 /// SHA-256 of the `ca-certificates` `libexec/post-install` this builder was
@@ -340,16 +338,36 @@ fn checkedElement(bytes: []const u8, pos: usize) !der.Element {
     return der.Element.parse(bytes, std.math.cast(u32, pos) orelse return error.MalformedDer);
 }
 
-/// Every nested TLV's declared length must stay inside its parent. Checking
-/// only the outer SEQUENCE is not enough: a truncated certificate whose outer
-/// length is patched to match still crashes the parser from within.
+/// DER gives these a minimum content length, and `std`'s reader trusts it: it
+/// indexes a BIT STRING's first byte without checking there is one, so an
+/// empty one panics rather than erroring. Structural nesting alone does not
+/// catch that — an empty TLV nests perfectly well.
+fn primitiveContentOk(tag: u8, len: usize) bool {
+    // Universal class only; a context-specific primitive carries opaque bytes.
+    if (tag & 0xC0 != 0) return true;
+    return switch (tag & 0x1F) {
+        0x01 => len == 1, // BOOLEAN
+        0x02, 0x03, 0x06 => len >= 1, // INTEGER, BIT STRING, OBJECT IDENTIFIER
+        else => true,
+    };
+}
+
+/// Every nested TLV's declared length must stay inside its parent, and every
+/// primitive must carry the content its tag requires. Checking only the outer
+/// SEQUENCE is not enough: a truncated certificate whose outer length is
+/// patched to match still crashes the parser from within.
 fn derStructureOk(bytes: []const u8, depth: u8) bool {
-    if (depth == 0) return false;
     var pos: usize = 0;
     while (pos < bytes.len) {
         const h = readHeader(bytes, pos) orelse return false;
-        if (h.constructed and !derStructureOk(bytes[h.content_start..h.content_end], depth - 1))
+        if (h.constructed) {
+            // Spend a level only on real nesting, so the cap counts what a
+            // reader would call depth rather than being quietly one short.
+            if (depth == 0) return false;
+            if (!derStructureOk(bytes[h.content_start..h.content_end], depth - 1)) return false;
+        } else if (!primitiveContentOk(bytes[pos], h.content_end - h.content_start)) {
             return false;
+        }
         pos = h.content_end;
     }
     return true;
@@ -357,8 +375,10 @@ fn derStructureOk(bytes: []const u8, depth: u8) bool {
 
 /// Whether `bytes` is exactly one well-formed DER certificate envelope.
 fn wellFormedCertificate(bytes: []const u8) bool {
+    // A certificate is a SEQUENCE, not merely something constructed.
+    if (bytes.len == 0 or bytes[0] != 0x30) return false;
     const h = readHeader(bytes, 0) orelse return false;
-    if (!h.constructed or h.content_end != bytes.len) return false;
+    if (h.content_end != bytes.len) return false;
     return derStructureOk(bytes[h.content_start..h.content_end], 32);
 }
 
@@ -490,48 +510,127 @@ fn fenced(a: std.mem.Allocator, fence: ?Fence, argv: []const []const u8) ?[]cons
     return sandbox.fenceArgv(a, argv, f.keg_path, f.prefix, .{}) catch null;
 }
 
-/// Production verifier: one `security verify-cert` per candidate. This is the
-/// whole remaining cost, and what an in-process trust evaluation would remove.
-const ForkVerifier = struct {
-    io: std.Io,
-    gpa: std.mem.Allocator,
-    /// Randomly named, inside the malt prefix rather than shared /tmp, so a
-    /// local attacker cannot pre-place a symlink on the path malt writes.
-    dir: []const u8,
-    fence: ?Fence,
+// --- Security.framework -----------------------------------------------
+//
+// The trust decision is the one part of upstream's script that genuinely
+// needs macOS. Asking `security(1)` meant a process per certificate; asking
+// the framework directly is the same question to the same daemon, minus the
+// fork, and it removes the temp file each answer used to need.
+//
+// Distinct opaque types rather than one `?*anyopaque` alias: these all look
+// alike to C, and a swapped certificate/policy argument in a trust path
+// should not compile.
 
-    fn verifier(self: *ForkVerifier) Verifier {
-        return .{ .ctx = self, .call = call };
-    }
+const CFAllocator = opaque {};
+const CFData = opaque {};
+const CFError = opaque {};
+const CFString = opaque {};
+const SecCertificate = opaque {};
+const SecPolicy = opaque {};
+const SecTrust = opaque {};
 
-    fn call(ctx: ?*anyopaque, pem: []const u8, purpose: Purpose) Verdict {
-        const self: *ForkVerifier = @ptrCast(@alignCast(ctx));
-        var path_buf: [std.fs.max_path_bytes]u8 = undefined;
-        const path = std.fmt.bufPrint(&path_buf, "{s}/{d}.pem", .{
-            self.dir, verify_seq.fetchAdd(1, .monotonic),
-        }) catch return .undetermined;
-        std.Io.Dir.cwd().writeFile(self.io, .{ .sub_path = path, .data = pem }) catch
-            return .undetermined;
-        defer std.Io.Dir.cwd().deleteFile(self.io, path) catch {};
+extern "c" fn CFDataCreate(allocator: ?*CFAllocator, bytes: [*]const u8, length: isize) ?*CFData;
+extern "c" fn SecCertificateCreateWithData(allocator: ?*CFAllocator, data: ?*CFData) ?*SecCertificate;
+extern "c" fn SecPolicyCreateBasicX509() ?*SecPolicy;
+extern "c" fn SecPolicyCreateSSL(server: u8, hostname: ?*CFString) ?*SecPolicy;
+extern "c" fn SecTrustCreateWithCertificates(certs: ?*SecCertificate, policies: ?*SecPolicy, trust: *?*SecTrust) i32;
+extern "c" fn SecTrustSetOptions(trust: ?*SecTrust, options: usize) i32;
+extern "c" fn SecTrustSetNetworkFetchAllowed(trust: ?*SecTrust, allow: u8) i32;
+extern "c" fn SecTrustEvaluateWithError(trust: ?*SecTrust, err: *?*CFError) u8;
+extern "c" fn CFErrorGetCode(err: ?*CFError) isize;
+extern "c" fn CFErrorGetDomain(err: ?*CFError) ?*CFString;
+extern "c" fn CFEqual(a: ?*anyopaque, b: ?*anyopaque) u8;
+/// The domain the codes above are numbered in. A code from any other domain
+/// means something else entirely, however familiar the number looks.
+extern const kCFErrorDomainOSStatus: ?*CFString;
 
-        var arena = std.heap.ArenaAllocator.init(self.gpa);
-        defer arena.deinit();
-        const argv = fenced(arena.allocator(), self.fence, &.{
-            "/usr/bin/security", "verify-cert", "-l", "-L",
-            "-c",                path,          "-p", purpose.flag(),
-            "-R",                "offline",
-        }) orelse return .undetermined;
+/// `CFRelease` takes any CoreFoundation handle; binding it once and casting
+/// here keeps the distinct pointer types at every other call site. Null is
+/// dropped rather than passed on — `CFRelease(NULL)` is a crash, not a no-op,
+/// and a handle only reaches here behind an `OSStatus` we did not set.
+fn cfRelease(handle: anytype) void {
+    const opaque_handle: ?*anyopaque = @ptrCast(handle);
+    if (opaque_handle == null) return;
+    const release = @extern(*const fn (?*anyopaque) callconv(.c) void, .{ .name = "CFRelease" });
+    release(opaque_handle);
+}
 
-        // Only a clean run answers the question. A spawn or wait failure -
-        // fd exhaustion during a wide parallel install, say - is not a "no".
-        var report = child.run(self.io, self.gpa, argv) catch return .undetermined;
-        defer report.deinit(self.gpa);
-        return if (report.code == 0) .trusted else .rejected;
-    }
+/// `kSecTrustOptionLeafIsCA`, mirroring upstream's `verify-cert -l`. Neither
+/// the tool nor `SecTrustEvaluateWithError` appears to enforce the old
+/// leaf-must-not-be-a-CA rule any more, so this changes no verdict today -
+/// it is set to keep the two invocations aligned if that ever returns.
+const leaf_is_ca: usize = 0x02;
+
+/// Codes the trust store returns when it has actually judged a certificate and
+/// said no. Observed across every root on a real machine under both policies,
+/// then checked against `Security/SecBase.h` for what each one means.
+///
+/// Deliberately an allowlist, and only within the OSStatus error domain.
+/// Anything else — a wedged trust daemon, an unreachable keychain — is the
+/// question going unanswered, and reading that as "untrusted" would write a
+/// bundle missing roots. An unlisted genuine rejection only costs speed: the
+/// build aborts and the shipped script runs.
+const rejection_codes = [_]isize{
+    -67843, // errSecNotTrusted
+    -67901, // errSecCertificateValidityPeriodTooLong
+    -67609, // errSecInvalidExtendedKeyUsage
 };
 
-/// Distinguishes the temp files concurrent hooks hand to `verify-cert`.
-var verify_seq: std.atomic.Value(u32) = .init(0);
+/// Evaluate `der_bytes` against the system trust store, mirroring
+/// `verify-cert -l -L -p <policy> -R offline`. Anything that stops the
+/// question being asked is `undetermined`, never a rejection.
+fn evaluateTrust(der_bytes: []const u8, purpose: Purpose) Verdict {
+    const data = CFDataCreate(null, der_bytes.ptr, @intCast(der_bytes.len)) orelse
+        return .undetermined;
+    defer cfRelease(data);
+    const cert = SecCertificateCreateWithData(null, data) orelse return .undetermined;
+    defer cfRelease(cert);
+
+    const policy = switch (purpose) {
+        // `true`: evaluate as a TLS *server* certificate, matching `-p ssl`.
+        .ssl => SecPolicyCreateSSL(1, null),
+        .basic => SecPolicyCreateBasicX509(),
+    } orelse return .undetermined;
+    defer cfRelease(policy);
+
+    var trust: ?*SecTrust = null;
+    if (SecTrustCreateWithCertificates(cert, policy, &trust) != 0) return .undetermined;
+    defer cfRelease(trust);
+
+    _ = SecTrustSetOptions(trust, leaf_is_ca);
+    // `-L` and `-R offline`: the evaluation must never reach the network. If
+    // that cannot be guaranteed, do not ask the question at all — an online
+    // evaluation can block for as long as the network takes to time out.
+    if (SecTrustSetNetworkFetchAllowed(trust, 0) != 0) return .undetermined;
+
+    var err: ?*CFError = null;
+    if (SecTrustEvaluateWithError(trust, &err) != 0) {
+        if (err) |e| cfRelease(e);
+        return .trusted;
+    }
+    // A `false` with no error, or with any other code, means the evaluation
+    // did not reach a verdict — a wedged trust daemon would otherwise read as
+    // "every root is untrusted" and write a bundle missing all of them.
+    const e = err orelse return .undetermined;
+    defer cfRelease(e);
+    if (CFEqual(CFErrorGetDomain(e), kCFErrorDomainOSStatus) == 0) return .undetermined;
+    const code = CFErrorGetCode(e);
+    return if (std.mem.indexOfScalar(isize, &rejection_codes, code) != null)
+        .rejected
+    else
+        .undetermined;
+}
+
+/// Production verifier. Holds no state: the trust store is the system's.
+const SystemVerifier = struct {
+    fn verifier() Verifier {
+        return .{ .call = call };
+    }
+
+    fn call(_: ?*anyopaque, der_bytes: []const u8, purpose: Purpose) Verdict {
+        return evaluateTrust(der_bytes, purpose);
+    }
+};
 
 // --- tests -----------------------------------------------------------
 
@@ -664,6 +763,33 @@ test "a nested length overrunning its parent is rejected, not handed to the pars
         // Must be refused; reaching Certificate.parse here aborts the process.
         try testing.expect(!wellFormedCertificate(probe[0..n]));
     }
+}
+
+test "an empty BIT STRING is refused before it reaches the parser" {
+    // Structurally flawless, and it panics std's reader: the whole reason the
+    // validator checks primitive content and not just nesting.
+    const empty_bitstring = [_]u8{ 0x30, 0x02, 0x03, 0x00 };
+    try testing.expect(!wellFormedCertificate(&empty_bitstring));
+    // One content byte is the minimum DER allows, and is accepted.
+    const minimal = [_]u8{ 0x30, 0x03, 0x03, 0x01, 0x00 };
+    try testing.expect(wellFormedCertificate(&minimal));
+}
+
+test "a top-level element that is not a SEQUENCE is refused" {
+    // Constructed, well-nested, but a SET - not a certificate.
+    try testing.expect(!wellFormedCertificate(&.{ 0x31, 0x03, 0x02, 0x01, 0x00 }));
+}
+
+test "the nesting cap counts levels exactly, and refuses one past it" {
+    // Each SEQUENCE wraps the next, innermost empty.
+    var deep: [66]u8 = undefined;
+    for (0..33) |i| {
+        deep[i * 2] = 0x30;
+        deep[i * 2 + 1] = @intCast((32 - i) * 2);
+    }
+    try testing.expect(!derStructureOk(&deep, 32)); // 33 levels
+    try testing.expect(derStructureOk(deep[2..], 32)); // 32 levels
+    try testing.expect(!derStructureOk(deep[2..], 31)); // ...but not under 31
 }
 
 test "every prefix of a real certificate is refused without crashing" {

--- a/src/core/dsl/sandbox.zig
+++ b/src/core/dsl/sandbox.zig
@@ -175,27 +175,33 @@ pub fn validateWriteDir(
     try resolvedDirWithinBoundary(io, std.fs.path.dirname(target_path), cellar_path, malt_prefix);
 }
 
-/// Confine a path that may legitimately be a symlink. `validatePath` is
-/// lexical and `openSourceNoFollow` refuses links outright — neither fits a
-/// read whose target malt's own linker points into the keg. Resolve the path
-/// and judge where it landed, against a boundary resolved the same way
-/// (macOS `/tmp` is itself a symlink, so both sides must be canonical).
-pub fn validateResolvedPath(
+/// Resolve a path that may legitimately be a symlink and confine where it
+/// lands. `validatePath` is lexical and `openSourceNoFollow` refuses links
+/// outright — neither fits a read whose target malt's own linker points into
+/// the keg. The boundary is resolved too: macOS `/tmp` is itself a symlink,
+/// so both sides must be canonical to compare.
+///
+/// Returns the resolved path rather than just approving the original, so the
+/// caller acts on what was actually checked. Handing back a verdict alone
+/// would leave the caller re-opening a link that can change in between.
+pub fn resolveConfined(
     io: std.Io,
+    buf: []u8,
     target_path: []const u8,
     cellar_path: []const u8,
     malt_prefix: []const u8,
-) SandboxError!void {
-    var buf: [std.fs.max_path_bytes]u8 = undefined;
-    const n = std.Io.Dir.cwd().realPathFile(io, target_path, &buf) catch
+) SandboxError![]const u8 {
+    const n = std.Io.Dir.cwd().realPathFile(io, target_path, buf) catch
         return SandboxError.PathSandboxViolation;
     const real = buf[0..n];
+    // realpath already collapses `..`, so this cannot currently fire; it
+    // mirrors `resolvedDirWithinBoundary` so both agree if that ever changes.
     if (containsDotDot(real)) return SandboxError.PathSandboxViolation;
 
     var cbuf: [std.fs.max_path_bytes]u8 = undefined;
     var xbuf: [std.fs.max_path_bytes]u8 = undefined;
-    if (pathHasPrefix(real, realPathOr(io, cellar_path, &cbuf, cellar_path))) return;
-    if (pathHasPrefix(real, realPathOr(io, malt_prefix, &xbuf, malt_prefix))) return;
+    if (pathHasPrefix(real, realPathOr(io, cellar_path, &cbuf, cellar_path))) return real;
+    if (pathHasPrefix(real, realPathOr(io, malt_prefix, &xbuf, malt_prefix))) return real;
     return SandboxError.PathSandboxViolation;
 }
 
@@ -512,4 +518,161 @@ pub fn pathHasPrefix(path: []const u8, prefix: []const u8) bool {
     // Next char in path must be the separator; otherwise it's a substring,
     // not a path-component prefix.
     return path[prefix.len] == '/';
+}
+
+// --- resolveConfined -------------------------------------------------------
+//
+// The read side of the CA-bundle substitution leans on this: the source is a
+// symlink malt's own linker planted, so links must be followed, and following
+// them is exactly how a hostile formula would reach outside the keg.
+
+/// Prefix/keg pair plus a file and the links used to probe the boundary.
+const ConfineFixture = struct {
+    scratch: Scratch,
+    prefix: [:0]const u8,
+    keg: [:0]const u8,
+
+    fn init() !ConfineFixture {
+        var s = try Scratch.init("confine");
+        errdefer s.deinit();
+        const prefix = s.p("/prefix");
+        const keg = s.p("/prefix/Cellar/pkg/1.0");
+        try std.Io.Dir.cwd().createDirPath(fs_test_io, keg);
+        try std.Io.Dir.cwd().createDirPath(fs_test_io, s.p("/prefix/share"));
+        try std.Io.Dir.cwd().createDirPath(fs_test_io, s.p("/outside"));
+        try writeEmpty(s.p("/prefix/Cellar/pkg/1.0/real.pem"));
+        try writeEmpty(s.p("/outside/secret.pem"));
+        return .{ .scratch = s, .prefix = prefix, .keg = keg };
+    }
+
+    fn deinit(self: *ConfineFixture) void {
+        self.scratch.deinit();
+    }
+
+    fn confine(self: *ConfineFixture, path: []const u8, buf: []u8) SandboxError![]const u8 {
+        return resolveConfined(fs_test_io, buf, path, self.keg, self.prefix);
+    }
+};
+
+fn writeEmpty(path: []const u8) !void {
+    const f = try std.Io.Dir.createFileAbsolute(fs_test_io, path, .{});
+    f.close(fs_test_io);
+}
+
+test "a real file inside the keg resolves and is allowed" {
+    var fx = try ConfineFixture.init();
+    defer fx.deinit();
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const got = try fx.confine(fx.scratch.p("/prefix/Cellar/pkg/1.0/real.pem"), &buf);
+    try std.testing.expectEqualStrings(fx.scratch.p("/prefix/Cellar/pkg/1.0/real.pem"), got);
+}
+
+test "a symlink into the keg is followed, and the target's path comes back" {
+    var fx = try ConfineFixture.init();
+    defer fx.deinit();
+    // This is malt's own layout: the linker points share/ at the keg.
+    const link = fx.scratch.p("/prefix/share/cacert.pem");
+    try std.Io.Dir.symLinkAbsolute(fs_test_io, fx.scratch.p("/prefix/Cellar/pkg/1.0/real.pem"), link, .{});
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const got = try fx.confine(link, &buf);
+    // The resolved target, not the link handed in - the caller reads this.
+    try std.testing.expectEqualStrings(fx.scratch.p("/prefix/Cellar/pkg/1.0/real.pem"), got);
+    try std.testing.expect(!std.mem.eql(u8, link, got));
+}
+
+test "a symlink inside the keg pointing outside it is refused" {
+    var fx = try ConfineFixture.init();
+    defer fx.deinit();
+    const link = fx.scratch.p("/prefix/Cellar/pkg/1.0/smuggled.pem");
+    try std.Io.Dir.symLinkAbsolute(fs_test_io, fx.scratch.p("/outside/secret.pem"), link, .{});
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    try std.testing.expectError(SandboxError.PathSandboxViolation, fx.confine(link, &buf));
+}
+
+test "a chain of symlinks is followed to its end, and judged there" {
+    var fx = try ConfineFixture.init();
+    defer fx.deinit();
+    const mid = fx.scratch.p("/prefix/share/mid.pem");
+    const outer = fx.scratch.p("/prefix/share/outer.pem");
+    try std.Io.Dir.symLinkAbsolute(fs_test_io, fx.scratch.p("/outside/secret.pem"), mid, .{});
+    try std.Io.Dir.symLinkAbsolute(fs_test_io, mid, outer, .{});
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    // Only the last hop leaves the boundary; a one-level check would miss it.
+    try std.testing.expectError(SandboxError.PathSandboxViolation, fx.confine(outer, &buf));
+}
+
+test "a path outside the boundary is refused even with no symlink involved" {
+    var fx = try ConfineFixture.init();
+    defer fx.deinit();
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    try std.testing.expectError(
+        SandboxError.PathSandboxViolation,
+        fx.confine(fx.scratch.p("/outside/secret.pem"), &buf),
+    );
+}
+
+test "dot-dot that climbs out is refused; dot-dot that stays inside is not" {
+    var fx = try ConfineFixture.init();
+    defer fx.deinit();
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+
+    try std.testing.expectError(
+        SandboxError.PathSandboxViolation,
+        fx.confine(fx.scratch.p("/prefix/Cellar/pkg/1.0/../../../../outside/secret.pem"), &buf),
+    );
+    // Resolution collapses the climb, so a path that never leaves is fine.
+    const got = try fx.confine(fx.scratch.p("/prefix/Cellar/pkg/1.0/../1.0/real.pem"), &buf);
+    try std.testing.expectEqualStrings(fx.scratch.p("/prefix/Cellar/pkg/1.0/real.pem"), got);
+}
+
+test "a sibling directory sharing the prefix's name is not inside it" {
+    var fx = try ConfineFixture.init();
+    defer fx.deinit();
+    // `/prefix-evil` starts with `/prefix` as a string but is a different tree.
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, fx.scratch.p("/prefix-evil"));
+    try writeEmpty(fx.scratch.p("/prefix-evil/secret.pem"));
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    try std.testing.expectError(
+        SandboxError.PathSandboxViolation,
+        fx.confine(fx.scratch.p("/prefix-evil/secret.pem"), &buf),
+    );
+}
+
+test "a boundary reached through a symlink still contains the file" {
+    var fx = try ConfineFixture.init();
+    defer fx.deinit();
+    // The boundary handed in is a link to the real prefix. macOS does this to
+    // every path under /tmp, and comparing the two literally is what once made
+    // the builder refuse its own source.
+    const prefix_link = fx.scratch.p("/prefix-via-link");
+    try std.Io.Dir.symLinkAbsolute(fs_test_io, fx.prefix, prefix_link, .{});
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    // An unrelated keg, so only the prefix branch can accept this.
+    const got = try resolveConfined(
+        fs_test_io,
+        &buf,
+        fx.scratch.p("/prefix/Cellar/pkg/1.0/real.pem"),
+        fx.scratch.p("/prefix/Cellar/other/9.9"),
+        prefix_link,
+    );
+    try std.testing.expectEqualStrings(fx.scratch.p("/prefix/Cellar/pkg/1.0/real.pem"), got);
+}
+
+test "a path that does not exist is refused rather than assumed safe" {
+    var fx = try ConfineFixture.init();
+    defer fx.deinit();
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    try std.testing.expectError(
+        SandboxError.PathSandboxViolation,
+        fx.confine(fx.scratch.p("/prefix/Cellar/pkg/1.0/missing.pem"), &buf),
+    );
+    // A dangling link resolves to nothing, which is the same answer.
+    const dangling = fx.scratch.p("/prefix/share/dangling.pem");
+    try std.Io.Dir.symLinkAbsolute(fs_test_io, fx.scratch.p("/prefix/nowhere.pem"), dangling, .{});
+    try std.testing.expectError(SandboxError.PathSandboxViolation, fx.confine(dangling, &buf));
 }

--- a/src/core/dsl/sandbox.zig
+++ b/src/core/dsl/sandbox.zig
@@ -175,6 +175,30 @@ pub fn validateWriteDir(
     try resolvedDirWithinBoundary(io, std.fs.path.dirname(target_path), cellar_path, malt_prefix);
 }
 
+/// Confine a path that may legitimately be a symlink. `validatePath` is
+/// lexical and `openSourceNoFollow` refuses links outright — neither fits a
+/// read whose target malt's own linker points into the keg. Resolve the path
+/// and judge where it landed, against a boundary resolved the same way
+/// (macOS `/tmp` is itself a symlink, so both sides must be canonical).
+pub fn validateResolvedPath(
+    io: std.Io,
+    target_path: []const u8,
+    cellar_path: []const u8,
+    malt_prefix: []const u8,
+) SandboxError!void {
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = std.Io.Dir.cwd().realPathFile(io, target_path, &buf) catch
+        return SandboxError.PathSandboxViolation;
+    const real = buf[0..n];
+    if (containsDotDot(real)) return SandboxError.PathSandboxViolation;
+
+    var cbuf: [std.fs.max_path_bytes]u8 = undefined;
+    var xbuf: [std.fs.max_path_bytes]u8 = undefined;
+    if (pathHasPrefix(real, realPathOr(io, cellar_path, &cbuf, cellar_path))) return;
+    if (pathHasPrefix(real, realPathOr(io, malt_prefix, &xbuf, malt_prefix))) return;
+    return SandboxError.PathSandboxViolation;
+}
+
 /// Validate a *directory* that will be written into (cp / cp_r dest). Unlike
 /// `validateWriteDir`, the directory itself is resolved: when copying into `D`, a
 /// symlinked `D` pointing out of the keg is the escape, not a safe replace

--- a/src/core/post_install_steps.zig
+++ b/src/core/post_install_steps.zig
@@ -1696,10 +1696,13 @@ fn buildCaBundle(ctx: StepsCtx, argv: []const []const u8) !void {
     });
 
     const dir = std.fs.path.dirname(argv[2]) orelse return error.NoParentDirectory;
-    try std.Io.Dir.cwd().createDirPath(ctx.io, dir);
-    // Re-check with the parent resolved: a symlinked destination directory is
-    // the escape a path-prefix test alone cannot see.
+    // Confine before creating, not after: `validatePath` above is lexical, so
+    // a destination under a symlinked directory inside the keg passes it, and
+    // creating the tree first would plant directories wherever that link
+    // points before the resolved check refuses. `validateWriteDir` resolves
+    // the nearest ancestor that already exists, so it sees the link.
     try sandbox.validateWriteDir(ctx.io, argv[2], ctx.keg_path, ctx.prefix);
+    try std.Io.Dir.cwd().createDirPath(ctx.io, dir);
     // 0644 explicitly: the script chmods it, and a restrictive umask would
     // otherwise leave the trust store unreadable to every other user.
     try atomic.atomicWriteFileMode(ctx.io, argv[2], bundle, @enumFromInt(0o644));

--- a/src/core/post_install_steps.zig
+++ b/src/core/post_install_steps.zig
@@ -1649,34 +1649,57 @@ fn nativeCaBundle(ctx: StepsCtx, argv: []const []const u8, cmd: []const u8) ?voi
     if (argv.len != 3) return null;
     if (!ca_bundle.isKnownScript(ctx.io, cmd)) return null;
 
+    buildCaBundle(ctx, argv) catch |err| {
+        // The script was recognised but the work could not be done, so the
+        // shipped script runs instead - correct, seconds slower. Say so:
+        // silence here is how a lost fast path, or a trust store that stopped
+        // answering, goes unnoticed on a user's machine.
+        // Name the reason: a code that recurs on every install is a systemic
+        // problem, and a bare "declined" cannot be told apart from a one-off.
+        ctx.flog.note(std.fmt.allocPrint(
+            ctx.allocator,
+            "ca-certificates: native trust-store build declined ({s}), running the shipped script",
+            .{@errorName(err)},
+        ) catch "ca-certificates: native trust-store build declined, running the shipped script");
+        return null;
+    };
+    return {};
+}
+
+fn buildCaBundle(ctx: StepsCtx, argv: []const []const u8) !void {
     // Recognising the script's bytes says nothing about its arguments, and any
     // formula can name this script. Running in-process skips the sandbox that
     // confined the spawned one, so the read and the write are confined here
     // instead — declining hands the step back to the fenced spawn.
-    sandbox.validatePath(argv[1], ctx.keg_path, ctx.prefix) catch return null;
-    sandbox.validatePath(argv[2], ctx.keg_path, ctx.prefix) catch return null;
+    try sandbox.validatePath(argv[2], ctx.keg_path, ctx.prefix);
+
+    // A lexical prefix check would let a link planted inside the keg read
+    // whatever it points at, but refusing links outright is wrong too: malt's
+    // own linker points `{prefix}/share/<name>` entries into the keg, and the
+    // real source is one of them. Resolve first, then confine where it landed.
+    try sandbox.validatePath(argv[1], ctx.keg_path, ctx.prefix);
+    try sandbox.validateResolvedPath(ctx.io, argv[1], ctx.keg_path, ctx.prefix);
 
     // Cap generously but refuse a truncated read: a short source silently
     // drops trusted roots. Upstream's bundle is a few hundred KB.
     const max_source = 8 * 1024 * 1024;
-    const source = fs_read.readFileAllAbsolute(ctx.io, ctx.allocator, argv[1], max_source) catch return null;
-    if (source.len == max_source) return null;
+    const source = try fs_read.readFileAllAbsolute(ctx.io, ctx.allocator, argv[1], max_source);
+    if (source.len == max_source) return error.SourceTruncated;
 
     const now: i64 = @intCast(@divTrunc(std.Io.Timestamp.now(ctx.io, .real).nanoseconds, std.time.ns_per_s));
-    const bundle = ca_bundle.build(ctx.io, ctx.allocator, source, now, .{
+    const bundle = try ca_bundle.build(ctx.io, ctx.allocator, source, now, .{
         .keg_path = ctx.keg_path,
         .prefix = ctx.prefix,
-    }) catch return null;
+    });
 
-    const dir = std.fs.path.dirname(argv[2]) orelse return null;
-    std.Io.Dir.cwd().createDirPath(ctx.io, dir) catch return null;
+    const dir = std.fs.path.dirname(argv[2]) orelse return error.NoParentDirectory;
+    try std.Io.Dir.cwd().createDirPath(ctx.io, dir);
     // Re-check with the parent resolved: a symlinked destination directory is
     // the escape a path-prefix test alone cannot see.
-    sandbox.validateWriteDir(ctx.io, argv[2], ctx.keg_path, ctx.prefix) catch return null;
+    try sandbox.validateWriteDir(ctx.io, argv[2], ctx.keg_path, ctx.prefix);
     // 0644 explicitly: the script chmods it, and a restrictive umask would
     // otherwise leave the trust store unreadable to every other user.
-    atomic.atomicWriteFileMode(ctx.io, argv[2], bundle, @enumFromInt(0o644)) catch return null;
-    return {};
+    try atomic.atomicWriteFileMode(ctx.io, argv[2], bundle, @enumFromInt(0o644));
 }
 
 // --- data-dir initialisers ---------------------------------------------------

--- a/src/core/post_install_steps.zig
+++ b/src/core/post_install_steps.zig
@@ -1678,12 +1678,15 @@ fn buildCaBundle(ctx: StepsCtx, argv: []const []const u8) !void {
     // own linker points `{prefix}/share/<name>` entries into the keg, and the
     // real source is one of them. Resolve first, then confine where it landed.
     try sandbox.validatePath(argv[1], ctx.keg_path, ctx.prefix);
-    try sandbox.validateResolvedPath(ctx.io, argv[1], ctx.keg_path, ctx.prefix);
+    var real_buf: [std.fs.max_path_bytes]u8 = undefined;
+    // Read the resolved path, not the one handed in: opening the link again
+    // would follow whatever it points at now, not what was just confined.
+    const source_path = try sandbox.resolveConfined(ctx.io, &real_buf, argv[1], ctx.keg_path, ctx.prefix);
 
     // Cap generously but refuse a truncated read: a short source silently
     // drops trusted roots. Upstream's bundle is a few hundred KB.
     const max_source = 8 * 1024 * 1024;
-    const source = try fs_read.readFileAllAbsolute(ctx.io, ctx.allocator, argv[1], max_source);
+    const source = try fs_read.readFileAllAbsolute(ctx.io, ctx.allocator, source_path, max_source);
     if (source.len == max_source) return error.SourceTruncated;
 
     const now: i64 = @intCast(@divTrunc(std.Io.Timestamp.now(ctx.io, .real).nanoseconds, std.time.ns_per_s));

--- a/tests/ca_bundle_test.zig
+++ b/tests/ca_bundle_test.zig
@@ -210,3 +210,127 @@ fn readWholeFile(io: std.Io, a: std.mem.Allocator, dir: std.Io.Dir, name: []cons
     }
     return list.items;
 }
+
+/// `security verify-cert` with the flags upstream's script uses. This is the
+/// tool the in-process evaluation replaces, so it is the oracle for it.
+fn verifyCertSaysTrusted(
+    io: std.Io,
+    gpa: std.mem.Allocator,
+    dir: []const u8,
+    pem: []const u8,
+    n: usize,
+    purpose: ca_bundle.Purpose,
+) !bool {
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&buf, "{s}/t{d}.pem", .{ dir, n });
+    try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = path, .data = pem });
+    defer std.Io.Dir.cwd().deleteFile(io, path) catch {};
+
+    var report = try malt.child.run(io, gpa, &.{
+        "/usr/bin/security", "verify-cert", "-l", "-L",
+        "-c",                path,          "-p", @tagName(purpose),
+        "-R",                "offline",
+    });
+    defer report.deinit(gpa);
+    return report.code == 0;
+}
+
+// The trust decision moved from a `security verify-cert` child into
+// Security.framework. Same question, same daemon, no fork - but only a
+// verdict-for-verdict comparison against the tool proves it. Both outcomes
+// are represented: the machine's own roots are trusted, and the synthetic
+// fixtures (self-signed, in nobody's trust store) are not, so an
+// implementation that simply always agreed could not pass.
+test "in-process trust evaluation agrees with security verify-cert" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir = dir_buf[0..try std.Io.Dir.realPath(tmp.dir, io, &dir_buf)];
+
+    var trusted: usize = 0;
+    var fixture_rejected: usize = 0;
+    var live_rejected: usize = 0;
+    var disagreements: usize = 0;
+    var n: usize = 0;
+
+    for ([_]ca_bundle.Purpose{ .basic, .ssl }) |purpose| {
+        // Both keychains the builder reads. The system one is where an admin
+        // or MDM adds trust overrides, which is where the tool and the
+        // framework are most likely to disagree.
+        for ([_][]const u8{ ca_bundle.root_keychain, ca_bundle.system_keychain }) |keychain| {
+            const pem = ca_bundle.dumpKeychain(io, testing.allocator, keychain) catch |e|
+                switch (e) {
+                    error.KeychainUnreadable => return error.SkipZigTest,
+                    else => return e,
+                };
+            defer testing.allocator.free(pem);
+
+            var it = ca_bundle.eachCertificate(pem);
+            while (it.next()) |block| {
+                n += 1;
+                const theirs = try verifyCertSaysTrusted(io, testing.allocator, dir, block, n, purpose);
+                const ours = ca_bundle.wouldTrust(block, purpose);
+                if ((ours == .trusted) != theirs) {
+                    disagreements += 1;
+                    std.debug.print(
+                        "{s} #{d} under {s}: malt says {s}, verify-cert says {}\n",
+                        .{ keychain, n, @tagName(purpose), @tagName(ours), theirs },
+                    );
+                }
+                if (theirs) trusted += 1 else live_rejected += 1;
+            }
+        }
+
+        // Certificates nobody trusts: the rejected side.
+        var fixtures = try std.Io.Dir.cwd().openDir(io, "tests/fixtures/ca_classify", .{ .iterate = true });
+        defer fixtures.close(io);
+        var fit = fixtures.iterate();
+        while (try fit.next(io)) |entry| {
+            if (entry.kind != .file or !std.mem.endsWith(u8, entry.name, ".pem")) continue;
+            n += 1;
+            const block = try readWholeFile(io, a, fixtures, entry.name);
+            const theirs = try verifyCertSaysTrusted(io, testing.allocator, dir, block, n, purpose);
+            const ours = ca_bundle.wouldTrust(block, purpose);
+            if ((ours == .trusted) != theirs) {
+                disagreements += 1;
+                std.debug.print(
+                    "{s} under {s}: malt says {s}, verify-cert says {}\n",
+                    .{ entry.name, @tagName(purpose), @tagName(ours), theirs },
+                );
+            }
+            if (theirs) trusted += 1 else fixture_rejected += 1;
+        }
+    }
+
+    try testing.expectEqual(@as(usize, 0), disagreements);
+    // Every outcome must be genuinely present, counted apart so neither
+    // source can stand in for the other: the machine's own roots supply the
+    // trusted and rejected verdicts, the fixtures supply rejections nobody
+    // could mistake for trust.
+    try testing.expect(trusted > 100);
+    try testing.expect(live_rejected > 10);
+    try testing.expect(fixture_rejected > 10);
+}
+
+// Input the trust store cannot be asked about at all must not read as a
+// rejection: one drops a certificate, the other is a question never answered.
+test "input that is not a certificate is undetermined, never rejected" {
+    const not_a_cert = "-----BEGIN CERTIFICATE-----\nQUJDREVGR0g=\n-----END CERTIFICATE-----\n";
+    try testing.expectEqual(ca_bundle.Verdict.undetermined, ca_bundle.wouldTrust(not_a_cert, .basic));
+
+    const empty_body = "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n";
+    try testing.expectEqual(ca_bundle.Verdict.undetermined, ca_bundle.wouldTrust(empty_body, .basic));
+    try testing.expectEqual(ca_bundle.Verdict.undetermined, ca_bundle.wouldTrust("", .ssl));
+
+    // A real certificate nobody trusts is a verdict, not a failure to ask.
+    const untrusted = @embedFile("fixtures/ca_classify/ca-plain.pem");
+    try testing.expectEqual(ca_bundle.Verdict.rejected, ca_bundle.wouldTrust(untrusted, .basic));
+}


### PR DESCRIPTION
## Description

Building the CA bundle still spawned `security verify-cert` per candidate certificate - a process, a temp file and a sandbox wrapper each - which was all that remained of the seconds the shipped script used to cost. The trust decision needs macOS, but it does not need a fork.

It now goes through Security.framework in-process. 

## Related Issue

- None

## Notes for Reviewers

- None