### PR TITLE
test: run the regression guards that were silently never running

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,10 @@ jobs:
   regressions-hermetic:
     name: Regression guards (hermetic)
     runs-on: macos-14
+    # Deliberate waiting dominates these: ~22 min of run time, 31 min observed
+    # worst case. Bound generously so a genuine hang fails in an hour rather
+    # than sitting for GitHub's six.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
         with:
@@ -142,6 +146,36 @@ jobs:
 
       - name: Hermetic regression guards
         run: just regressions-hermetic
+
+  # Split from the job above rather than appended to it: those guards are
+  # already the longest pole at ~22 min, and these are compile-bound, so as
+  # their own job they cost nothing on the critical path.
+  regressions-harness:
+    name: Regression guards (harness)
+    runs-on: macos-14
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+          use-cache: false
+
+      - name: Install just
+        uses: taiki-e/install-action@v2.85.4
+        with:
+          tool: just
+
+      # The guards bound themselves with `timeout`, which macOS does not ship.
+      - name: Install coreutils
+        run: brew install coreutils
+
+      - name: Harness regression guards
+        run: just regressions-harness
 
   # Drift guard: verify every committed manifest entry's hash against the
   # committed pin on every PR. Catches "bumped pins.zig, forgot to

--- a/justfile
+++ b/justfile
@@ -49,12 +49,40 @@ test: regressions-static
 # Loopback-only regression guards: no network, no GitHub API, no rate limit,
 # so they are safe to gate every PR on. The full pool (`just regressions`)
 # needs a token and live installs, which is why it stays manual.
+#
+# These are deadline tests - they spend most of their time waiting on purpose,
+# about 22 minutes on a CI runner. Keep that in mind before adding to them.
 [group('test')]
 regressions-hermetic:
     @./scripts/regressions/head-read-deadline-response-head-reads-have-no-deadline.sh
     @./scripts/regressions/no-deadline-on-connect-tls-response-head.sh
     @./scripts/regressions/redirect-response-released-with-draining-deinit.sh
     @./scripts/regressions/notifier-probe-unbounded-by-client-retry-backoff.sh
+
+# Guards that build a standalone `zig test` harness. Those duplicate build.zig's
+# module wiring by hand, so they stop compiling when it changes - and a guard
+# that no longer compiles is a guard that no longer guards, which is how the
+# progress-counter one sat broken unnoticed. Compile-bound rather than
+# deadline-bound, so they run as their own job instead of lengthening the
+# slowest one.
+[group('test')]
+regressions-harness:
+    @./scripts/regressions/cached-outdated-drops-revision-bumped-packages.sh
+    @./scripts/regressions/child-run-sequential-pipe-drain-deadlock.sh
+    @./scripts/regressions/cosign-guard-fails-open-and-spawn-not-pinned.sh
+    @./scripts/regressions/csi-whitelist-ignores-private-parameter-bytes.sh
+    @./scripts/regressions/dsl-chmod-mode-cast-panic-large-literal.sh
+    @./scripts/regressions/frame-putcontent-passes-lone-c1-bytes.sh
+    @./scripts/regressions/post-install-run-step-gh804.sh
+    @./scripts/regressions/progress-shared-counters-atomic-progressbar-update-lock-free-data-race.sh
+    @./scripts/regressions/scaled-timeout-clamp-scaled-timeout-overflow-on-content-length.sh
+    @./scripts/regressions/term-sanitize-anti-injection-guarantee.sh
+    @./scripts/regressions/tui-startup-outdated-network-freeze.sh
+    @./scripts/regressions/tui-wrap-rune-boundary-tui-text-wrap-splits-utf8-sequence.sh
+    @./scripts/regressions/tui_tab_chrome_separator_and_headings.sh
+    @./scripts/regressions/unbounded-relative-cursor-motion-enables-spoofing.sh
+    @./scripts/regressions/upgrade-prunes-outdated-snapshot-upgrade-does-not-update-outdated-json.sh
+    @./scripts/regressions/utf8-lead-byte-smuggles-c1-introducer.sh
 
 # Run the full regression pool (token + built binary + per-script timeout).
 # Pass script names to run a subset; MALT_REGRESSION_TIMEOUT overrides the cap.

--- a/scripts/regressions/cosign-guard-fails-open-and-spawn-not-pinned.sh
+++ b/scripts/regressions/cosign-guard-fails-open-and-spawn-not-pinned.sh
@@ -27,21 +27,21 @@ ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 
 # Source-shape pin for the fail-open arm: no resolution error may leave the
 # guard on its success path.
-if rg -q 'realPathFile\(.*\) catch return;' "$ROOT/src/update/verify.zig"; then
+if grep -qE 'realPathFile\(.*\) catch return;' "$ROOT/src/update/verify.zig"; then
   echo "FAIL: the cosign resolver still treats a realpath error as trusted" >&2
   exit 1
 fi
 
 # Pin the defect itself: argv[0] must come from the resolver, never from the
 # caller-supplied name, or the spawn resolves PATH a second time.
-if rg -q '^\s+args\.cosign_bin,$' "$ROOT/src/update/verify.zig"; then
+if grep -qE '^[[:space:]]+args\.cosign_bin,$' "$ROOT/src/update/verify.zig"; then
   echo "FAIL: the cosign spawn takes argv[0] from the unresolved input again" >&2
   exit 1
 fi
 
 # The harness cannot notice the in-tree tests being deleted, so guard them too.
 while IFS= read -r name; do
-  if ! rg -Fq -- "$name" "$ROOT/src/update/verify.zig" "$ROOT/tests/verify_test.zig"; then
+  if ! grep -qF -- "$name" "$ROOT/src/update/verify.zig" "$ROOT/tests/verify_test.zig"; then
     echo "FAIL: a cosign pinning test is missing: $name" >&2
     exit 1
   fi
@@ -122,7 +122,7 @@ ZIG
 
 if OUT=$(cd "$ROOT" && MALT_COSIGN_PIN_TMP="$TMP" zig test -lc -OReleaseSafe "$HARNESS" 2>&1); then
   echo "PASS: the cosign spawn is pinned to the vetted resolution"
-elif printf '%s' "$OUT" | rg -q 'UnvettedCosignRan'; then
+elif printf '%s' "$OUT" | grep -q 'UnvettedCosignRan'; then
   echo "FAIL: the guard vetted a PATH entry the spawn did not run; a prefix-resident cosign rubber-stamped the update" >&2
   exit 1
 else

--- a/scripts/regressions/dsl-chmod-mode-cast-panic-large-literal.sh
+++ b/scripts/regressions/dsl-chmod-mode-cast-panic-large-literal.sh
@@ -21,7 +21,7 @@ ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 # The harness imports the builtin via a repo-relative path, so it must sit at the
 # repo root: the builtin's sibling imports (`../values.zig`, `../sandbox.zig`)
 # only resolve from inside the source tree's module boundary.
-HARNESS="$ROOT/.chmod-mode-cast-regression.zig"
+HARNESS="$ROOT/.chmod-mode-cast-regression.$$.zig"
 trap 'rm -f "$HARNESS"' EXIT
 
 cat >"$HARNESS" <<'ZIG'

--- a/scripts/regressions/progress-shared-counters-atomic-progressbar-update-lock-free-data-race.sh
+++ b/scripts/regressions/progress-shared-counters-atomic-progressbar-update-lock-free-data-race.sh
@@ -8,8 +8,10 @@
 # ThreadSanitizer cannot be the oracle here (a -fsanitize-thread hello-world
 # segfaults on the target toolchain), so the synchronization discipline is
 # pinned structurally at compile time, plus a two-thread smoke run that must
-# survive a resize-repaint storm. progress.zig compiles as a standalone
-# module with its relative sibling imports — no malt build, no network.
+# survive a resize-repaint storm. The driver reaches progress.zig through the
+# `malt` module root: rooting a module at src/ui/progress.zig stops resolving
+# as soon as anything under src/ui/ imports a sibling outside it, which is how
+# this guard silently stopped compiling. No network.
 #
 # Exits 0 when the counters are atomic and the storm run is clean; non-zero
 # with a clear message otherwise.
@@ -22,7 +24,7 @@ trap 'rm -rf "$TMP"' EXIT
 
 cat >"$TMP/driver.zig" <<'ZIG'
 const std = @import("std");
-const progress = @import("progress");
+const progress = @import("malt").progress;
 
 comptime {
     // The group mutex only guards draws; the counters cross threads on their own.
@@ -75,9 +77,22 @@ pub fn main() !void {
 }
 ZIG
 
-if ! zig build-exe -femit-bin="$TMP/driver" \
-  --dep progress -Mmain="$TMP/driver.zig" \
-  -Mprogress="$ROOT/src/ui/progress.zig" 2>"$TMP/build_err.txt"; then
+zig translate-c -I "$ROOT/vendor/" "$ROOT/c/sqlite.h" >"$TMP/c_sqlite.zig" 2>/dev/null
+zig translate-c "$ROOT/c/clonefile.h" >"$TMP/c_clonefile.zig" 2>/dev/null
+zig translate-c "$ROOT/c/mount.h" >"$TMP/c_mount.zig" 2>/dev/null
+
+# ca_bundle.zig evaluates trust in-process; the module graph needs the same
+# frameworks build.zig links.
+if ! zig build-exe -femit-bin="$TMP/driver" -lc \
+  -I "$ROOT/vendor/" -I "$ROOT/c/" \
+  -framework Security -framework CoreFoundation \
+  --dep malt -Mmain="$TMP/driver.zig" \
+  --dep c_sqlite --dep c_clonefile --dep c_mount \
+  -Mmalt="$ROOT/src/lib.zig" \
+  -cflags -DSQLITE_OMIT_LOAD_EXTENSION -DSQLITE_THREADSAFE=1 -DSQLITE_DQS=0 -- "$ROOT/vendor/sqlite3.c" \
+  -Mc_sqlite="$TMP/c_sqlite.zig" \
+  -Mc_clonefile="$TMP/c_clonefile.zig" \
+  -Mc_mount="$TMP/c_mount.zig" 2>"$TMP/build_err.txt"; then
   if grep -q "must be atomic" "$TMP/build_err.txt"; then
     echo "FAIL: shared progress counters are not atomic" >&2
   else

--- a/scripts/regressions/scaled-timeout-clamp-scaled-timeout-overflow-on-content-length.sh
+++ b/scripts/regressions/scaled-timeout-clamp-scaled-timeout-overflow-on-content-length.sh
@@ -19,7 +19,7 @@ ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 
 # The harness imports the client via a repo-relative path, so it must sit at the
 # repo root for that path to resolve.
-HARNESS="$ROOT/.scaled-timeout-clamp-regression.zig"
+HARNESS="$ROOT/.scaled-timeout-clamp-regression.$$.zig"
 trap 'rm -f "$HARNESS"' EXIT
 
 cat >"$HARNESS" <<'ZIG'

--- a/scripts/regressions/term-sanitize-anti-injection-guarantee.sh
+++ b/scripts/regressions/term-sanitize-anti-injection-guarantee.sh
@@ -22,7 +22,7 @@ ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 
 # The harness imports the sanitizer via a repo-relative path, so it must sit at
 # the repo root for the source tree's module boundary to resolve.
-HARNESS="$ROOT/.term-sanitize-anti-injection-regression.zig"
+HARNESS="$ROOT/.term-sanitize-anti-injection-regression.$$.zig"
 trap 'rm -f "$HARNESS"' EXIT
 
 cat >"$HARNESS" <<'ZIG'

--- a/scripts/regressions/tui-startup-outdated-network-freeze.sh
+++ b/scripts/regressions/tui-startup-outdated-network-freeze.sh
@@ -38,7 +38,7 @@ command -v zig >/dev/null 2>&1 || fail 'zig not found on PATH'
 WORK=$(mktemp -d -t mt_tui_async.XXXXXX)
 # The check file must sit at the repo root so its `src/...` imports stay inside
 # the module path. Both temp artifacts are removed on exit.
-CHECK="$ROOT/.tui_async_outdated_check.zig"
+CHECK="$ROOT/.tui_async_outdated_check.$$.zig"
 trap 'rm -rf "$WORK" "$CHECK"' EXIT
 
 cat >"$CHECK" <<'ZIG'
@@ -99,7 +99,10 @@ test "a fetch is reported ready by index on its EOF, among several" {
 }
 ZIG
 
-if ! zig test "$CHECK" 2>"$WORK/err.txt"; then
+# Hard bound: the check polls a pipe deliberately held open with no data, so
+# the regression it guards against is precisely a hang. Unbounded, that would
+# stall CI for hours instead of failing.
+if ! timeout 120 zig test "$CHECK" 2>"$WORK/err.txt"; then
   sed 's/^/  /' "$WORK/err.txt" >&2
   fail 'tui async-fetch multiplex check failed — the input loop does not multiplex the tty with the background tab audits'
 fi

--- a/scripts/regressions/tui_tab_chrome_separator_and_headings.sh
+++ b/scripts/regressions/tui_tab_chrome_separator_and_headings.sh
@@ -33,7 +33,7 @@ WORK=$(mktemp -d -t mt_tui_chrome.XXXXXX)
 # The check file must sit at the repo root so its imports stay inside the
 # module path (the tui render modules reach into src/ui/). Both temp artifacts
 # are removed on exit.
-CHECK="$ROOT/.tui_chrome_check.zig"
+CHECK="$ROOT/.tui_chrome_check.$$.zig"
 trap 'rm -rf "$WORK" "$CHECK"' EXIT
 
 cat >"$CHECK" <<ZIG


### PR DESCRIPTION
## Description

The progress-counter race guard had stopped compiling: it rooted a Zig module at `src/ui/progress.zig`, which breaks as soon as anything under `src/ui/` imports a sibling outside it. Nothing noticed, because nothing ran it - of 185 regression guards, 11 were reachable from CI or a justfile recipe and 174 only ran in a manual sweep.

The guard is repaired and re-verified to still fail on a non-atomic counter.

## Related Issue

- None

## Notes for Reviewers

- None