### PR TITLE
fix(install): install tap formulas that ship an uncompressed binary

### DIFF
--- a/scripts/regressions/tap-raw-binary-cliamp-installation-failure.sh
+++ b/scripts/regressions/tap-raw-binary-cliamp-installation-failure.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Regression for tap formulas whose `url` is a bare release binary.
+#
+# The tap install path classified the archive by URL suffix before
+# fetching anything, and only knew .tar.gz/.tgz/.tar.xz/.zip. A
+# GoReleaser-style asset (`.../cliamp-darwin-arm64`) matched nothing, so
+# the install aborted with "Unsupported archive format" before a byte
+# was downloaded — an entire class of single-file taps was unreachable.
+# The fix lets an unrecognised suffix take a raw-binary path, sniffs the
+# staged bytes for Mach-O magic, and copies the asset straight to
+# `bin/<name>` (the `bin.install <asset> => <name>` rename).
+#
+# Both halves matter: the bare binary must install, AND a compressed
+# body arriving on the same path must still be refused — the fallback
+# is a sniff, not a blanket accept.
+#
+# The 30 MB release asset is never fetched: the warm-cache branch is
+# keyed purely on `<sha>.<ext>` and re-verifies nothing, so seeding
+# `<prefix>/cache/Tap/<sha>.bin` leaves only the tap resolve and one
+# raw `.rb` fetch on the network.
+#
+# Usage: scripts/regressions/tap-raw-binary-cliamp-installation-failure.sh
+# Requirements: built `malt` at $MALT_BIN or zig-out/bin/malt, macOS
+# (the sniff is Mach-O), network access to raw.githubusercontent.com.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+[[ "$(uname -s)" == "Darwin" ]] || {
+  printf '  - not macOS; the raw-binary sniff is Mach-O only\n'
+  exit 0
+}
+
+# MALT_PREFIX must be ≤ 13 bytes (Mach-O in-place patching budget).
+PREFIX="/tmp/mt_rawbin"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+export MALT_GITHUB_TOKEN="${MALT_GITHUB_TOKEN:-$(gh auth token 2>/dev/null || true)}"
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX/cache/Tap"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  ✓ %s\n' "$*"; }
+skip() { printf '  - %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+TAP_RB="https://raw.githubusercontent.com/bjarneo/homebrew-cliamp/main/Formula/cliamp.rb"
+RB=$(curl -fsSL "$TAP_RB" 2>/dev/null) || {
+  skip "upstream tap unreachable; nothing to assert"
+  exit 0
+}
+
+VERSION=$(printf '%s\n' "$RB" | sed -n 's/^[[:space:]]*version "\([^"]*\)".*/\1/p' | head -1)
+[[ -n "$VERSION" ]] || fail "could not read version from the upstream formula"
+
+# The formula pairs one url/sha256 per platform block; pick the pair
+# matching this host so the seeded cache filename is the one malt looks up.
+case "$(uname -m)" in
+arm64) ASSET="darwin-arm64" ;;
+x86_64) ASSET="darwin-amd64" ;;
+*) fail "unsupported host architecture: $(uname -m)" ;;
+esac
+SHA=$(printf '%s\n' "$RB" |
+  awk -v want="$ASSET" '
+    $0 ~ "url .*" want "\"" { armed = 1; next }
+    armed && /sha256 "/ { gsub(/^.*sha256 "|".*$/, ""); print; exit }
+  ')
+[[ ${#SHA} -eq 64 ]] || fail "could not read the $ASSET sha256 from the upstream formula"
+
+CACHED="$PREFIX/cache/Tap/$SHA.bin"
+DEST="$PREFIX/Cellar/cliamp/$VERSION/bin/cliamp"
+
+# ── Positive half: a bare-binary url installs ───────────────────────────
+#
+# /usr/bin/true is a real, tiny, code-signed Mach-O — it stands in for the
+# release asset and doubles as the byte-for-byte comparison source: the
+# install must not mutate the bytes (any edit voids the adhoc signature).
+cp /usr/bin/true "$CACHED"
+LOG="$PREFIX/install.log"
+"$BIN" install bjarneo/cliamp/cliamp >"$LOG" 2>&1 || true
+
+if grep -q "Unsupported archive format" "$LOG"; then
+  tail -20 "$LOG" >&2
+  fail "regression — bare-binary tap url still rejected at the format gate"
+fi
+
+# Tolerate an upstream/network failure that never reached the gate.
+if grep -qE "Tap formula/cask not found|Failed to resolve|rate limit" "$LOG"; then
+  skip "tap resolve reported a non-regression failure; continuing"
+  exit 0
+fi
+
+[[ -f "$DEST" ]] || {
+  tail -20 "$LOG" >&2
+  fail "expected the asset at $DEST"
+}
+[[ -x "$DEST" ]] || fail "$DEST is not executable"
+cmp -s /usr/bin/true "$DEST" || fail "installed bytes differ from the staged asset"
+pass "bare-binary tap url installs to bin/<name> byte-for-byte"
+
+# ── Negative half: a compressed body must still be refused ──────────────
+rm -rf "${PREFIX:?}/Cellar" "${PREFIX:?}/db" "${PREFIX:?}/bin"
+printf 'BZh9' >"$CACHED"
+LOG2="$PREFIX/install_bz2.log"
+if "$BIN" install bjarneo/cliamp/cliamp >"$LOG2" 2>&1; then
+  tail -20 "$LOG2" >&2
+  fail "a bzip2 body on the raw-binary path was accepted"
+fi
+grep -q "Unsupported archive format" "$LOG2" || {
+  tail -20 "$LOG2" >&2
+  fail "expected the unsupported-format refusal for a non-Mach-O body"
+}
+[[ ! -e "$PREFIX/Cellar/cliamp" ]] || fail "refused install left a keg behind"
+pass "non-Mach-O body on the same path is still refused"
+
+printf '\n✔ tap raw-binary install regression passed\n'

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -17,6 +17,7 @@ const forge = @import("../../core/forge.zig");
 const tap_cache = @import("../../core/tap_cache.zig");
 const sqlite = @import("../../db/sqlite.zig");
 const atomic = @import("../../fs/atomic.zig");
+const macho_parser = @import("../../macho/parser.zig");
 const client_mod = @import("../../net/client.zig");
 const output = @import("../../ui/output.zig");
 const progress_mod = @import("../../ui/progress.zig");
@@ -95,6 +96,11 @@ const TapArchiveKind = enum {
     tar_gz,
     tar_xz,
     zip,
+    /// Uncompressed release binary — the GoReleaser / `bin.install <asset>
+    /// => <name>` shape, which carries no archive suffix at all. Never
+    /// returned by `fromUrl`; the call site falls back to it and confirms
+    /// with a content sniff.
+    raw_binary,
 
     /// Canonical suffix used when staging the downloaded archive on
     /// disk. The `.tgz` alias is accepted on input via `fromUrl` but
@@ -105,6 +111,7 @@ const TapArchiveKind = enum {
             .tar_gz => ".tar.gz",
             .tar_xz => ".tar.xz",
             .zip => ".zip",
+            .raw_binary => ".bin",
         };
     }
 
@@ -553,6 +560,17 @@ fn fstatRisk(f: std.Io.File) ?LocalPermissionRisk {
     return describeLocalPermissionRisk(@intCast(raw.mode), @intCast(raw.uid), @intCast(effective));
 }
 
+/// Does the staged file open with Mach-O magic? The only signal available
+/// once a URL's suffix has told us nothing — a truncated or unreadable file
+/// answers no, so the caller refuses rather than guessing.
+fn stagedIsMachO(io: std.Io, path: []const u8) bool {
+    const file = std.Io.Dir.openFileAbsolute(io, path, .{}) catch return false;
+    defer file.close(io);
+    var magic: [4]u8 = undefined;
+    const n = file.readPositional(io, &.{&magic}, 0) catch return false;
+    return macho_parser.isMachO(magic[0..n]);
+}
+
 /// Compose the staging-archive path used by the tap/local install
 /// flow. The pid suffix prevents two concurrent invocations from
 /// racing on a shared `tap_download.<ext>` filename — without it,
@@ -617,13 +635,10 @@ pub fn materializeRubyFormula(
 
     // Pick the archive kind early so the cache-or-fetch step below
     // can compose `<prefix>/cache/Tap/<sha>.<ext>` before any HTTP
-    // work. Unknown formats fail fast — no point fetching bytes we
-    // can't extract.
-    const archive_kind = TapArchiveKind.fromUrl(resolved.url) orelse {
-        sink.err("Unsupported archive format for {s}: {s}", .{ resolved.name, resolved.url });
-        sink.err("Supported formats: .tar.gz, .tar.xz, .zip.", .{});
-        return InstallError.DownloadFailed;
-    };
+    // work. An unrecognised suffix is not a rejection: many taps ship a
+    // bare release binary. It provisionally takes the raw path and the
+    // staged bytes decide, once they exist.
+    const archive_kind = TapArchiveKind.fromUrl(resolved.url) orelse .raw_binary;
     const archive_ext = archive_kind.extension();
 
     // Same ndjson event shape as the bottle + cask paths so CI
@@ -716,6 +731,15 @@ pub fn materializeRubyFormula(
         ) catch return InstallError.DownloadFailed;
     };
 
+    // The URL suffix said nothing, so the bytes must. Sniff `cache_path`
+    // rather than the freshly fetched body: a warm hit re-verifies nothing,
+    // and would otherwise walk straight past this check.
+    if (archive_kind == .raw_binary and !stagedIsMachO(ctx.io, cache_path)) {
+        sink.err("Unsupported archive format for {s}: {s}", .{ resolved.name, resolved.url });
+        sink.err("Supported formats: .tar.gz, .tar.xz, .zip, or an uncompressed Mach-O binary.", .{});
+        return InstallError.DownloadFailed;
+    }
+
     // `--download-only` stops once the cache holds the SHA-verified
     // bytes — no Cellar writes, no DB inserts. A follow-up
     // `mt install` consumes the warmed entry above.
@@ -766,6 +790,12 @@ pub fn materializeRubyFormula(
         else => return InstallError.CellarFailed,
     };
 
+    // For casks that declare `binary "<x>"`, the shipped file is named
+    // `<x>` while the keg is named by the cask token; match on the
+    // declared binary so a tap cask like `longbridge-terminal` lands its
+    // `longbridge` executable.
+    const target_binary = resolved.binary_name orelse resolved.name;
+
     const archive_mod = @import("../../fs/archive.zig");
     switch (archive_kind) {
         .tar_gz => archive_mod.extractTarGz(ctx.io, cache_path, cellar_path) catch {
@@ -780,6 +810,24 @@ pub fn materializeRubyFormula(
             sink.err("Failed to extract .zip archive for {s}", .{resolved.name});
             return InstallError.CellarFailed;
         },
+        // Nothing to unpack: the asset *is* the artifact. Copy it under the
+        // name the formula declared — the staged basename is the SHA, and
+        // upstream's is `<tool>-<os>-<arch>`, so neither ever matches.
+        .raw_binary => {
+            var dest_buf: [512]u8 = undefined;
+            const dest = std.fmt.bufPrint(&dest_buf, "{s}/{s}", .{ bin_path, target_binary }) catch
+                return InstallError.CellarFailed;
+            // Copied verbatim: the asset is usually adhoc/linker-signed and
+            // any edit makes an arm64 binary unrunnable. The cache entry is
+            // 0644, so the mode is set on create rather than chmod'd after —
+            // the file is never briefly present and unexecutable.
+            std.Io.Dir.copyFileAbsolute(cache_path, dest, ctx.io, .{
+                .permissions = std.Io.File.Permissions.fromMode(0o755),
+            }) catch {
+                sink.err("Failed to stage binary for {s}", .{resolved.name});
+                return InstallError.CellarFailed;
+            };
+        },
     }
 
     // This path never relocates, so nothing overwrites a marker the archive
@@ -789,13 +837,10 @@ pub fn materializeRubyFormula(
     cellar_mod.writeRelocStamp(ctx.io, allocator, cellar_path, .not_applicable);
 
     // Promote the binary to bin/ (GoReleaser may extract directly or
-    // into a subdirectory — walk to handle both). For casks that
-    // declare `binary "<x>"`, the archive file is named `<x>` while
-    // the keg is named by the cask token; match on the declared
-    // binary so a tap cask like `longbridge-terminal` lands its
-    // `longbridge` executable.
-    const target_binary = resolved.binary_name orelse resolved.name;
-    {
+    // into a subdirectory — walk to handle both). The raw path already
+    // wrote bin/<target_binary>; re-running the walk would copy that file
+    // onto itself.
+    if (archive_kind != .raw_binary) {
         var cellar_dir = std.Io.Dir.openDirAbsolute(ctx.io, cellar_path, .{ .iterate = true }) catch return InstallError.CellarFailed;
         defer cellar_dir.close(ctx.io);
 
@@ -1132,6 +1177,33 @@ fn finalizeTapCaskInstall(
             tap_mod.add(db, tap_label, pair.owner, pair.repo, t.commit_sha) catch {};
             if (t.head_etag) |et| tap_mod.updateHead(db, tap_label, t.commit_sha, et) catch {};
         } else |_| {}
+    }
+}
+
+test "fromUrl leaves a bare release binary unclassified" {
+    // The classifier stays a positive archive-suffix match; the
+    // raw-binary fallback is the call site's decision, taken only
+    // after the staged bytes have been sniffed.
+    try std.testing.expectEqual(@as(?TapArchiveKind, null), TapArchiveKind.fromUrl(
+        "https://example.invalid/releases/download/v1.0/tool-darwin-arm64",
+    ));
+    try std.testing.expectEqual(@as(?TapArchiveKind, null), TapArchiveKind.fromUrl("https://example.invalid/tool"));
+    try std.testing.expectEqual(@as(?TapArchiveKind, null), TapArchiveKind.fromUrl("https://example.invalid/tool.bin"));
+}
+
+test "fromUrl still classifies every extractable suffix" {
+    try std.testing.expectEqual(TapArchiveKind.tar_gz, TapArchiveKind.fromUrl("https://e.invalid/a.tar.gz").?);
+    try std.testing.expectEqual(TapArchiveKind.tar_gz, TapArchiveKind.fromUrl("https://e.invalid/a.tgz").?);
+    try std.testing.expectEqual(TapArchiveKind.tar_xz, TapArchiveKind.fromUrl("https://e.invalid/a.tar.xz").?);
+    try std.testing.expectEqual(TapArchiveKind.zip, TapArchiveKind.fromUrl("https://e.invalid/a.zip").?);
+}
+
+test "raw_binary stages under a distinct, stable cache suffix" {
+    // The suffix is the cache key's tail, so it must not collide with an
+    // archive kind and must not drift.
+    try std.testing.expectEqualStrings(".bin", TapArchiveKind.raw_binary.extension());
+    for ([_]TapArchiveKind{ .tar_gz, .tar_xz, .zip }) |kind| {
+        try std.testing.expect(!std.mem.eql(u8, ".bin", kind.extension()));
     }
 }
 

--- a/tests/install_download_only_test.zig
+++ b/tests/install_download_only_test.zig
@@ -126,6 +126,30 @@ fn runTar(argv: []const []const u8) !void {
     }
 }
 
+/// Seed `<prefix>/cache/Tap/<sha>.bin` with `body` so `materializeRubyFormula`
+/// takes the warm-cache branch and never touches the network.
+fn seedRawBinaryCache(prefix: []const u8, sha: []const u8, body: []const u8) ![]const u8 {
+    var parent_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const parent = try std.fmt.bufPrint(&parent_buf, "{s}/cache/Tap", .{prefix});
+    try test_io.cwd().createDirPath(std.Options.debug_io, parent);
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try malt.tap_cache.cachePath(&path_buf, prefix, sha, ".bin");
+    const f = try test_io.cwd().createFile(std.Options.debug_io, path, .{});
+    defer f.close(std.Options.debug_io);
+    try f.writeStreamingAll(std.Options.debug_io, body);
+    return testing.allocator.dupe(u8, path);
+}
+
+/// Minimal body that passes the Mach-O magic sniff. The install path only
+/// reads the magic, so a header-shaped stub stands in for a release asset.
+const macho_stub = blk: {
+    var bytes: [64]u8 = @splat(0);
+    std.mem.writeInt(u32, bytes[0..4], std.macho.MH_MAGIC_64, .little);
+    bytes[8] = 0xAB; // tail marker: proves the copy is byte-for-byte
+    break :blk bytes;
+};
+
 test "execute refuses --download-only combined with --only-dependencies" {
     // The two flags are semantically ambiguous: one says "don't touch the
     // requested package", the other says "don't materialise anything".
@@ -981,4 +1005,262 @@ test "--download-only reports a Ctrl-C as an interruption" {
     // Paired half of the same flag: a cancelled job must not also be listed
     // as a download failure.
     try testing.expect(std.mem.indexOf(u8, captured.items, "Download failed for") == null);
+}
+
+test "materializeRubyFormula installs a tap formula whose url is an uncompressed binary" {
+    // GoReleaser-style taps publish a bare release asset — no archive suffix
+    // at all. The suffix gate used to refuse these before fetching a byte, so
+    // a whole class of single-file taps was uninstallable. The asset must land
+    // at bin/<name> renamed (its own basename never matches) and byte-for-byte
+    // (any edit voids the adhoc signature an arm64 binary needs to run).
+    const prefix = try setupPrefix("rawbin");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const sha = "1a" ** 32;
+    const cache_path = try seedRawBinaryCache(prefix, sha, &macho_stub);
+    defer testing.allocator.free(cache_path);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var http = malt.client.HttpClient.init(ctx.io, ctx.environ, allocator);
+    defer http.deinit();
+
+    const db_path = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/db/malt.db", .{prefix}, 0);
+    defer testing.allocator.free(db_path);
+    var db = try malt.sqlite.Database.open(db_path);
+    defer db.close();
+    try malt.schema.initSchema(&db);
+
+    var linker = malt.linker.Linker.init(ctx.io, allocator, &db, prefix);
+
+    // `.invalid` host: any regression back to the fetch path surfaces as a
+    // network error instead of silently passing.
+    const resolved: malt.install_local.ResolvedRubyFormula = .{
+        .name = "rawpkg",
+        .full_name = "user/repo/rawpkg",
+        .tap_label = "user/repo",
+        .version = "1.0",
+        .url = "https://malt-rawbin-test.invalid/releases/download/v1.0/rawpkg-darwin-arm64",
+        .sha256 = sha,
+    };
+
+    try malt.install_local.materializeRubyFormula(
+        &ctx,
+        allocator,
+        resolved,
+        &http,
+        &db,
+        &linker,
+        prefix,
+        false, // dry_run
+        false, // force
+        false, // download_only
+        malt.install_sink.terminal,
+    );
+
+    const dest = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/rawpkg/1.0/bin/rawpkg", .{prefix});
+    defer testing.allocator.free(dest);
+    try testing.expect(pathExists(dest));
+
+    const st = try test_io.cwd().statFile(std.Options.debug_io, dest, .{});
+    try testing.expectEqual(@as(std.posix.mode_t, 0o755), st.permissions.toMode() & 0o777);
+
+    const got = try test_io.cwd().readFileAlloc(std.Options.debug_io, dest, testing.allocator, .unlimited);
+    defer testing.allocator.free(got);
+    try testing.expectEqualSlices(u8, &macho_stub, got);
+
+    // Recorded and linked like any other keg.
+    try testing.expectEqual(@as(i64, 1), try kegRowCount(prefix));
+    const link = try std.fmt.allocPrint(testing.allocator, "{s}/bin/rawpkg", .{prefix});
+    defer testing.allocator.free(link);
+    try testing.expect(pathExists(link));
+}
+
+test "materializeRubyFormula honours binary_name when staging an uncompressed binary" {
+    // The raw path is what makes `bin.install <asset> => <name>` work: the
+    // destination name comes from the DSL, never from the asset's basename.
+    const prefix = try setupPrefix("rawbinname");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const sha = "2b" ** 32;
+    const cache_path = try seedRawBinaryCache(prefix, sha, &macho_stub);
+    defer testing.allocator.free(cache_path);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var http = malt.client.HttpClient.init(ctx.io, ctx.environ, allocator);
+    defer http.deinit();
+
+    const db_path = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/db/malt.db", .{prefix}, 0);
+    defer testing.allocator.free(db_path);
+    var db = try malt.sqlite.Database.open(db_path);
+    defer db.close();
+    try malt.schema.initSchema(&db);
+
+    var linker = malt.linker.Linker.init(ctx.io, allocator, &db, prefix);
+
+    const resolved: malt.install_local.ResolvedRubyFormula = .{
+        .name = "rawtoken",
+        .full_name = "user/repo/rawtoken",
+        .tap_label = "user/repo",
+        .version = "2.0",
+        .url = "https://malt-rawbin-test.invalid/releases/download/v2.0/rawtoken-linux-amd64",
+        .sha256 = sha,
+        .binary_name = "rawtool",
+    };
+
+    try malt.install_local.materializeRubyFormula(
+        &ctx,
+        allocator,
+        resolved,
+        &http,
+        &db,
+        &linker,
+        prefix,
+        false, // dry_run
+        false, // force
+        false, // download_only
+        malt.install_sink.terminal,
+    );
+
+    const dest = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/rawtoken/2.0/bin/rawtool", .{prefix});
+    defer testing.allocator.free(dest);
+    try testing.expect(pathExists(dest));
+
+    const wrong = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/rawtoken/2.0/bin/rawtoken", .{prefix});
+    defer testing.allocator.free(wrong);
+    try testing.expect(!pathExists(wrong));
+}
+
+test "materializeRubyFormula refuses a compressed body arriving on the raw-binary path" {
+    // The fallback is a sniff, not a blanket accept: an unrecognised suffix
+    // hiding a gzip/bzip2/xz body must still be refused, and must not leave a
+    // keg behind.
+    const prefix = try setupPrefix("rawbinbz");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const sha = "3c" ** 32;
+    const cache_path = try seedRawBinaryCache(prefix, sha, "BZh91AY&SY");
+    defer testing.allocator.free(cache_path);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var http = malt.client.HttpClient.init(ctx.io, ctx.environ, allocator);
+    defer http.deinit();
+
+    const db_path = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/db/malt.db", .{prefix}, 0);
+    defer testing.allocator.free(db_path);
+    var db = try malt.sqlite.Database.open(db_path);
+    defer db.close();
+    try malt.schema.initSchema(&db);
+
+    var linker = malt.linker.Linker.init(ctx.io, allocator, &db, prefix);
+
+    const resolved: malt.install_local.ResolvedRubyFormula = .{
+        .name = "bzpkg",
+        .full_name = "user/repo/bzpkg",
+        .tap_label = "user/repo",
+        .version = "1.0",
+        .url = "https://malt-rawbin-test.invalid/releases/download/v1.0/bzpkg-darwin-arm64",
+        .sha256 = sha,
+    };
+
+    try testing.expectError(install_record.InstallError.DownloadFailed, malt.install_local.materializeRubyFormula(
+        &ctx,
+        allocator,
+        resolved,
+        &http,
+        &db,
+        &linker,
+        prefix,
+        false, // dry_run
+        false, // force
+        false, // download_only
+        malt.install_sink.terminal,
+    ));
+
+    const keg = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/bzpkg", .{prefix});
+    defer testing.allocator.free(keg);
+    try testing.expect(!pathExists(keg));
+    try testing.expectEqual(@as(i64, 0), try kegRowCount(prefix));
+}
+
+test "materializeRubyFormula truncated body on the raw-binary path is refused" {
+    // A body shorter than the 4-byte magic must not read out of bounds or
+    // fall through to accept.
+    const prefix = try setupPrefix("rawbintrunc");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const sha = "4d" ** 32;
+    const cache_path = try seedRawBinaryCache(prefix, sha, "\xcf");
+    defer testing.allocator.free(cache_path);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var http = malt.client.HttpClient.init(ctx.io, ctx.environ, allocator);
+    defer http.deinit();
+
+    const db_path = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/db/malt.db", .{prefix}, 0);
+    defer testing.allocator.free(db_path);
+    var db = try malt.sqlite.Database.open(db_path);
+    defer db.close();
+    try malt.schema.initSchema(&db);
+
+    var linker = malt.linker.Linker.init(ctx.io, allocator, &db, prefix);
+
+    const resolved: malt.install_local.ResolvedRubyFormula = .{
+        .name = "truncpkg",
+        .full_name = "user/repo/truncpkg",
+        .tap_label = "user/repo",
+        .version = "1.0",
+        .url = "https://malt-rawbin-test.invalid/releases/download/v1.0/truncpkg-darwin-arm64",
+        .sha256 = sha,
+    };
+
+    try testing.expectError(install_record.InstallError.DownloadFailed, malt.install_local.materializeRubyFormula(
+        &ctx,
+        allocator,
+        resolved,
+        &http,
+        &db,
+        &linker,
+        prefix,
+        false, // dry_run
+        false, // force
+        false, // download_only
+        malt.install_sink.terminal,
+    ));
+    try testing.expectEqual(@as(i64, 0), try kegRowCount(prefix));
 }


### PR DESCRIPTION
## Description

Taps that publish a bare release binary - the shape used by many single-file taps - were uninstallable. malt classified the artifact from the URL suffix alone and refused anything that was not a known archive, before fetching a byte, with no user-side workaround.

An unrecognised suffix now takes a raw-binary path: the staged bytes are sniffed for Mach-O magic and the asset lands under the name the formula declared. A compressed body arriving the same way is still refused.

## Related Issue

- None

## Notes for Reviewers

- None