### PR TITLE
feat(install): install the dependencies a tap formula declares

### DIFF
--- a/scripts/regressions/tap-formula-declared-dependencies.sh
+++ b/scripts/regressions/tap-formula-declared-dependencies.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Regression for `depends_on` on tap and local formulas.
+#
+# Tap formulas name their runtime dependencies in the `.rb`, not in the
+# JSON API. The tap install path never read them, so a formula declaring
+# `depends_on "flac"` installed as a bare binary with none of the
+# libraries it links against — and `mt cleanup` then saw those libraries
+# as orphans and reaped them.
+#
+# Asserts three things on a local `.rb` (no network, no live tap):
+#   1. `--dry-run` names every declared dependency it would pull in.
+#   2. `:build` and `:optional` deps are NOT named — Homebrew installs
+#      neither by default, so neither describes the keg on disk.
+#   3. A dependency that cannot be resolved fails the install rather than
+#      landing a keg linked against libraries that are absent.
+#
+# Usage: scripts/regressions/tap-formula-declared-dependencies.sh
+# Requirements: built `malt` at $MALT_BIN or zig-out/bin/malt. Offline.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+# MALT_PREFIX must be ≤ 13 bytes (Mach-O in-place patching budget).
+PREFIX="/tmp/mt_tapdep"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  ✓ %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+RB="$PREFIX/deptool.rb"
+cat >"$RB" <<'FORMULA'
+class Deptool < Formula
+  desc "Fixture formula declaring a mix of dependency kinds"
+  homepage "https://example.invalid/deptool"
+  version "1.0.0"
+
+  depends_on "flac"
+  depends_on "libvorbis" => :recommended
+  depends_on "cmake" => :build
+  depends_on "lua" => :optional
+  depends_on :xcode
+
+  on_macos do
+    on_arm do
+      url "https://example.invalid/releases/download/v1.0.0/deptool-darwin-arm64"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+    on_intel do
+      url "https://example.invalid/releases/download/v1.0.0/deptool-darwin-amd64"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+  end
+end
+FORMULA
+
+# ── 1 + 2: the plan names runtime deps only ─────────────────────────────
+LOG="$PREFIX/dryrun.log"
+"$BIN" install --local "$RB" --dry-run >"$LOG" 2>&1 || {
+  cat "$LOG" >&2
+  fail "--dry-run on a local .rb reported a failure"
+}
+
+for dep in flac libvorbis; do
+  grep -q "$dep" "$LOG" || {
+    cat "$LOG" >&2
+    fail "--dry-run did not name the runtime dependency '$dep'"
+  }
+done
+pass "runtime and recommended dependencies appear in the plan"
+
+for dep in cmake lua; do
+  if grep -q "$dep" "$LOG"; then
+    cat "$LOG" >&2
+    fail "--dry-run named '$dep', which malt must not install by default"
+  fi
+done
+pass "build-only and optional dependencies stay out of the plan"
+
+# ── 3: an unresolvable dependency fails the install ─────────────────────
+#
+# The url is unreachable by construction, so without dependency handling
+# this run dies at the download instead — the assertion is specifically
+# that the dependency layer is the one that refuses, and that it refuses
+# before anything is recorded.
+RB2="$PREFIX/ghosttool.rb"
+sed -e 's/Deptool/Ghosttool/' \
+  -e 's/deptool/ghosttool/g' \
+  -e 's/depends_on "flac"/depends_on "malt-no-such-dependency"/' "$RB" >"$RB2"
+
+LOG2="$PREFIX/ghost.log"
+if "$BIN" install --local "$RB2" >"$LOG2" 2>&1; then
+  cat "$LOG2" >&2
+  fail "a formula depending on a nonexistent package installed anyway"
+fi
+grep -qi "depend" "$LOG2" || {
+  cat "$LOG2" >&2
+  fail "install failed without naming the dependency layer"
+}
+[[ ! -e "$PREFIX/Cellar/ghosttool" ]] || fail "refused install left a keg behind"
+pass "an unresolvable dependency fails the install before any keg lands"
+
+printf '\n✔ tap formula dependency regression passed\n'

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -9,6 +9,7 @@ const std = @import("std");
 const AppCtx = @import("../../app_ctx.zig").AppCtx;
 const cask_mod = @import("../../core/cask.zig");
 const cellar_mod = @import("../../core/cellar.zig");
+const formula_mod = @import("../../core/formula.zig");
 const hash = @import("../../core/hash.zig");
 const linker_mod = @import("../../core/linker.zig");
 const tap_mod = @import("../../core/tap.zig");
@@ -71,6 +72,10 @@ pub const ResolvedRubyFormula = struct {
     /// (which ship a bundle) from formula bottles (which ship a binary
     /// tree). Null for formulas and for casks that omit the directive.
     app_name: ?[]const u8 = null,
+    /// Runtime dependencies declared by the `.rb`, already filtered of
+    /// `:build`/`:optional`. Borrowed from the formula source, which
+    /// outlives the install. Empty when the formula declares none.
+    dependencies: []const []const u8 = &.{},
     /// When set, the tap is registered in the DB (mirrors the original
     /// tap install behaviour). Local installs leave this null so they
     /// never pollute the tap list.
@@ -377,6 +382,9 @@ fn installTapRb(
         return InstallError.FormulaNotFound;
     };
 
+    // Borrows from `resp.body`, which outlives the materialise call below.
+    var dep_buf: [64][]const u8 = undefined;
+
     // Substitute #{version} and #{arch} so the SHA-verified fetch
     // hits the right per-platform asset.
     var final_url_buf: [512]u8 = undefined;
@@ -391,6 +399,7 @@ fn installTapRb(
         .sha256 = rb.sha256,
         .binary_name = parseCaskBinary(resp.body),
         .app_name = parseCaskApp(resp.body),
+        .dependencies = formula_mod.declaredInstallDependencies(&dep_buf, resp.body),
         .tap_registration = .{
             .url = urls.repo_url,
             .commit_sha = commit_sha,
@@ -512,6 +521,8 @@ pub fn installLocalFormula(
     var final_url_buf: [512]u8 = undefined;
     const final_url = args.interpolateUrl(&final_url_buf, rb.url, rb.version, rb.arch_token);
 
+    var dep_buf: [64][]const u8 = undefined;
+
     const resolved = ResolvedRubyFormula{
         .name = name,
         .full_name = realpath,
@@ -519,6 +530,8 @@ pub fn installLocalFormula(
         .version = rb.version,
         .url = final_url,
         .sha256 = rb.sha256,
+        // Borrows from `body`, which outlives the materialise call below.
+        .dependencies = formula_mod.declaredInstallDependencies(&dep_buf, body),
         // No tap_registration — never pollute `mt tap` with a local path.
     };
 
@@ -558,6 +571,30 @@ fn fstatRisk(f: std.Io.File) ?LocalPermissionRisk {
     if (std.c.fstat(f.handle, &raw) != 0) return null;
     const effective = std.c.geteuid();
     return describeLocalPermissionRisk(@intCast(raw.mode), @intCast(raw.uid), @intCast(effective));
+}
+
+/// Install a tap/local formula's declared runtime dependencies through the
+/// ordinary API pipeline. `skip_lock` because the caller already holds
+/// `malt.lock` — BSD flock is per-fd, so re-entering would EAGAIN against
+/// our own hold. A dependency that cannot be installed fails the install:
+/// landing a binary against libraries that are not there is worse than
+/// refusing.
+fn installDeclaredDeps(
+    ctx: *const AppCtx,
+    allocator: std.mem.Allocator,
+    resolved: ResolvedRubyFormula,
+    sink: OutputSink,
+) InstallError!void {
+    if (resolved.dependencies.len == 0) return;
+
+    sink.info("Installing {d} dependencies for {s}...", .{ resolved.dependencies.len, resolved.name });
+    install_mod.installAll(ctx, allocator, resolved.dependencies, .{
+        .skip_lock = true,
+        .sink = sink,
+    }) catch {
+        sink.err("Failed to install dependencies for {s}", .{resolved.name});
+        return InstallError.DependencyFailed;
+    };
 }
 
 /// Does the staged file open with Mach-O magic? The only signal available
@@ -623,6 +660,7 @@ pub fn materializeRubyFormula(
 
     if (dry_run) {
         sink.info("Dry run: would install {s} {s} from {s}", .{ resolved.name, resolved.version, resolved.url });
+        for (resolved.dependencies) |dep| sink.info("Dry run: would install dependency {s}", .{dep});
         return;
     }
 
@@ -632,6 +670,14 @@ pub fn materializeRubyFormula(
         sink.info("{s} is already installed", .{resolved.name});
         return;
     }
+
+    // Dependencies first, like `brew`: a tap formula names them in the `.rb`
+    // rather than the API, so nothing else on this path would install them
+    // and the binary would land linked against libraries that are absent.
+    // Ahead of the fetch so a missing dep costs nothing to discover.
+    // `--download-only` skips it — that mode warms a cache, it installs
+    // nothing, and pulling deps would exceed what the user asked for.
+    if (!download_only) try installDeclaredDeps(ctx, allocator, resolved, sink);
 
     // Pick the archive kind early so the cache-or-fetch step below
     // can compose `<prefix>/cache/Tap/<sha>.<ext>` before any HTTP
@@ -932,6 +978,10 @@ pub fn materializeRubyFormula(
             .install_reason = "direct",
             .bin_isolated = false,
         }, .{ .in_transaction = true }) catch return InstallError.RecordFailed;
+
+        // Without these rows `mt cleanup` sees the deps as orphans and
+        // reaps the libraries this keg links against.
+        record.recordDepNames(db, keg_id, resolved.dependencies);
 
         if (resolved.tap_registration) |t| {
             // `COALESCE` in tap_mod.add pins the commit on first install

--- a/src/cli/install/record.zig
+++ b/src/cli/install/record.zig
@@ -43,6 +43,10 @@ pub const InstallError = error{
     /// run build blocks, so it unwinds the half-extracted keg and records
     /// nothing — the user is pointed at `brew install` instead.
     BuildFromSourceUnsupported,
+    /// A tap/local formula's declared `depends_on` could not be installed.
+    /// Distinct from `FormulaNotFound`: the formula itself resolved fine,
+    /// so the user is told which layer failed rather than doubting the tap.
+    DependencyFailed,
     /// `--use-system-ruby` used with multiple formulas and no explicit
     /// scope list. The flag widens the trust boundary (runs full Ruby
     /// with only OS-level sandboxing), so malt requires the user to
@@ -100,6 +104,9 @@ pub fn localErrorIsAnnounced(e: InstallError) bool {
         // Raise site prints the actionable "builds from source" line, so
         // the generic dispatch summary stays suppressed.
         InstallError.BuildFromSourceUnsupported,
+        // Raise site names the formula whose deps failed; the inner
+        // install already printed which dep and why.
+        InstallError.DependencyFailed,
         => true,
 
         InstallError.NoPackages,
@@ -260,7 +267,13 @@ pub fn deleteKeg(db: *sqlite.Database, keg_id: i64) void {
 /// failure we skip and continue so a partial dep table is preferred to
 /// the install being rolled back wholesale.
 pub fn recordDeps(db: *sqlite.Database, keg_id: i64, formula: *const formula_mod.Formula) void {
-    for (formula.dependencies) |dep_name| {
+    recordDepNames(db, keg_id, formula.dependencies);
+}
+
+/// Same rows from a bare name list — tap formulas have no `Formula`, their
+/// deps come straight off the `.rb`. One SQL site so the two cannot drift.
+pub fn recordDepNames(db: *sqlite.Database, keg_id: i64, dep_names: []const []const u8) void {
+    for (dep_names) |dep_name| {
         var stmt = db.prepare(
             "INSERT OR IGNORE INTO dependencies (keg_id, dep_name, dep_type) VALUES (?1, ?2, 'runtime');",
         ) catch continue;

--- a/src/core/formula.zig
+++ b/src/core/formula.zig
@@ -86,6 +86,26 @@ const dependency_placeholders = [_]struct {
 /// this is for paths without one, where the DB rows describe a different
 /// version than the keg on disk.
 pub fn declaredDependencies(out: [][]const u8, rb_source: []const u8) []const []const u8 {
+    return declaredDepsExcluding(out, rb_source, &.{":build"});
+}
+
+/// The deps an installer must actually pull in. Also drops `:optional`,
+/// which Homebrew installs only when asked — so a plain install that pulled
+/// them would exceed what the user requested.
+///
+/// Separate from `declaredDependencies` on purpose: that one answers "what
+/// does this keg link at runtime" for a keg already on disk, and its answer
+/// is baked into relocated bytes. Widening it would invalidate every cached
+/// relocation to serve a caller that is not asking the same question.
+pub fn declaredInstallDependencies(out: [][]const u8, rb_source: []const u8) []const []const u8 {
+    return declaredDepsExcluding(out, rb_source, &.{ ":build", ":optional" });
+}
+
+fn declaredDepsExcluding(
+    out: [][]const u8,
+    rb_source: []const u8,
+    exclude: []const []const u8,
+) []const []const u8 {
     const decl = "depends_on ";
     var n: usize = 0;
     var lines = std.mem.tokenizeScalar(u8, rb_source, '\n');
@@ -99,10 +119,14 @@ pub fn declaredDependencies(out: [][]const u8, rb_source: []const u8) []const []
         const rest = trimmed[decl.len..];
         if (rest.len == 0 or rest[0] != '"') continue;
         const close = std.mem.indexOfScalarPos(u8, rest, 1, '"') orelse continue;
-        if (std.mem.indexOf(u8, rest[close..], ":build") != null) continue;
 
-        out[n] = rest[1..close];
-        n += 1;
+        const tail = rest[close..];
+        for (exclude) |tag| {
+            if (std.mem.indexOf(u8, tail, tag) != null) break;
+        } else {
+            out[n] = rest[1..close];
+            n += 1;
+        }
     }
     return out[0..n];
 }
@@ -1174,6 +1198,34 @@ test "declaredDependencies skips build-only dependencies" {
     );
     try testing.expectEqual(@as(usize, 1), got.len);
     try testing.expectEqualStrings("openjdk", got[0]);
+}
+
+test "declaredInstallDependencies keeps recommended deps but drops optional ones" {
+    // Homebrew installs `:recommended` by default and `:optional` only on
+    // request; an installer that pulled the latter would exceed the ask.
+    var out: [8][]const u8 = undefined;
+    const got = declaredInstallDependencies(&out,
+        \\  depends_on "ffmpeg" => :recommended
+        \\  depends_on "lua" => :optional
+        \\  depends_on "cmake" => :build
+        \\  depends_on "flac"
+    );
+    try testing.expectEqual(@as(usize, 2), got.len);
+    try testing.expectEqualStrings("ffmpeg", got[0]);
+    try testing.expectEqualStrings("flac", got[1]);
+}
+
+test "declaredDependencies still reports an optional dep as a runtime one" {
+    // Its answer is baked into relocated bytes via the perl placeholder, so
+    // narrowing it would invalidate every cached relocation. An optional dep
+    // that IS installed is a runtime dep of the keg on disk.
+    var out: [8][]const u8 = undefined;
+    const got = declaredDependencies(&out,
+        \\  depends_on "lua" => :optional
+        \\  depends_on "cmake" => :build
+    );
+    try testing.expectEqual(@as(usize, 1), got.len);
+    try testing.expectEqualStrings("lua", got[0]);
 }
 
 test "declaredDependencies ignores commented and symbol forms" {

--- a/tests/install_download_only_test.zig
+++ b/tests/install_download_only_test.zig
@@ -1264,3 +1264,153 @@ test "materializeRubyFormula truncated body on the raw-binary path is refused" {
     ));
     try testing.expectEqual(@as(i64, 0), try kegRowCount(prefix));
 }
+
+test "materializeRubyFormula records the declared dependencies of a tap formula" {
+    // Tap formulas name their deps in the `.rb`, not the API. Without these
+    // rows `mt cleanup` reads the libraries this keg links against as
+    // orphans and reaps them out from under it.
+    const prefix = try setupPrefix("rawbindeps");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const sha = "5e" ** 32;
+    const cache_path = try seedRawBinaryCache(prefix, sha, &macho_stub);
+    defer testing.allocator.free(cache_path);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var http = malt.client.HttpClient.init(ctx.io, ctx.environ, allocator);
+    defer http.deinit();
+
+    const db_path = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/db/malt.db", .{prefix}, 0);
+    defer testing.allocator.free(db_path);
+    var db = try malt.sqlite.Database.open(db_path);
+    defer db.close();
+    try malt.schema.initSchema(&db);
+
+    var linker = malt.linker.Linker.init(ctx.io, allocator, &db, prefix);
+
+    // Pre-seed the deps as installed kegs so the install step is a no-op and
+    // the test stays offline; the rows are what this pins.
+    for ([_][]const u8{ "flac", "libogg" }) |dep| {
+        const dep_cellar = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/{s}/1.0", .{ prefix, dep });
+        defer testing.allocator.free(dep_cellar);
+        try test_io.cwd().createDirPath(std.Options.debug_io, dep_cellar);
+        _ = malt.install_record.recordKegFields(&db, .{
+            .name = dep,
+            .full_name = dep,
+            .version = "1.0",
+            .revision = 0,
+            .tap = "homebrew/core",
+            .store_sha256 = "00" ** 32,
+            .cellar_path = dep_cellar,
+            .install_reason = "dependency",
+            .bin_isolated = false,
+        }, .{}) catch return error.SeedFailed;
+    }
+
+    const resolved: malt.install_local.ResolvedRubyFormula = .{
+        .name = "deppkg",
+        .full_name = "user/repo/deppkg",
+        .tap_label = "user/repo",
+        .version = "1.0",
+        .url = "https://malt-rawbin-test.invalid/releases/download/v1.0/deppkg-darwin-arm64",
+        .sha256 = sha,
+        .dependencies = &.{ "flac", "libogg" },
+    };
+
+    try malt.install_local.materializeRubyFormula(
+        &ctx,
+        allocator,
+        resolved,
+        &http,
+        &db,
+        &linker,
+        prefix,
+        false, // dry_run
+        false, // force
+        false, // download_only
+        malt.install_sink.terminal,
+    );
+
+    var stmt = try db.prepare(
+        \\SELECT COUNT(*) FROM dependencies d
+        \\JOIN kegs k ON k.id = d.keg_id
+        \\WHERE k.name = 'deppkg' AND d.dep_type = 'runtime';
+    );
+    defer stmt.finalize();
+    _ = try stmt.step();
+    try testing.expectEqual(@as(i64, 2), stmt.columnInt(0));
+}
+
+test "materializeRubyFormula --dry-run names the dependencies it would pull in" {
+    // The plan is only useful if it shows the deps: a tap formula can drag in
+    // several core kegs the user never named.
+    const prefix = try setupPrefix("rawbindepdry");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var http = malt.client.HttpClient.init(ctx.io, ctx.environ, allocator);
+    defer http.deinit();
+
+    const db_path = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/db/malt.db", .{prefix}, 0);
+    defer testing.allocator.free(db_path);
+    var db = try malt.sqlite.Database.open(db_path);
+    defer db.close();
+    try malt.schema.initSchema(&db);
+
+    var linker = malt.linker.Linker.init(ctx.io, allocator, &db, prefix);
+
+    const resolved: malt.install_local.ResolvedRubyFormula = .{
+        .name = "drypkg",
+        .full_name = "user/repo/drypkg",
+        .tap_label = "user/repo",
+        .version = "1.0",
+        .url = "https://malt-rawbin-test.invalid/releases/download/v1.0/drypkg-darwin-arm64",
+        .sha256 = "6f" ** 32,
+        .dependencies = &.{"libvorbis"},
+    };
+
+    const prior_quiet = malt.output.isQuiet();
+    malt.output.setQuiet(false);
+    defer malt.output.setQuiet(prior_quiet);
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    malt.output.beginStderrCapture(testing.allocator, &captured);
+    defer malt.output.endStderrCapture();
+
+    try malt.install_local.materializeRubyFormula(
+        &ctx,
+        allocator,
+        resolved,
+        &http,
+        &db,
+        &linker,
+        prefix,
+        true, // dry_run
+        false, // force
+        false, // download_only
+        malt.install_sink.terminal,
+    );
+
+    try testing.expect(std.mem.indexOf(u8, captured.items, "libvorbis") != null);
+    // A plan must stay a plan: nothing recorded.
+    try testing.expectEqual(@as(i64, 0), try kegRowCount(prefix));
+}


### PR DESCRIPTION
## Description

A tap formula names its runtime dependencies in the `.rb`, not in the JSON API, and malt never read them. Such a formula installed with none of the libraries it links against - and `mt cleanup` then treated those libraries as orphans and reaped them.

Declared dependencies are now installed before the fetch and recorded against the keg. `:build` and `:optional` are excluded, since Homebrew installs neither by default.

## Related Issue

- None

## Notes for Reviewers

- The `:optional` filter is a new installer-facing variant rather than a change to `declaredDependencies`, whose answer is baked into relocated bytes. Narrowing that one would have invalidated every cached relocation.