### PR TITLE
fix(net): report a malformed registry token payload instead of aborting

### DIFF
--- a/justfile
+++ b/justfile
@@ -72,6 +72,7 @@ regressions-harness:
     @./scripts/regressions/cosign-guard-fails-open-and-spawn-not-pinned.sh
     @./scripts/regressions/csi-whitelist-ignores-private-parameter-bytes.sh
     @./scripts/regressions/dsl-chmod-mode-cast-panic-large-literal.sh
+    @./scripts/regressions/extract-token-field-panics-on-non-object-json.sh
     @./scripts/regressions/frame-putcontent-passes-lone-c1-bytes.sh
     @./scripts/regressions/post-install-run-step-gh804.sh
     @./scripts/regressions/progress-shared-counters-atomic-progressbar-update-lock-free-data-race.sh

--- a/scripts/regressions/extract-token-field-panics-on-non-object-json.sh
+++ b/scripts/regressions/extract-token-field-panics-on-non-object-json.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+
+# Must live at the repo root: ghcr.zig's relative sibling imports
+# (client.zig, client_pool.zig, mirror.zig) only resolve from inside
+# the source tree's module boundary.
+HARNESS="$ROOT/.extract-token-field-regression.$$.zig"
+trap 'rm -f "$HARNESS"' EXIT
+
+cat >"$HARNESS" <<'ZIG'
+const std = @import("std");
+const ghcr = @import("src/net/ghcr.zig");
+
+// Root shapes a registry or bottle-domain mirror can answer 200 with.
+// Each was a distinct inactive-union-field abort before the fix.
+test "extractTokenField rejects a non-object token payload" {
+    for ([_][]const u8{ "[]", "\"x\"", "42", "null", "true" }) |body| {
+        try std.testing.expectError(
+            error.InvalidResponse,
+            ghcr.extractTokenField(std.testing.allocator, body),
+        );
+    }
+}
+ZIG
+
+if (cd "$ROOT" && zig test --test-filter "rejects a non-object token payload" "$HARNESS") >/dev/null 2>&1; then
+  echo "PASS: extractTokenField reports a non-object token payload as an error"
+else
+  echo "FAIL: extractTokenField aborted on a non-object token payload (unchecked std.json.Value tag)" >&2
+  exit 1
+fi

--- a/src/net/ghcr.zig
+++ b/src/net/ghcr.zig
@@ -328,7 +328,12 @@ pub fn extractTokenField(allocator: std.mem.Allocator, json_bytes: []const u8) !
     const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_bytes, .{});
     defer parsed.deinit();
 
-    const obj = parsed.value.object;
+    // A registry can answer 200 with any JSON root; reaching into an
+    // inactive union field would abort instead of failing the install.
+    const obj = switch (parsed.value) {
+        .object => |o| o,
+        else => return error.InvalidResponse,
+    };
     const token_val = obj.get("token") orelse return error.InvalidResponse;
     const token_str = switch (token_val) {
         .string => |s| s,

--- a/tests/ghcr_test.zig
+++ b/tests/ghcr_test.zig
@@ -29,6 +29,14 @@ test "extractTokenField returns InvalidResponse when token field is not a string
     try testing.expectError(error.InvalidResponse, ghcr.extractTokenField(testing.allocator, json));
 }
 
+// A registry answering 200 with a non-object body must stay reportable:
+// mid-install it has to surface as an error, never abort the process.
+test "extractTokenField returns InvalidResponse when the root is not an object" {
+    for ([_][]const u8{ "[]", "\"x\"", "42", "null", "true" }) |body| {
+        try testing.expectError(error.InvalidResponse, ghcr.extractTokenField(testing.allocator, body));
+    }
+}
+
 test "GhcrClient.init/deinit does not leak and starts without cached token" {
     var pool = try pool_mod.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator, 1);
     defer pool.deinit();


### PR DESCRIPTION
## Description

A registry that answers a token request with `200` and a non-object JSON body used to kill `mt` mid-install with a panic trace. It now fails the download cleanly, the way every other bad response from a registry already does.

This is reachable in practice: `MALT_BOTTLE_DOMAIN` / `HOMEBREW_BOTTLE_DOMAIN` point the token endpoint at any host, and both token call sites sit on the `mt install` path.

## Related Issue

- None

## Notes for Reviewers

- None