### PR TITLE
fix(ghcr): stop oversized tokens and long mirror bases from failing downloads

### DIFF
--- a/justfile
+++ b/justfile
@@ -74,6 +74,7 @@ regressions-harness:
     @./scripts/regressions/dsl-chmod-mode-cast-panic-large-literal.sh
     @./scripts/regressions/extract-token-field-panics-on-non-object-json.sh
     @./scripts/regressions/frame-putcontent-passes-lone-c1-bytes.sh
+    @./scripts/regressions/ghcr-bearer-header-fixed-stack-buffer.sh
     @./scripts/regressions/post-install-run-step-gh804.sh
     @./scripts/regressions/progress-shared-counters-atomic-progressbar-update-lock-free-data-race.sh
     @./scripts/regressions/scaled-timeout-clamp-scaled-timeout-overflow-on-content-length.sh

--- a/scripts/regressions/ghcr-bearer-header-fixed-stack-buffer.sh
+++ b/scripts/regressions/ghcr-bearer-header-fixed-stack-buffer.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+
+# Must live at the repo root: ghcr.zig's relative sibling imports
+# (client.zig, client_pool.zig, mirror.zig) only resolve from inside
+# the source tree's module boundary.
+HARNESS="$ROOT/.ghcr-bearer-header-regression.$$.zig"
+trap 'rm -f "$HARNESS"' EXIT
+
+cat >"$HARNESS" <<'ZIG'
+const std = @import("std");
+const client = @import("src/net/client.zig");
+const ghcr = @import("src/net/ghcr.zig");
+
+// A batch install mints one token covering every repo, so token length grows
+// with batch size. The base URL is a closed port: a header that was built
+// surfaces as DownloadFailed, OutOfMemory means it never was.
+test "an oversized multi-scope token still reaches the transport" {
+    const a = std.testing.allocator;
+    var threaded: std.Io.Threaded = .init(a, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var inner: std.http.Client = .{ .allocator = a, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, a);
+    defer http.deinit();
+
+    var g = ghcr.GhcrClient.init(io, a, &http);
+    defer g.deinit();
+    g.base_url = "http://127.0.0.1:1";
+
+    const big = try a.alloc(u8, 2100);
+    @memset(big, 'A');
+    g.cached_token = big;
+    const scope = try a.dupe(u8, "homebrew/core/tree");
+    try g.cached_scopes.put(a, scope, {});
+    g.token_expiry = std.math.maxInt(i64);
+
+    var sink: std.Io.Writer.Allocating = .init(a);
+    defer sink.deinit();
+
+    const result = g.downloadBlob(&http, "homebrew/core/tree", "sha256:abc", &sink.writer, null);
+    try std.testing.expectError(ghcr.GhcrError.DownloadFailed, result);
+}
+ZIG
+
+if (cd "$ROOT" && zig test --test-filter "oversized multi-scope token" "$HARNESS") >/dev/null 2>&1; then
+  echo "PASS: downloadBlob builds the Bearer header at exact size"
+else
+  echo "FAIL: downloadBlob rejected an oversized token as OutOfMemory (fixed-size auth buffer)" >&2
+  exit 1
+fi

--- a/src/net/ghcr.zig
+++ b/src/net/ghcr.zig
@@ -111,10 +111,11 @@ pub const GhcrClient = struct {
     }
 
     /// Build the registry blob URL for `(repo, digest)`. Pure, `pub`
-    /// so tests can pin the override-honouring shape.
-    pub fn buildBlobUrl(buf: []u8, base: []const u8, repo: []const u8, digest: []const u8) GhcrError![]const u8 {
-        return std.fmt.bufPrint(buf, "{s}/v2/{s}/blobs/{s}", .{ base, repo, digest }) catch
-            GhcrError.OutOfMemory;
+    /// so tests can pin the override-honouring shape. A mirror base is
+    /// caller-supplied and unbounded, so the result is sized to its inputs.
+    /// Caller owns the result.
+    pub fn buildBlobUrl(allocator: std.mem.Allocator, base: []const u8, repo: []const u8, digest: []const u8) ![]u8 {
+        return std.fmt.allocPrint(allocator, "{s}/v2/{s}/blobs/{s}", .{ base, repo, digest });
     }
 
     /// Fetch one token covering every repo in `repos` with a single
@@ -243,8 +244,9 @@ pub const GhcrClient = struct {
         sink: *std.Io.Writer,
         progress: ?client_mod.ProgressCallback,
     ) GhcrError!void {
-        var url_buf: [512]u8 = undefined;
-        const url = try buildBlobUrl(&url_buf, self.base_url, repo, digest);
+        const url = buildBlobUrl(self.allocator, self.base_url, repo, digest) catch
+            return GhcrError.OutOfMemory;
+        defer self.allocator.free(url);
 
         // A 401 on a token the local clock still deems valid means the
         // registry rejected it (skew / early revocation / scope gap), so
@@ -377,14 +379,17 @@ test "buildTokenUrl emits scope params against a mirror base URL" {
 }
 
 test "buildBlobUrl threads the override base into the blob path" {
-    var buf: [256]u8 = undefined;
-    const url = try GhcrClient.buildBlobUrl(&buf, "https://reg.example.com", "homebrew/core/wget", "sha256:abc");
+    const url = try GhcrClient.buildBlobUrl(testing.allocator, "https://reg.example.com", "homebrew/core/wget", "sha256:abc");
+    defer testing.allocator.free(url);
     try testing.expectEqualStrings("https://reg.example.com/v2/homebrew/core/wget/blobs/sha256:abc", url);
 }
 
-test "buildBlobUrl returns OutOfMemory when the buffer can't hold the URL" {
-    var tiny: [8]u8 = undefined;
-    try testing.expectError(GhcrError.OutOfMemory, GhcrClient.buildBlobUrl(&tiny, "https://reg.example.com", "homebrew/core/wget", "sha256:abc"));
+test "buildBlobUrl fits a mirror base far past any fixed path buffer" {
+    const long_base = "https://" ++ ("mirror." ** 90) ++ "example.com";
+    const url = try GhcrClient.buildBlobUrl(testing.allocator, long_base, "homebrew/core/wget", "sha256:abc");
+    defer testing.allocator.free(url);
+    try testing.expect(url.len > 512);
+    try testing.expectEqualStrings(long_base ++ "/v2/homebrew/core/wget/blobs/sha256:abc", url);
 }
 
 test "invalidateToken clears a seeded cache and is a no-op when already empty" {

--- a/src/net/ghcr.zig
+++ b/src/net/ghcr.zig
@@ -341,6 +341,9 @@ pub fn extractTokenField(allocator: std.mem.Allocator, json_bytes: []const u8) !
         .string => |s| s,
         else => return error.InvalidResponse,
     };
+    // An empty token would ride out as a credential-less "Bearer ", buying
+    // two 401s and a misleading Unauthorized instead of naming the real fault.
+    if (token_str.len == 0) return error.InvalidResponse;
 
     return allocator.dupe(u8, token_str);
 }

--- a/src/net/ghcr.zig
+++ b/src/net/ghcr.zig
@@ -260,9 +260,11 @@ pub const GhcrClient = struct {
             const token = self.fetchToken(http, repo) catch return GhcrError.TokenFetchFailed;
             defer self.allocator.free(token);
 
-            var auth_buf: [2048]u8 = undefined;
-            const auth_value = std.fmt.bufPrint(&auth_buf, "Bearer {s}", .{token}) catch
+            // Sized exactly to the token: a batch-wide multi-scope token has
+            // no bounded length, so any fixed buffer just moves the cliff.
+            const auth_value = std.fmt.allocPrint(self.allocator, "Bearer {s}", .{token}) catch
                 return GhcrError.OutOfMemory;
+            defer self.allocator.free(auth_value);
 
             const headers = [_]std.http.Header{
                 .{ .name = "Authorization", .value = auth_value },
@@ -405,4 +407,35 @@ test "invalidateToken clears a seeded cache and is a no-op when already empty" {
     try testing.expect(g.cached_token == null);
     try testing.expectEqual(@as(usize, 0), g.cached_scopes.count());
     try testing.expect(!g.hasTokenFor("homebrew/core/tree"));
+}
+
+test "downloadBlob does not report an oversized token as OutOfMemory" {
+    // A fixed-size auth buffer used to fail long batch-wide tokens as
+    // OutOfMemory before any request left the process. Against a closed port a
+    // header that was built surfaces as a transport failure instead.
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var inner: std.http.Client = .{ .allocator = testing.allocator, .io = io };
+    var http = client_mod.HttpClient.initWith(&inner, io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+
+    var g = GhcrClient.init(io, testing.allocator, &http);
+    defer g.deinit();
+    g.base_url = "http://127.0.0.1:1";
+
+    const big = try testing.allocator.alloc(u8, 2100);
+    @memset(big, 'A');
+    g.cached_token = big;
+    try g.cached_scopes.put(testing.allocator, try testing.allocator.dupe(u8, "homebrew/core/tree"), {});
+    g.token_expiry = std.math.maxInt(i64);
+
+    var sink: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer sink.deinit();
+
+    try testing.expectError(
+        GhcrError.DownloadFailed,
+        g.downloadBlob(&http, "homebrew/core/tree", "sha256:abc", &sink.writer, null),
+    );
 }

--- a/tests/ghcr_401_retry_test.zig
+++ b/tests/ghcr_401_retry_test.zig
@@ -12,6 +12,10 @@ const net = std.Io.net;
 
 const blob_body = "BOTTLE-BYTES";
 
+// A batch install mints one token covering every repo, so token length grows
+// with batch size. Past any plausible fixed-size auth buffer.
+const big_token_len = 2100;
+
 const Stub = struct {
     io: std.Io,
     listener: *net.Server,
@@ -21,12 +25,17 @@ const Stub = struct {
     // When set, every blob GET answers this status (used to prove a non-401
     // error is NOT treated as the skew/revocation retry case).
     force_status: ?std.http.Status = null,
+    // When true `/token` answers with a `big_token_len`-byte token.
+    big_token: bool = false,
     token_count: usize = 0,
     blob_count: usize = 0,
     // Bearer value presented on each blob GET, copied out of the per-request
     // buffer so the test can compare token#1 vs token#2 after the join.
     blob_auth: [2][256]u8 = undefined,
     blob_auth_len: [2]usize = .{ 0, 0 },
+    // Untruncated length of each presented Bearer value, so an oversized
+    // token can be checked without widening the capture buffers.
+    blob_auth_full_len: [2]usize = .{ 0, 0 },
 };
 
 // Serves the whole token→blob→token→blob sequence on one keep-alive
@@ -46,8 +55,14 @@ fn serveStub(s: *Stub) void {
         const target = req.head.target;
         if (std.mem.indexOf(u8, target, "/token") != null) {
             s.token_count += 1;
-            var body_buf: [64]u8 = undefined;
-            const body = std.fmt.bufPrint(&body_buf, "{{\"token\":\"t{d}\"}}", .{s.token_count}) catch return;
+            var body_buf: [big_token_len + 64]u8 = undefined;
+            const body = if (s.big_token) blk: {
+                var tok: [big_token_len]u8 = undefined;
+                @memset(&tok, 'A');
+                // Keep each minted token distinct so a replayed one is visible.
+                tok[0] = '0' + @as(u8, @intCast(s.token_count % 10));
+                break :blk std.fmt.bufPrint(&body_buf, "{{\"token\":\"{s}\"}}", .{tok}) catch return;
+            } else std.fmt.bufPrint(&body_buf, "{{\"token\":\"t{d}\"}}", .{s.token_count}) catch return;
             req.respond(body, .{}) catch return;
         } else if (std.mem.indexOf(u8, target, "/blobs/") != null) {
             const idx = @min(s.blob_count, s.blob_auth.len - 1);
@@ -57,6 +72,7 @@ fn serveStub(s: *Stub) void {
                     const n = @min(h.value.len, s.blob_auth[idx].len);
                     @memcpy(s.blob_auth[idx][0..n], h.value[0..n]);
                     s.blob_auth_len[idx] = n;
+                    s.blob_auth_full_len[idx] = h.value.len;
                 }
             }
             s.blob_count += 1;
@@ -388,4 +404,45 @@ test "concurrent downloadBlob workers recover from 401 without cache corruption"
     // Each worker fetched, hit 401, invalidated, re-fetched: at least the two
     // initial fetches happened (the exact total races by design).
     try std.testing.expect(cs.token_count.load(.monotonic) >= 2);
+}
+
+test "downloadBlob presents an oversized multi-scope token in full" {
+    // The bearer must reach the wire whole however long the batch-wide token
+    // gets - on the first attempt and on the post-401 retry.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+
+    var stub = Stub{ .io = io, .listener = &listener, .big_token = true };
+    const server_thread = try std.Thread.spawn(.{}, serveStub, .{&stub});
+
+    var base_buf: [64]u8 = undefined;
+    const base = try std.fmt.bufPrint(&base_buf, "http://127.0.0.1:{d}", .{port});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+
+    var g = ghcr.GhcrClient.init(io, std.testing.allocator, &http);
+    defer g.deinit();
+    g.base_url = base;
+
+    var sink: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer sink.deinit();
+
+    const result = g.downloadBlob(&http, "homebrew/core/tree", "sha256:abc", &sink.writer, null);
+
+    http.deinit();
+    server_thread.join();
+
+    try result;
+    try std.testing.expectEqualStrings(blob_body, sink.writer.buffered());
+    // "Bearer " + the whole token, both times - no truncation, no cliff.
+    const expected = "Bearer ".len + big_token_len;
+    try std.testing.expectEqual(expected, stub.blob_auth_full_len[0]);
+    try std.testing.expectEqual(expected, stub.blob_auth_full_len[1]);
 }

--- a/tests/ghcr_test.zig
+++ b/tests/ghcr_test.zig
@@ -80,8 +80,8 @@ test "GhcrClient honours a base_url override across token and blob URLs" {
         token_url,
     );
 
-    var blob_buf: [256]u8 = undefined;
-    const blob_url = try ghcr.GhcrClient.buildBlobUrl(&blob_buf, g.base_url, "homebrew/core/wget", "sha256:deadbeef");
+    const blob_url = try ghcr.GhcrClient.buildBlobUrl(testing.allocator, g.base_url, "homebrew/core/wget", "sha256:deadbeef");
+    defer testing.allocator.free(blob_url);
     try testing.expectEqualStrings(
         "https://reg.example.com/v2/homebrew/core/wget/blobs/sha256:deadbeef",
         blob_url,

--- a/tests/ghcr_test.zig
+++ b/tests/ghcr_test.zig
@@ -37,6 +37,13 @@ test "extractTokenField returns InvalidResponse when the root is not an object" 
     }
 }
 
+// An empty token is well-formed JSON but useless: accepting it sends a
+// credential-less "Bearer " and reports the resulting 401 as Unauthorized,
+// hiding the fact that the registry never handed one over.
+test "extractTokenField returns InvalidResponse when the token field is empty" {
+    try testing.expectError(error.InvalidResponse, ghcr.extractTokenField(testing.allocator, "{\"token\":\"\"}"));
+}
+
 test "GhcrClient.init/deinit does not leak and starts without cached token" {
     var pool = try pool_mod.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator, 1);
     defer pool.deinit();


### PR DESCRIPTION
## Description

A batch install mints one registry token whose scopes cover every repo, so the token grows with batch size. Past ~2 KiB it stopped fitting the fixed buffer the `Authorization` header was built in, and every download in the batch died as `OutOfMemory` before a request was made. The header is now sized to the token, the way the HTTP client already does it.

Two neighbours in the same file got the same treatment: the blob URL was built in a fixed 512-byte buffer, which a long corporate mirror base can overflow, and an empty `token` in the registry's reply was accepted and sent as a blank credential, turning a malformed payload into two wasted round-trips and a misleading `Unauthorized`.

## Related Issue

- None

## Notes for Reviewers

- None