### PR TITLE
docs(regressions): give the whole-suite guards their real runtime

### DIFF
--- a/scripts/regressions/atomicreplace-false-rollbackfailed.sh
+++ b/scripts/regressions/atomicreplace-false-rollbackfailed.sh
@@ -18,7 +18,7 @@
 # exits non-zero if the guard regresses or the test goes missing.
 #
 # Exits 0 when the bug is absent, non-zero (with a clear message) when present.
-# No network required; finishes well under 30s once the test binary is built.
+# No network required; finishes in about a minute once the test binary is built.
 
 set -euo pipefail
 

--- a/scripts/regressions/cask-token-version-unsanitized-path-traversal.sh
+++ b/scripts/regressions/cask-token-version-unsanitized-path-traversal.sh
@@ -19,7 +19,7 @@
 # No CLI surface drives parseCask offline without standing up a local tap, and
 # the guard fires before any download, so it is exercised by the colocated unit
 # tests in the inline suite (`lib_tests`). This script builds and runs only that
-# binary: it stays well under 30s and needs no network. A pass means every
+# binary: it takes about a minute and needs no network. A pass means every
 # inline test — including the traversal-rejection guard — held; a regression
 # flips that binary to a non-zero exit.
 

--- a/scripts/regressions/cleanup-keeps-binary-linked-deps.sh
+++ b/scripts/regressions/cleanup-keeps-binary-linked-deps.sh
@@ -14,7 +14,7 @@
 # exits non-zero if the guard regresses or the test goes missing.
 #
 # Exits 0 when the bug is absent, non-zero (with a clear message) when
-# present. No network required; finishes well under 30s once built.
+# present. No network required; finishes in about a minute once built.
 
 set -euo pipefail
 

--- a/scripts/regressions/dsl-fs-builtins-follow-symlinks-arbitrary-write.sh
+++ b/scripts/regressions/dsl-fs-builtins-follow-symlinks-arbitrary-write.sh
@@ -15,7 +15,7 @@
 # name; it exits non-zero if the guard regresses or the test goes missing.
 #
 # Exits 0 when the bug is absent, non-zero (with a clear message) when present.
-# No network required; finishes well under 30s once the test binary is built.
+# No network required; finishes in about a minute once the test binary is built.
 
 set -euo pipefail
 

--- a/scripts/regressions/dsl-mv-cp-validate-only-destination.sh
+++ b/scripts/regressions/dsl-mv-cp-validate-only-destination.sh
@@ -18,7 +18,7 @@
 # regresses or a test goes missing.
 #
 # Exits 0 when the bug is absent, non-zero (with a clear message) when present.
-# No network required; finishes well under 30s once the test binary is built.
+# No network required; finishes in about a minute once the test binary is built.
 
 set -euo pipefail
 

--- a/scripts/regressions/emitters-dont-escape-names-versions.sh
+++ b/scripts/regressions/emitters-dont-escape-names-versions.sh
@@ -12,7 +12,7 @@
 # No CLI surface round-trips a quoted identifier offline without standing up a
 # tap or seeding the DB with an adversarial name, so the guarantee is pinned by
 # the colocated inline tests (`lib_tests`). This script builds and runs only
-# that binary: it stays well under 30s and needs no network. Pre-fix, the three
+# that binary: it takes about a minute and needs no network. Pre-fix, the three
 # round-trip tests fail and the binary exits non-zero; the fix flips it green.
 
 set -euo pipefail

--- a/scripts/regressions/formula-embedded-name-version-unvalidated.sh
+++ b/scripts/regressions/formula-embedded-name-version-unvalidated.sh
@@ -20,7 +20,7 @@
 # No CLI surface drives parseFormula offline without standing up a local tap,
 # and the guard fires before any download, so it is exercised by the colocated
 # inline unit tests (`lib_tests`). This script builds and runs only that binary:
-# it stays well under 30s and needs no network. A pass means every inline test —
+# it takes about a minute and needs no network. A pass means every inline test —
 # including the guard — held; a regression flips that binary to a non-zero exit.
 
 set -euo pipefail

--- a/scripts/regressions/getdeps-swallows-fetch-failures-empty-list.sh
+++ b/scripts/regressions/getdeps-swallows-fetch-failures-empty-list.sh
@@ -18,7 +18,7 @@
 # guard regresses or the test goes missing.
 #
 # Exits 0 when the bug is absent, non-zero (with a clear message) when present.
-# No network required (loopback-only); finishes well under 30s once built.
+# No network required (loopback-only); finishes in about a minute once built.
 
 set -euo pipefail
 

--- a/scripts/regressions/head-resolved-follows-https-to-http-downgrade.sh
+++ b/scripts/regressions/head-resolved-follows-https-to-http-downgrade.sh
@@ -18,7 +18,7 @@
 #
 # Presenting a real https origin needs a TLS fixture, so the guard is judged
 # through the colocated inline unit tests (`lib_tests`). This script builds and
-# runs only that binary: no network, well under 30s.
+# runs only that binary: no network, about a minute.
 
 set -euo pipefail
 

--- a/scripts/regressions/migrate-parallel-incrementref-races-last-insert-rowid.sh
+++ b/scripts/regressions/migrate-parallel-incrementref-races-last-insert-rowid.sh
@@ -19,7 +19,7 @@
 # regresses or the test goes missing.
 #
 # Exits 0 when the bug is absent, non-zero (with a clear message) when
-# present. No network required; finishes well under 30s once built.
+# present. No network required; finishes in about a minute once built.
 
 set -euo pipefail
 

--- a/scripts/regressions/pkg-cask-sudo-prompt-ask-for-sudo-when-needed.sh
+++ b/scripts/regressions/pkg-cask-sudo-prompt-ask-for-sudo-when-needed.sh
@@ -16,7 +16,7 @@
 # so the behaviour is pinned by the colocated unit test in the inline suite
 # (lib_tests). This script asserts the predicate, the gate, both call sites,
 # and the user-facing message are all present (so the suite cannot go green
-# vacuously), then builds and runs that binary. Offline, well under 30s.
+# vacuously), then builds and runs that binary. Offline, about a minute.
 
 set -euo pipefail
 

--- a/scripts/regressions/post-install-revisioned-keg-paths-git-cola-fails.sh
+++ b/scripts/regressions/post-install-revisioned-keg-paths-git-cola-fails.sh
@@ -15,7 +15,7 @@
 #
 # Exits 0 when the bugs are absent, non-zero (with a message naming
 # the failing assertion) when present. No network required; finishes
-# well under 30s once the test binary is built.
+# in about a minute once the test binary is built.
 
 set -euo pipefail
 

--- a/scripts/regressions/service-label-unvalidated-path-separators.sh
+++ b/scripts/regressions/service-label-unvalidated-path-separators.sh
@@ -17,8 +17,8 @@
 #
 # No CLI surface drives validate offline without standing up launchd, and the
 # guard fires before any write, so it is exercised by the colocated inline unit
-# tests (`lib_tests`). This script builds and runs only that binary: it stays
-# well under 30s and needs no network. A pass means every inline test —
+# tests (`lib_tests`). This script builds and runs only that binary: it takes
+# about a minute and needs no network. A pass means every inline test —
 # including the label-rejection guard — held; a regression flips that binary to
 # a non-zero exit.
 

--- a/scripts/regressions/silent-skip-post-install-steps.sh
+++ b/scripts/regressions/silent-skip-post-install-steps.sh
@@ -20,7 +20,7 @@
 # No CLI surface drives parseFormula or the tap extraction offline without
 # standing up a live tap, so the behaviour is pinned by colocated inline unit
 # tests (`lib_tests`). This script asserts the load-bearing code and its tests
-# are present, then builds and runs that binary: well under 30s, no network.
+# are present, then builds and runs that binary: about a minute, no network.
 
 set -euo pipefail
 

--- a/scripts/regressions/tar-prescan-blind-to-pax-linkpath-symlink-escape.sh
+++ b/scripts/regressions/tar-prescan-blind-to-pax-linkpath-symlink-escape.sh
@@ -16,7 +16,7 @@
 # the guard regresses or the test goes missing.
 #
 # Exits 0 when the bug is absent, non-zero (with a clear message) when present.
-# No network required; finishes well under 30s once the test binary is built.
+# No network required; finishes in about a minute once the test binary is built.
 
 set -euo pipefail
 

--- a/scripts/regressions/trailing-interpolation-oob-slice-panic.sh
+++ b/scripts/regressions/trailing-interpolation-oob-slice-panic.sh
@@ -19,7 +19,7 @@
 # exits non-zero if the guard regresses or the test goes missing.
 #
 # Exits 0 when the bug is absent, non-zero (with a clear message) when
-# present. No network required; finishes well under 30s once the test
+# present. No network required; finishes in about a minute once the test
 # binary is built.
 
 set -euo pipefail

--- a/scripts/regressions/tui-upgrade-db-busy-tui-upgrade-error.sh
+++ b/scripts/regressions/tui-upgrade-db-busy-tui-upgrade-error.sh
@@ -17,7 +17,7 @@
 # if the guard regresses or the test goes missing.
 #
 # Exits 0 when the bug is absent, non-zero (with a clear message) when present.
-# No network required; finishes well under 30s once built.
+# No network required; finishes in about a minute once built.
 
 set -euo pipefail
 

--- a/scripts/regressions/ui-output-missing-control-byte-scrub.sh
+++ b/scripts/regressions/ui-output-missing-control-byte-scrub.sh
@@ -14,7 +14,7 @@
 # Driving a hostile `desc` end to end would need a local HTTP fixture server the
 # repo does not have, so the guarantee is pinned by colocated inline tests that
 # assert against the real writers. This script builds and runs only that unit
-# binary: no network, no state outside zig-cache/zig-out, well under 30s.
+# binary: no network, no state outside zig-cache/zig-out, about a minute.
 
 set -euo pipefail
 

--- a/scripts/regressions/unbounded-recursion-parser-interpreter-dos.sh
+++ b/scripts/regressions/unbounded-recursion-parser-interpreter-dos.sh
@@ -19,7 +19,7 @@
 # goes missing.
 #
 # Exits 0 when the guards hold, non-zero (with a clear message) when the bug is
-# present. No network required; finishes well under 30s once the binary builds.
+# present. No network required; finishes in about a minute once the binary builds.
 
 set -euo pipefail
 

--- a/scripts/regressions/upgrade-dep-reentry-db-busy-some-failures-over-upgrade.sh
+++ b/scripts/regressions/upgrade-dep-reentry-db-busy-some-failures-over-upgrade.sh
@@ -22,7 +22,7 @@
 # test goes missing.
 #
 # Exits 0 when the bug is absent, non-zero (with a clear message) when
-# present. No network required; finishes well under 30s once built.
+# present. No network required; finishes in about a minute once built.
 
 set -euo pipefail
 

--- a/scripts/regressions/upgrade-preserves-dependency-rows.sh
+++ b/scripts/regressions/upgrade-preserves-dependency-rows.sh
@@ -16,7 +16,7 @@
 # regresses or the test goes missing.
 #
 # Exits 0 when the bug is absent, non-zero (with a clear message) when
-# present. No network required; finishes well under 30s once built.
+# present. No network required; finishes in about a minute once built.
 
 set -euo pipefail
 


### PR DESCRIPTION
## Description

Twenty-one regression guards told the reader they finish "well under 30s" while
actually running the whole inline unit suite, which takes about a minute. The
number is what someone consults before deciding whether to run one by hand, so
it is now the real one.

Only the guards that run the whole suite were touched. The rest of the pool
runs a single per-file binary and genuinely is that fast, so their wording
stands.

## Related Issue

- None

## Notes for Reviewers

- Comments only - no guard changed what it asserts or how it exits.