### PR TITLE
fix(cask): anchor ZIP extraction to a fresh directory

### DIFF
--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -991,20 +991,25 @@ pub const CaskInstaller = struct {
     }
 
     fn installZip(self: *CaskInstaller, zip_path: []const u8, app_dir: []const u8, cask: *const Cask) ![]const u8 {
-        // Create temp extraction directory
+        // A token-derived path is guessable, so it can be planted and then
+        // extracted through.
         var tmp_buf: [512]u8 = undefined;
-        const extract_dir = std.fmt.bufPrint(&tmp_buf, "{s}/tmp/cask_extract_{s}", .{ self.prefix, cask.token }) catch
-            return error.InstallFailed;
-        std.Io.Dir.createDirAbsolute(self.io, extract_dir, .default_dir) catch |e| switch (e) {
-            error.PathAlreadyExists => {},
-            else => return error.InstallFailed,
-        };
+        const extract_dir = try self.freshTempDir(&tmp_buf, "extract", cask.token);
         // temp extract dir; leftover tolerated if teardown races.
         defer std.Io.Dir.cwd().deleteTree(self.io, extract_dir) catch {};
 
-        // Extract with ditto -xk (handles macOS-specific ZIP features)
-        const ditto_argv = [_][]const u8{ system_tools.ditto, "-xk", zip_path, extract_dir };
-        child_mod.runOrFail(self.io, self.allocator, &ditto_argv) catch return error.InstallFailed;
+        // Hold the directory itself and make it the child's cwd. `fchdir`
+        // anchors ditto to the created inode, closing the check/use gap that a
+        // later pathname replacement would otherwise reopen.
+        const extract_handle = std.Io.Dir.openDirAbsolute(self.io, extract_dir, .{
+            .follow_symlinks = false,
+        }) catch return error.InstallFailed;
+        defer extract_handle.close(self.io);
+
+        // Extract with ditto -xk (handles macOS-specific ZIP features).
+        const ditto_argv = [_][]const u8{ system_tools.ditto, "-xk", zip_path, "." };
+        child_mod.runOrFailInDir(self.io, self.allocator, &ditto_argv, extract_handle) catch
+            return error.InstallFailed;
 
         return self.placeExtracted(extract_dir, app_dir, cask);
     }
@@ -2027,6 +2032,64 @@ test "linkCaskBinary links regular relative and in-prefix Caskroom sources" {
         const stat = try std.Io.Dir.cwd().statFile(io, source, .{});
         try std.testing.expectEqual(@as(std.posix.mode_t, 0o755), stat.permissions.toMode() & 0o777);
     }
+}
+
+test "installZip does not extract through a pre-existing predictable symlink" {
+    var threaded: std.Io.Threaded = .init(std.heap.c_allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const base = try std.fmt.allocPrintSentinel(a, "/tmp/malt_cask_zip_root_{d}", .{std.c.getpid()}, 0);
+    std.Io.Dir.cwd().deleteTree(io, base) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, base) catch {};
+
+    const prefix = try std.fmt.allocPrintSentinel(a, "{s}/prefix", .{base}, 0);
+    const tmp_dir = try std.fmt.allocPrint(a, "{s}/tmp", .{prefix});
+    const extract_link = try std.fmt.allocPrint(a, "{s}/cask_extract_evil", .{tmp_dir});
+    const outside = try std.fmt.allocPrint(a, "{s}/outside", .{base});
+    const source = try std.fmt.allocPrint(a, "{s}/source/Evil.app/Contents", .{base});
+    const source_root = try std.fmt.allocPrint(a, "{s}/source/Evil.app", .{base});
+    const payload = try std.fmt.allocPrint(a, "{s}/payload", .{source});
+    const zip_path = try std.fmt.allocPrint(a, "{s}/evil.zip", .{base});
+    const app_dir = try std.fmt.allocPrint(a, "{s}/Applications", .{base});
+
+    try std.Io.Dir.cwd().createDirPath(io, tmp_dir);
+    try std.Io.Dir.cwd().createDirPath(io, outside);
+    try std.Io.Dir.cwd().createDirPath(io, source);
+    try std.Io.Dir.cwd().createDirPath(io, app_dir);
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, payload, .{});
+        defer f.close(io);
+        try f.writeStreamingAll(io, "OWNED");
+    }
+    try std.Io.Dir.symLinkAbsolute(io, outside, extract_link, .{});
+
+    const zip_argv = [_][]const u8{ system_tools.ditto, "-c", "-k", "--keepParent", source_root, zip_path };
+    try child_mod.runOrFail(io, a, &zip_argv);
+
+    var cask = try parseCask(a,
+        \\{"token":"evil","name":["Evil"],"version":"1.0","url":"https://example.invalid/evil.zip","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","artifacts":[{"app":["Evil.app"]}]}
+    );
+    defer cask.deinit();
+    var installer: CaskInstaller = .{
+        .allocator = a,
+        .io = io,
+        .environ = .empty,
+        .prefix = prefix,
+        .db = undefined,
+        .progress = null,
+    };
+
+    const installed = try installer.installZip(zip_path, app_dir, &cask);
+    a.free(installed);
+
+    const escaped_payload = try std.fmt.allocPrint(a, "{s}/Evil.app/Contents/payload", .{outside});
+    try std.testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.accessAbsolute(io, escaped_payload, .{}),
+    );
 }
 
 test "parseCask does not length-cap a clean version" {

--- a/src/core/child.zig
+++ b/src/core/child.zig
@@ -91,8 +91,19 @@ pub fn runCapped(
     argv: []const []const u8,
     cap: usize,
 ) ChildError!RunReport {
+    return runCappedInDir(io, allocator, argv, cap, .inherit);
+}
+
+fn runCappedInDir(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    argv: []const []const u8,
+    cap: usize,
+    cwd: std.process.Child.Cwd,
+) ChildError!RunReport {
     var child = std.process.spawn(io, .{
         .argv = argv,
+        .cwd = cwd,
         .stdout = .pipe,
         .stderr = .pipe,
     }) catch return error.SpawnFailed;
@@ -148,6 +159,25 @@ pub fn runOrFail(
     argv: []const []const u8,
 ) ChildError!void {
     const report = try run(io, allocator, argv);
+    defer report.deinit(allocator);
+    if (report.code == 0) return;
+
+    const stderr_file = std.Io.File.stderr();
+    if (report.stderr.len > 0) stderr_file.writeStreamingAll(io, report.stderr) catch {};
+    if (report.stdout.len > 0) stderr_file.writeStreamingAll(io, report.stdout) catch {};
+    return error.NonZeroExit;
+}
+
+/// Run a command with its working directory anchored to an already-open
+/// directory handle. On POSIX, spawn uses `fchdir`, so a pathname swap cannot
+/// redirect a child that writes relative to `.`.
+pub fn runOrFailInDir(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    argv: []const []const u8,
+    cwd: std.Io.Dir,
+) ChildError!void {
+    const report = try runCappedInDir(io, allocator, argv, default_capture_bytes, .{ .dir = cwd });
     defer report.deinit(allocator);
     if (report.code == 0) return;
 
@@ -246,6 +276,44 @@ test "runOrFail returns SpawnFailed when program does not exist" {
     defer threaded.deinit();
     const argv = [_][]const u8{"/nonexistent/binary/malt_child_test"};
     try std.testing.expectError(ChildError.SpawnFailed, runOrFail(threaded.io(), std.testing.allocator, &argv));
+}
+
+test "runOrFailInDir anchors relative writes to the open directory" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+    const a = std.testing.allocator;
+    const base = try std.fmt.allocPrintSentinel(a, "/tmp/malt_child_cwd_{d}", .{std.c.getpid()}, 0);
+    defer a.free(base);
+    std.Io.Dir.cwd().deleteTree(io, base) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, base) catch {};
+
+    const work = try std.fmt.allocPrint(a, "{s}/work", .{base});
+    defer a.free(work);
+    const held = try std.fmt.allocPrint(a, "{s}/held", .{base});
+    defer a.free(held);
+    const outside = try std.fmt.allocPrint(a, "{s}/outside", .{base});
+    defer a.free(outside);
+    const held_marker = try std.fmt.allocPrint(a, "{s}/marker", .{held});
+    defer a.free(held_marker);
+    const outside_marker = try std.fmt.allocPrint(a, "{s}/marker", .{outside});
+    defer a.free(outside_marker);
+
+    try std.Io.Dir.cwd().createDirPath(io, work);
+    try std.Io.Dir.cwd().createDirPath(io, outside);
+    const work_handle = try std.Io.Dir.openDirAbsolute(io, work, .{ .follow_symlinks = false });
+    defer work_handle.close(io);
+    try std.Io.Dir.renameAbsolute(work, held, io);
+    try std.Io.Dir.symLinkAbsolute(io, outside, work, .{});
+
+    const argv = [_][]const u8{ "/usr/bin/touch", "marker" };
+    try runOrFailInDir(io, a, &argv, work_handle);
+
+    try std.Io.Dir.accessAbsolute(io, held_marker, .{});
+    try std.testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.accessAbsolute(io, outside_marker, .{}),
+    );
 }
 
 test "runOrFailInherit returns void on exit code 0" {


### PR DESCRIPTION
## Description

A cask's ZIP extraction root was a predictable path under the prefix that malt adopted if it already existed, so anything able to plant that path first could have `ditto` write through a symlink to a location of its choosing. The root is now created fresh with OS entropy, and the extraction is anchored to the open directory handle so a pathname swap after creation cannot redirect it.

## Related Issue

- Closes #853

- Supersedes #844 - same change by the original author, rebased onto current main.

## Notes for Reviewers

- Two hunks are merge resolutions rather than the author's code. `child.zig` had gained `runCapped` on main while the PR added a cwd variant, so both now share one private `runCappedInDir`; `.inherit` is the `SpawnOptions.cwd` default, so existing callers are byte-identical.
- The extraction root uses main's `freshTempDir` helper instead of the PR's inlined equivalent.
