### PR TITLE
fix: sanitize declarative post-install output

### DIFF
--- a/scripts/regressions/post-install-output-sanitized.sh
+++ b/scripts/regressions/post-install-output-sanitized.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Regression: a formula's declarative post-install output reached the terminal
+# unfiltered. The `--use-system-ruby` path already pumped its child through the
+# terminal sanitizer, but the native executor spawned with stdout inherited, so
+# a formula could emit any escape the terminal acts on - OSC 52 clipboard
+# writes, scrollback erase - straight from `malt install`.
+#
+# No CLI subcommand drives the executor without a network install, so a
+# standalone `zig test` harness feeds it a synthetic formula whose `run` step
+# emits an OSC 52 sequence followed by visible text. The sanitized bytes land
+# on the harness process's own stdout, which this script captures: asserting
+# from the shell keeps the check out of the in-process test runner, whose
+# stdout is its own IPC channel.
+#
+# Exits 0 when the bug is absent, non-zero (with a clear message) when present.
+# No network required; finishes well under 30s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+STUBS=$(mktemp -d)
+
+# The harness imports the executor via a repo-relative path, so it must sit at
+# the repo root: the module's sibling imports only resolve inside the tree.
+HARNESS="$ROOT/.post-install-output-sanitized-regression.$$.zig"
+trap 'rm -rf "$STUBS" "$HARNESS"' EXIT
+
+# Only the `copy` step calls these translate-c bindings and this harness never
+# runs one, so declarations are enough to link.
+cat >"$STUBS/c_clonefile.zig" <<'ZIG'
+pub extern "c" fn clonefile(src: [*:0]const u8, dst: [*:0]const u8, flags: c_uint) c_int;
+ZIG
+cat >"$STUBS/c_mount.zig" <<'ZIG'
+pub const struct_statfs = extern struct { f_fstypename: [16]u8 };
+pub extern "c" fn statfs(path: [*:0]const u8, buf: *struct_statfs) c_int;
+ZIG
+
+cat >"$HARNESS" <<'ZIG'
+const std = @import("std");
+const steps = @import("src/core/post_install_steps.zig");
+
+test "a run step's output reaches the terminal sanitized" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const prefix = path_buf[0..try std.Io.Dir.realPath(tmp.dir, io, &path_buf)];
+
+    const keg = try std.fmt.allocPrint(a, "{s}/Cellar/probe/1.0", .{prefix});
+    const libexec = try std.fmt.allocPrint(a, "{s}/libexec", .{keg});
+    try std.Io.Dir.cwd().createDirPath(io, libexec);
+
+    // Emits an OSC 52 clipboard write followed by visible text, so the shell
+    // can tell stripping from swallowing: the escape must go, the text stay.
+    const script = try std.fmt.allocPrint(a, "{s}/post-install", .{libexec});
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, script, .{});
+        defer f.close(io);
+        var w = f.writer(io, &.{});
+        try w.interface.print("#!/bin/sh\nprintf '\\033]52;c;cHduZWQ=\\007SENTINEL-VISIBLE\\n'\n", .{});
+        try w.interface.flush();
+        try f.setPermissions(io, @enumFromInt(0o755));
+    }
+
+    var flog = steps.FallbackLog.init(std.testing.allocator);
+    defer flog.deinit();
+    const ctx: steps.StepsCtx = .{
+        .io = io,
+        .allocator = a,
+        .name = "probe",
+        .version = "1.0",
+        .prefix = prefix,
+        .keg_path = keg,
+        .flog = &flog,
+    };
+
+    const formula =
+        \\{"name":"probe","versions":{"stable":"1.0"},"post_install_steps":
+        \\[{"type":"run","command":{"base":"libexec","path":"post-install"}}]}
+    ;
+    try std.testing.expect(steps.execute(ctx, formula));
+}
+ZIG
+
+run_harness() {
+  # ca_bundle.zig evaluates trust in-process; the module graph needs the same
+  # frameworks build.zig links.
+  (cd "$ROOT" && zig test -lc -framework Security -framework CoreFoundation \
+    --dep c_clonefile --dep c_mount \
+    -Mroot="$HARNESS" \
+    -Mc_clonefile="$STUBS/c_clonefile.zig" \
+    -Mc_mount="$STUBS/c_mount.zig")
+}
+
+# The child's sanitized bytes arrive on the harness's stdout; the test runner's
+# own chatter goes to stderr and is dropped.
+if ! captured=$(run_harness 2>/dev/null); then
+  run_harness 2>&1 | grep -Ev '\.\.\.OK$' | tail -20 >&2
+  echo "FAIL: the harness could not run the declarative step" >&2
+  exit 1
+fi
+
+if ! printf '%s' "$captured" | grep -q 'SENTINEL-VISIBLE'; then
+  echo "FAIL: sanitizing swallowed the step's legitimate output" >&2
+  exit 1
+fi
+
+if printf '%s' "$captured" | LC_ALL=C grep -q $'\033'; then
+  echo "FAIL: a declarative post-install step leaked a terminal escape" >&2
+  exit 1
+fi
+
+echo "PASS: declarative post-install output reaches the terminal sanitized"

--- a/src/core/dsl/builtins/process.zig
+++ b/src/core/dsl/builtins/process.zig
@@ -13,59 +13,6 @@ const Value = values.Value;
 const BuiltinError = pathname.BuiltinError;
 const ExecCtx = pathname.ExecCtx;
 
-/// Post_install output is attacker-influenced: a formula's `system` call can
-/// emit whatever the child writes, and a terminal will act on it. The
-/// `--use-system-ruby` path already pumps the child through
-/// `ui/term_sanitize.zig`, which drops OSC (including OSC 52 clipboard
-/// writes), DCS, absolute cursor positioning, and scrollback erase. The
-/// native interpreter — the default path, and the one the README leads with —
-/// inherited the terminal directly, so none of that applied to it.
-///
-/// Piping means the child no longer sees a TTY, so colour-on-TTY heuristics
-/// turn themselves off. That is the same trade the ruby path already makes,
-/// and `MALT_ALLOW_RAW_POST_INSTALL=1` opts out of both.
-fn childStdioMode(suppress: bool, raw: bool) std.process.SpawnOptions.StdIo {
-    if (suppress) return .ignore;
-    return if (raw) .inherit else .pipe;
-}
-
-/// Test seam mirroring `sandbox/macos.zig`'s `SpawnHooks`: forces the Nth pump
-/// spawn to fail, so the undrained-pipe path is reachable without exhausting
-/// threads for real.
-const PumpHooks = struct { fail_spawn_on: ?u32 = null };
-
-fn spawnPump(hooks: PumpHooks, idx: u32, fd: c_int, out_fd: c_int) std.Thread.SpawnError!std.Thread {
-    if (hooks.fail_spawn_on) |n| if (idx == n) return error.SystemResources;
-    return std.Thread.spawn(.{}, macos_sandbox.filterInto, .{ fd, out_fd });
-}
-
-/// Pump `child`'s piped stdout/stderr through the sanitizer, then reap it.
-/// One thread each, so a chatty child cannot wedge one pipe while we block on
-/// the other. `wait` owns the pipe fds, hence the non-closing `filterInto`.
-fn waitSanitized(ctx: ExecCtx, child: *std.process.Child, hooks: PumpHooks) !std.process.Child.Term {
-    var out_thread: ?std.Thread = null;
-    var err_thread: ?std.Thread = null;
-    // A pump that never starts leaves its pipe undrained, so the child blocks
-    // on a full buffer and `wait` never returns. Kill first — that EOFs any
-    // pump that did start — then join.
-    errdefer {
-        child.kill(ctx.io);
-        if (out_thread) |t| t.join();
-        if (err_thread) |t| t.join();
-    }
-
-    if (child.stdout) |f| out_thread = try spawnPump(hooks, 0, f.handle, std.c.STDOUT_FILENO);
-    if (child.stderr) |f| err_thread = try spawnPump(hooks, 1, f.handle, std.c.STDERR_FILENO);
-
-    // The pumps see EOF when the child's write ends close, i.e. when it exits,
-    // so joining before `wait` cannot hang on a live child.
-    if (out_thread) |t| t.join();
-    if (err_thread) |t| t.join();
-    out_thread = null;
-    err_thread = null;
-    return child.wait(ctx.io);
-}
-
 /// Coerce every argument to a string and collect them into an owned argv.
 /// A coercion/allocation failure aborts the whole call rather than silently
 /// dropping an element and shifting the command line — the DSL runs untrusted
@@ -117,11 +64,11 @@ pub fn system(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Value {
     defer env_map.deinit();
     var child = std.process.spawn(ctx.io, .{
         .argv = spawn_argv,
-        .stdout = childStdioMode(ctx.suppress_child_stdout, raw),
-        .stderr = childStdioMode(false, raw),
+        .stdout = macos_sandbox.childStdioMode(ctx.suppress_child_stdout, raw),
+        .stderr = macos_sandbox.childStdioMode(false, raw),
         .environ_map = &env_map,
     }) catch return BuiltinError.SystemCommandFailed;
-    const term = waitSanitized(ctx, &child, .{}) catch return BuiltinError.SystemCommandFailed;
+    const term = macos_sandbox.waitSanitizedChild(ctx.io, &child, .{}) catch return BuiltinError.SystemCommandFailed;
 
     switch (term) {
         .exited => |code| if (code == 0) return Value{ .bool = true } else recordFailure(ctx, argv_slice[0], code),
@@ -360,12 +307,12 @@ fn readPipeAll(file: std.Io.File, allocator: std.mem.Allocator, max_bytes: usize
 test "childStdioMode: suppression wins, then raw passthrough, else sanitized pipe" {
     // Under --json/--ndjson the caller suppresses the child's stdout so it
     // can't corrupt the document — that still takes precedence.
-    try std.testing.expect(std.meta.activeTag(childStdioMode(true, false)) == .ignore);
-    try std.testing.expect(std.meta.activeTag(childStdioMode(true, true)) == .ignore);
+    try std.testing.expect(std.meta.activeTag(macos_sandbox.childStdioMode(true, false)) == .ignore);
+    try std.testing.expect(std.meta.activeTag(macos_sandbox.childStdioMode(true, true)) == .ignore);
     // MALT_ALLOW_RAW_POST_INSTALL=1 hands the terminal straight to the child.
-    try std.testing.expect(std.meta.activeTag(childStdioMode(false, true)) == .inherit);
+    try std.testing.expect(std.meta.activeTag(macos_sandbox.childStdioMode(false, true)) == .inherit);
     // Default: pipe, so the bytes can be run through the sanitizer first.
-    try std.testing.expect(std.meta.activeTag(childStdioMode(false, false)) == .pipe);
+    try std.testing.expect(std.meta.activeTag(macos_sandbox.childStdioMode(false, false)) == .pipe);
 }
 
 // Homebrew's formula-context `system` raises on failure, so a child
@@ -744,7 +691,7 @@ test "waitSanitized fails loudly when a sanitizer pump cannot start" {
     });
     try std.testing.expectError(
         error.SystemResources,
-        waitSanitized(ctx, &child, .{ .fail_spawn_on = 0 }),
+        macos_sandbox.waitSanitizedChild(ctx.io, &child, .{ .fail_spawn_on = 0 }),
     );
 }
 

--- a/src/core/post_install_steps.zig
+++ b/src/core/post_install_steps.zig
@@ -1903,15 +1903,17 @@ fn spawnFenced(ctx: StepsCtx, argv: []const []const u8, extra_env: []const EnvVa
     };
     defer env_map.deinit();
 
+    const raw = sandbox_macos.rawPassthroughEnabled(ctx.environ);
     var child = std.process.spawn(ctx.io, .{
         .argv = fenced,
-        .stdout = if (ctx.suppress_child_stdout) .ignore else .inherit,
+        .stdout = sandbox_macos.childStdioMode(ctx.suppress_child_stdout, raw),
+        .stderr = sandbox_macos.childStdioMode(false, raw),
         .environ_map = &env_map,
     }) catch {
         logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "{s} failed to spawn", .{label}) catch label);
         return false;
     };
-    const term = child.wait(ctx.io) catch {
+    const term = sandbox_macos.waitSanitizedChild(ctx.io, &child, .{}) catch {
         logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "{s} did not terminate cleanly", .{label}) catch label);
         return false;
     };

--- a/src/core/sandbox/macos.zig
+++ b/src/core/sandbox/macos.zig
@@ -347,6 +347,52 @@ pub fn rawPassthroughEnabled(environ: std.process.Environ) bool {
     return std.mem.eql(u8, v, "1");
 }
 
+/// Select child stdio for every native post_install executor. Formula output
+/// is attacker-controlled, so normal output is piped through the sanitizer
+/// that drops OSC 52 clipboard writes and other active terminal controls.
+/// JSON modes may suppress stdout; the explicit raw opt-out preserves
+/// inherited terminal behavior. Piping also disables colour-on-TTY heuristics.
+pub fn childStdioMode(suppress: bool, raw: bool) std.process.SpawnOptions.StdIo {
+    if (suppress) return .ignore;
+    return if (raw) .inherit else .pipe;
+}
+
+/// Test seam for a failed sanitizer-pump spawn. Production uses the zero
+/// value; tests force the error path without exhausting threads for real.
+pub const ChildPumpHooks = struct { fail_spawn_on: ?u32 = null };
+
+fn spawnChildPump(hooks: ChildPumpHooks, idx: u32, fd: c_int, out_fd: c_int) std.Thread.SpawnError!std.Thread {
+    if (hooks.fail_spawn_on) |n| if (idx == n) return error.SystemResources;
+    return std.Thread.spawn(.{}, filterInto, .{ fd, out_fd });
+}
+
+/// Pump a std.process child through the terminal sanitizer and reap it. Both
+/// pipes drain concurrently so a chatty child cannot fill one while the
+/// caller blocks on the other. `wait` owns the pipe descriptors, so the pump
+/// uses `filterInto`, which leaves them open for `wait` to close.
+pub fn waitSanitizedChild(
+    io: std.Io,
+    child: *std.process.Child,
+    hooks: ChildPumpHooks,
+) !std.process.Child.Term {
+    var out_thread: ?std.Thread = null;
+    var err_thread: ?std.Thread = null;
+    errdefer {
+        child.kill(io);
+        if (out_thread) |t| t.join();
+        if (err_thread) |t| t.join();
+    }
+
+    if (child.stdout) |f| out_thread = try spawnChildPump(hooks, 0, f.handle, std.c.STDOUT_FILENO);
+    if (child.stderr) |f| err_thread = try spawnChildPump(hooks, 1, f.handle, std.c.STDERR_FILENO);
+
+    if (out_thread) |t| t.join();
+    if (err_thread) |t| t.join();
+    out_thread = null;
+    err_thread = null;
+    return child.wait(io);
+}
+
 fn spawnInherit(
     argv_z: [:null]?[*:0]u8,
     envp: [:null]?[*:0]u8,


### PR DESCRIPTION
## Description

Output from a formula's declarative post-install steps reached the terminal unfiltered, so a formula could emit escape sequences the terminal acts on, including OSC 52 clipboard writes. Those children now pass through the same sanitizer the `--use-system-ruby` path already used, with `MALT_ALLOW_RAW_POST_INSTALL=1` as the opt-out.

## Related Issue

- Closes #848

- Supersedes #846 - same change by the original author, rebased onto current main.

## Notes for Reviewers

- The declarative steps path landed on main after this was written, so the fix now covers the formulas upstream is migrating onto, not just what the author targeted.
- The escape-leak proof lives in a regression script rather than an inline test: the sanitized bytes have to be observed on a real stdout, and asserting from the shell keeps that out of the in-process test runner, whose own stdout is its IPC channel.
- Piping stderr means a step that outlives its parent while holding the pipe open would block the drain. `child.zig`'s `run` already has the same drain-then-wait shape, so this extends an existing property rather than introducing one.
