### PR TITLE
fix(sandbox): confine child file reads

### DIFF
--- a/src/core/dsl/builtins/process.zig
+++ b/src/core/dsl/builtins/process.zig
@@ -54,7 +54,9 @@ pub fn system(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Value {
     // The lint above waves bare/system-dir argv0 through; the real write
     // containment is the sandbox-exec fence wrapping the spawn (parity with
     // the --use-system-ruby path).
-    const spawn_argv = sandbox.fenceArgv(ctx.allocator, argv_slice, ctx.cellar_path, ctx.malt_prefix, .{}) catch |e| switch (e) {
+    const spawn_argv = sandbox.fenceArgv(ctx.allocator, argv_slice, ctx.cellar_path, ctx.malt_prefix, .{
+        .home = std.process.Environ.getPosix(ctx.environ, "HOME"),
+    }) catch |e| switch (e) {
         error.OutOfMemory => return BuiltinError.OutOfMemory,
         error.PathSandboxViolation => return BuiltinError.PathSandboxViolation,
     };
@@ -268,7 +270,9 @@ pub fn safePopenRead(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!
     // capturing stdout must not be a way to spawn unconfined.
     sandbox.validateArgv(argv_slice, ctx.cellar_path, ctx.malt_prefix) catch
         return BuiltinError.PathSandboxViolation;
-    const spawn_argv = sandbox.fenceArgv(ctx.allocator, argv_slice, ctx.cellar_path, ctx.malt_prefix, .{}) catch |e| switch (e) {
+    const spawn_argv = sandbox.fenceArgv(ctx.allocator, argv_slice, ctx.cellar_path, ctx.malt_prefix, .{
+        .home = std.process.Environ.getPosix(ctx.environ, "HOME"),
+    }) catch |e| switch (e) {
         error.OutOfMemory => return BuiltinError.OutOfMemory,
         error.PathSandboxViolation => return BuiltinError.PathSandboxViolation,
     };

--- a/src/core/dsl/builtins/process.zig
+++ b/src/core/dsl/builtins/process.zig
@@ -769,8 +769,12 @@ test "system drains child output larger than a pipe buffer" {
     var lio: std.Io.Threaded = .init(alloc, .{});
     defer lio.deinit();
 
-    const fixture = try std.fmt.allocPrint(alloc, "/tmp/malt_bigout_{d}", .{std.c.getpid()});
-    defer std.Io.Dir.cwd().deleteFile(lio.io(), fixture) catch {};
+    const root = try std.fmt.allocPrint(alloc, "/tmp/malt_bigout_{d}", .{std.c.getpid()});
+    std.Io.Dir.cwd().deleteTree(lio.io(), root) catch {};
+    defer std.Io.Dir.cwd().deleteTree(lio.io(), root) catch {};
+    const cellar = try std.fmt.allocPrint(alloc, "{s}/Cellar/foo/1.0", .{root});
+    try std.Io.Dir.cwd().createDirPath(lio.io(), cellar);
+    const fixture = try std.fmt.allocPrint(alloc, "{s}/payload", .{root});
     {
         const f = try std.Io.Dir.createFileAbsolute(lio.io(), fixture, .{ .truncate = true });
         defer f.close(lio.io());
@@ -782,7 +786,10 @@ test "system drains child output larger than a pipe buffer" {
     }
 
     var cap = try FdCapture.start(alloc, lio.io(), std.c.STDOUT_FILENO, "big");
-    _ = system(sanitizeTestCtx(alloc, lio.io()), null, &.{
+    var ctx = sanitizeTestCtx(alloc, lio.io());
+    ctx.cellar_path = cellar;
+    ctx.malt_prefix = root;
+    _ = system(ctx, null, &.{
         .{ .string = "/bin/cat" },
         .{ .string = fixture },
     }) catch {};

--- a/src/core/post_install_steps.zig
+++ b/src/core/post_install_steps.zig
@@ -10,6 +10,7 @@
 //! router downgrades to the loud partial-skip envelope.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const sandbox = @import("dsl/sandbox.zig");
 const sandbox_macos = @import("sandbox/macos.zig");
 const fallback_log = @import("dsl/fallback_log.zig");
@@ -1892,7 +1893,9 @@ fn spawnFenced(ctx: StepsCtx, argv: []const []const u8, extra_env: []const EnvVa
         logViolation(ctx, argv[0]);
         return false;
     };
-    const fenced = sandbox.fenceArgv(ctx.allocator, argv, ctx.keg_path, ctx.prefix, opts) catch {
+    var profile_opts = opts;
+    profile_opts.home = std.process.Environ.getPosix(ctx.environ, "HOME");
+    const fenced = sandbox.fenceArgv(ctx.allocator, argv, ctx.keg_path, ctx.prefix, profile_opts) catch {
         logViolation(ctx, argv[0]);
         return false;
     };
@@ -3516,6 +3519,53 @@ test "a tool step's own env vars layer onto the scrubbed base" {
     // the tool without a PATH; they now sit on top of the scrubbed base.
     try testing.expect(std.mem.indexOf(u8, dump, "PATH=" ++ sandbox_macos.sandbox_path ++ "\n") != null);
     try testing.expect(std.mem.indexOf(u8, dump, "sentinel-must-not-leak") == null);
+}
+
+test "run can read a standard user font without opening the rest of HOME" {
+    if (builtin.os.tag != .macos) return error.SkipZigTest;
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    var h = try TestHarness.init();
+    defer h.deinit();
+    h.io = threaded.io();
+    const a = h.arena.allocator();
+
+    const home = try std.fmt.allocPrint(a, "{s}_home", .{h.prefix});
+    defer std.Io.Dir.cwd().deleteTree(h.io, home) catch {};
+    const fonts = try std.fmt.allocPrint(a, "{s}/Library/Fonts", .{home});
+    const source = try std.fmt.allocPrint(a, "{s}/Probe.ttf", .{fonts});
+    const copied = try std.fmt.allocPrint(a, "{s}/share/Probe.ttf", .{h.prefix});
+    try std.Io.Dir.cwd().createDirPath(h.io, fonts);
+    try std.Io.Dir.cwd().createDirPath(h.io, try std.fmt.allocPrint(a, "{s}/share", .{h.prefix}));
+    {
+        const f = try std.Io.Dir.createFileAbsolute(h.io, source, .{});
+        defer f.close(h.io);
+        try f.writeStreamingAll(h.io, "FONT");
+    }
+
+    const libexec = try std.fmt.allocPrint(a, "{s}/libexec", .{h.keg});
+    try std.Io.Dir.cwd().createDirPath(h.io, libexec);
+    try std.Io.Dir.symLinkAbsolute(h.io, "/bin/cp", try std.fmt.allocPrint(a, "{s}/copy-font", .{libexec}), .{});
+
+    const home_var = try std.fmt.allocPrintSentinel(a, "HOME={s}", .{home}, 0);
+    var env_entries = [_:null]?[*:0]const u8{home_var.ptr};
+    h.environ = .{ .block = .{ .slice = &env_entries } };
+
+    const steps = try std.fmt.allocPrint(
+        a,
+        \\[{{"type":"run","command":{{"base":"libexec","path":"copy-font"}},
+        \\  "args":["{s}","{s}"]}}]
+    ,
+        .{ source, copied },
+    );
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h, steps)));
+    try testing.expect(!h.flog.hasErrors());
+    const copied_file = try std.Io.Dir.openFileAbsolute(h.io, copied, .{});
+    defer copied_file.close(h.io);
+    var buf: [4]u8 = undefined;
+    const n = try copied_file.readPositionalAll(h.io, &buf, 0);
+    try testing.expectEqualStrings("FONT", buf[0..n]);
 }
 
 test "run refuses the execution fields malt does not honour" {

--- a/src/core/sandbox/macos.zig
+++ b/src/core/sandbox/macos.zig
@@ -192,14 +192,22 @@ pub fn renderRubyProfile(
         return SandboxError.ProfileBuildFailed;
     w.writeAll(")\n(allow file-read-data") catch return SandboxError.ProfileBuildFailed;
     for ([_][]const u8{
-        "/Library/Apple",
-        "/private/var/db/timezone",
         "/dev/null",
         "/dev/random",
         "/dev/urandom",
         "/dev/zero",
         "/dev/tty",
     }) |path| w.print("\n  (literal \"{s}\")", .{path}) catch
+        return SandboxError.ProfileBuildFailed;
+    // Directories, so they need the contents too: a literal rule matches only
+    // the directory node and the denies above take everything inside. Without
+    // the timezone tree a fenced child silently reports UTC, and LibreSSL
+    // reads its config under /private/etc/ssl before it will run at all.
+    for ([_][]const u8{
+        "/Library/Apple",
+        "/private/var/db/timezone",
+        "/private/etc/ssl",
+    }) |path| w.print("\n  (subpath \"{s}\")", .{path}) catch
         return SandboxError.ProfileBuildFailed;
     w.writeAll("\n  (subpath \"/Library/Fonts\")") catch return SandboxError.ProfileBuildFailed;
     var cellar_real_buf: [std.fs.max_path_bytes]u8 = undefined;

--- a/src/core/sandbox/macos.zig
+++ b/src/core/sandbox/macos.zig
@@ -122,6 +122,10 @@ pub fn validatePathForProfile(p: []const u8) SandboxError!void {
 /// initialisers only — every other fenced child stays IPC-free.
 pub const ProfileOpts = struct {
     allow_ipc: bool = false,
+    /// Formula tools such as fontconfig legitimately scan the standard user
+    /// font directories. The renderer grants only those descendants, never
+    /// the rest of HOME.
+    home: ?[]const u8 = null,
     /// Individual files needed by this spawn, such as the generated Ruby
     /// wrapper. These are literal rules, not directory grants.
     read_files: []const []const u8 = &.{},
@@ -137,6 +141,7 @@ pub fn renderRubyProfile(
 ) SandboxError![]const u8 {
     try validatePathForProfile(cellar_path);
     try validatePathForProfile(malt_prefix);
+    if (opts.home) |home| try validatePathForProfile(home);
 
     var buf: std.ArrayList(u8) = .empty;
     errdefer buf.deinit(allocator);
@@ -196,14 +201,21 @@ pub fn renderRubyProfile(
         "/dev/tty",
     }) |path| w.print("\n  (literal \"{s}\")", .{path}) catch
         return SandboxError.ProfileBuildFailed;
+    w.writeAll("\n  (subpath \"/Library/Fonts\")") catch return SandboxError.ProfileBuildFailed;
     var cellar_real_buf: [std.fs.max_path_bytes]u8 = undefined;
     var prefix_real_buf: [std.fs.max_path_bytes]u8 = undefined;
+    var home_real_buf: [std.fs.max_path_bytes]u8 = undefined;
     writeCellarRule(w, cellar_path) catch return SandboxError.ProfileBuildFailed;
     if (resolvedForProfile(cellar_path, &cellar_real_buf)) |real|
         writeCellarRule(w, real) catch return SandboxError.ProfileBuildFailed;
     writeCellarRule(w, malt_prefix) catch return SandboxError.ProfileBuildFailed;
     if (resolvedForProfile(malt_prefix, &prefix_real_buf)) |real|
         writeCellarRule(w, real) catch return SandboxError.ProfileBuildFailed;
+    if (opts.home) |home| {
+        writeHomeFontRules(w, home) catch return SandboxError.ProfileBuildFailed;
+        if (resolvedForProfile(home, &home_real_buf)) |real|
+            writeHomeFontRules(w, real) catch return SandboxError.ProfileBuildFailed;
+    }
     for (opts.read_files) |path| {
         w.print("\n  (literal \"{s}\")", .{path}) catch return SandboxError.ProfileBuildFailed;
         var real_buf: [std.fs.max_path_bytes]u8 = undefined;
@@ -243,6 +255,13 @@ pub fn renderRubyProfile(
 
 fn writeCellarRule(w: *std.Io.Writer, root: []const u8) !void {
     try w.print("\n  (subpath \"{s}\")", .{root});
+}
+
+fn writeHomeFontRules(w: *std.Io.Writer, home: []const u8) !void {
+    const root = std.mem.trimEnd(u8, home, "/");
+    if (root.len == 0) return;
+    for ([_][]const u8{ "Library/Fonts", ".fonts", ".local/share/fonts" }) |sub|
+        try w.print("\n  (subpath \"{s}/{s}\")", .{ root, sub });
 }
 
 fn writePrefixRules(w: *std.Io.Writer, prefix: []const u8) !void {
@@ -374,6 +393,7 @@ pub fn runRubySandboxed(
     if (builtin.os.tag != .macos) return SandboxError.SandboxUnsupported;
 
     const profile = try renderRubyProfile(allocator, cellar_path, malt_prefix, .{
+        .home = env.home,
         .read_files = &.{script_path},
     });
     defer allocator.free(profile);

--- a/src/core/sandbox/macos.zig
+++ b/src/core/sandbox/macos.zig
@@ -122,6 +122,9 @@ pub fn validatePathForProfile(p: []const u8) SandboxError!void {
 /// initialisers only — every other fenced child stays IPC-free.
 pub const ProfileOpts = struct {
     allow_ipc: bool = false,
+    /// Individual files needed by this spawn, such as the generated Ruby
+    /// wrapper. These are literal rules, not directory grants.
+    read_files: []const []const u8 = &.{},
 };
 
 /// Render the deny-by-default SCL profile; writes limited to `cellar_path`
@@ -147,7 +150,6 @@ pub fn renderRubyProfile(
         \\(allow sysctl-read)
         \\(allow mach-lookup)
         \\(allow iokit-open)
-        \\(allow file-read*)
         \\(deny network*)
         \\(allow file-write-data
         \\  (regex #"^/dev/(null|dtracehelper|tty|stdout|stderr)$")
@@ -158,12 +160,64 @@ pub fn renderRubyProfile(
     ;
     buf.appendSlice(allocator, header) catch return SandboxError.ProfileBuildFailed;
 
+    for (opts.read_files) |path| try validatePathForProfile(path);
+
+    var aw: std.Io.Writer.Allocating = .fromArrayList(allocator, &buf);
+    const w = &aw.writer;
+    // macOS executables need read operations beyond file contents during
+    // startup. Keep those operations available, then deny file contents in
+    // every mutable or user-data root. More-specific grants below restore
+    // contents only for Malt and a small set of platform runtime paths.
+    w.writeAll(
+        \\(allow file-read*)
+        \\(deny file-read-data
+    ) catch return SandboxError.ProfileBuildFailed;
+    for ([_][]const u8{
+        "/Applications",
+        "/Library",
+        "/Users",
+        "/Volumes",
+        "/cores",
+        "/dev",
+        "/opt",
+        "/private",
+        "/usr/local",
+        "/System/Volumes/Data",
+    }) |root| w.print("\n  (subpath \"{s}\")", .{root}) catch
+        return SandboxError.ProfileBuildFailed;
+    w.writeAll(")\n(allow file-read-data") catch return SandboxError.ProfileBuildFailed;
+    for ([_][]const u8{
+        "/Library/Apple",
+        "/private/var/db/timezone",
+        "/dev/null",
+        "/dev/random",
+        "/dev/urandom",
+        "/dev/zero",
+        "/dev/tty",
+    }) |path| w.print("\n  (literal \"{s}\")", .{path}) catch
+        return SandboxError.ProfileBuildFailed;
+    var cellar_real_buf: [std.fs.max_path_bytes]u8 = undefined;
+    var prefix_real_buf: [std.fs.max_path_bytes]u8 = undefined;
+    writeCellarRule(w, cellar_path) catch return SandboxError.ProfileBuildFailed;
+    if (resolvedForProfile(cellar_path, &cellar_real_buf)) |real|
+        writeCellarRule(w, real) catch return SandboxError.ProfileBuildFailed;
+    writeCellarRule(w, malt_prefix) catch return SandboxError.ProfileBuildFailed;
+    if (resolvedForProfile(malt_prefix, &prefix_real_buf)) |real|
+        writeCellarRule(w, real) catch return SandboxError.ProfileBuildFailed;
+    for (opts.read_files) |path| {
+        w.print("\n  (literal \"{s}\")", .{path}) catch return SandboxError.ProfileBuildFailed;
+        var real_buf: [std.fs.max_path_bytes]u8 = undefined;
+        if (resolvedForProfile(path, &real_buf)) |real|
+            w.print("\n  (literal \"{s}\")", .{real}) catch return SandboxError.ProfileBuildFailed;
+    }
+    w.writeAll(")\n") catch return SandboxError.ProfileBuildFailed;
+
     // Database initialisers (postgres bootstrap) allocate SysV/POSIX shared
     // memory + SysV semaphores; without these grants initdb dies in
     // shmget/semctl. Scoped to `init_data_dir` so no other fenced child
     // (DSL system, cache-regen tools, Ruby fallback) gets IPC access.
     if (opts.allow_ipc) {
-        buf.appendSlice(allocator,
+        w.writeAll(
             \\(allow ipc-sysv-shm)
             \\(allow ipc-sysv-sem)
             \\(allow ipc-posix-shm)
@@ -171,16 +225,11 @@ pub fn renderRubyProfile(
         ) catch return SandboxError.ProfileBuildFailed;
     }
 
-    var aw: std.Io.Writer.Allocating = .fromArrayList(allocator, &buf);
-    const w = &aw.writer;
     w.writeAll("(allow file-write*") catch return SandboxError.ProfileBuildFailed;
 
     // The kernel matches subpath filters against resolved vnode paths;
     // a symlinked root (macOS /tmp → /private/tmp) needs its resolved
     // form granted too or writes under it are silently denied.
-    var cellar_real_buf: [std.fs.max_path_bytes]u8 = undefined;
-    var prefix_real_buf: [std.fs.max_path_bytes]u8 = undefined;
-
     writeCellarRule(w, cellar_path) catch return SandboxError.ProfileBuildFailed;
     if (resolvedForProfile(cellar_path, &cellar_real_buf)) |real|
         writeCellarRule(w, real) catch return SandboxError.ProfileBuildFailed;
@@ -324,11 +373,13 @@ pub fn runRubySandboxed(
 ) SandboxError!u8 {
     if (builtin.os.tag != .macos) return SandboxError.SandboxUnsupported;
 
-    const profile = try renderRubyProfile(allocator, cellar_path, malt_prefix, .{});
+    const profile = try renderRubyProfile(allocator, cellar_path, malt_prefix, .{
+        .read_files = &.{script_path},
+    });
     defer allocator.free(profile);
 
     const argv = [_][]const u8{
-        "/usr/bin/sandbox-exec", "-p", profile, ruby_path, script_path,
+        "/usr/bin/sandbox-exec", "-p", profile, ruby_path, "--disable-gems", script_path,
     };
     const argv_z = try buildArgv(allocator, argv[0..]);
     defer freeArgv(allocator, argv_z);

--- a/tests/sandbox_macos_test.zig
+++ b/tests/sandbox_macos_test.zig
@@ -43,6 +43,9 @@ test "renderRubyProfile deny-by-default, network denied, cellar + prefix subpath
     try testing.expect(std.mem.indexOf(u8, profile, "(deny default)") != null);
     try testing.expect(std.mem.indexOf(u8, profile, "(deny network*)") != null);
     try testing.expect(std.mem.indexOf(u8, profile, "(allow file-read*)") != null);
+    try testing.expect(std.mem.indexOf(u8, profile, "(deny file-read-data") != null);
+    try testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/Users\")") != null);
+    try testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/System/Volumes/Data\")") != null);
     try testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/Cellar/foo/1.0\")") != null);
     try testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/etc\")") != null);
     try testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/var\")") != null);
@@ -98,6 +101,63 @@ test "ScrubbedEnv type smoke — only allowlisted keys" {
 test "sandbox_path restricts to system directories only" {
     // Nothing in the minimal PATH should be user-writable.
     try testing.expectEqualStrings("/usr/bin:/bin:/usr/sbin:/sbin", sandbox.sandbox_path);
+}
+
+test "sandbox profile refuses copying a source from outside the prefix" {
+    if (builtin.os.tag != .macos) return error.SkipZigTest;
+    try test_io.skipIfNoSubprocess();
+
+    const root = try test_io.uniqueTempPath(testing.allocator, "sandbox_macos", "read_source");
+    defer testing.allocator.free(root);
+    test_io.deleteTreeAbsolute(std.Options.debug_io, root) catch {};
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, root) catch {};
+
+    const prefix = try std.fmt.allocPrint(testing.allocator, "{s}/prefix", .{root});
+    defer testing.allocator.free(prefix);
+    const keg = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/foo/1.0", .{prefix});
+    defer testing.allocator.free(keg);
+    const share = try std.fmt.allocPrint(testing.allocator, "{s}/share", .{prefix});
+    defer testing.allocator.free(share);
+    const victim = try std.fmt.allocPrint(testing.allocator, "{s}/private", .{root});
+    defer testing.allocator.free(victim);
+    const leaked = try std.fmt.allocPrint(testing.allocator, "{s}/leaked", .{share});
+    defer testing.allocator.free(leaked);
+    try test_io.cwd().createDirPath(std.Options.debug_io, keg);
+    try test_io.cwd().createDirPath(std.Options.debug_io, share);
+    {
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, victim, .{});
+        defer f.close(std.Options.debug_io);
+        try f.writeStreamingAll(std.Options.debug_io, "PRIVATE");
+    }
+
+    const profile = try sandbox.renderRubyProfile(testing.allocator, keg, prefix, .{});
+    defer testing.allocator.free(profile);
+    const argv = [_][]const u8{
+        "/usr/bin/sandbox-exec", "-p", profile, "/bin/cp", victim, leaked,
+    };
+    const argv_z = try sandbox.buildArgv(testing.allocator, &argv);
+    defer sandbox.freeArgv(testing.allocator, argv_z);
+    const envp = try sandbox.buildEnvp(testing.allocator, .{
+        .home = prefix,
+        .path = sandbox.sandbox_path,
+        .malt_prefix = prefix,
+        .tmpdir = prefix,
+    });
+    defer sandbox.freeEnvp(testing.allocator, envp);
+
+    const sink = test_io.testSink();
+    const exit_code = try sandbox.spawnFilteredWithHooks(
+        argv_z,
+        envp,
+        .{},
+        .{ .out = sink.handle, .err = sink.handle },
+        .{},
+    );
+    try testing.expectError(
+        error.FileNotFound,
+        test_io.accessAbsolute(std.Options.debug_io, leaked, .{}),
+    );
+    try testing.expect(exit_code != 0);
 }
 
 test "std.posix.rlimit_resource tags resolve on macOS for CPU/FSIZE/AS" {

--- a/tests/sandbox_macos_test.zig
+++ b/tests/sandbox_macos_test.zig
@@ -72,6 +72,21 @@ test "renderRubyProfile grants IPC only under allow_ipc" {
     try testing.expect(std.mem.indexOf(u8, profile, "(allow ipc-sysv-sem)") != null);
 }
 
+test "renderRubyProfile grants standard font directories but not all of HOME" {
+    const profile = try sandbox.renderRubyProfile(
+        testing.allocator,
+        "/opt/malt/Cellar/fontconfig/2.18.3",
+        "/opt/malt",
+        .{ .home = "/test-home" },
+    );
+    defer testing.allocator.free(profile);
+    try testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/Library/Fonts\")") != null);
+    try testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/test-home/Library/Fonts\")") != null);
+    try testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/test-home/.fonts\")") != null);
+    try testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/test-home/.local/share/fonts\")") != null);
+    try testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/test-home\")") == null);
+}
+
 test "renderRubyProfile refuses unsafe cellar path" {
     try testing.expectError(
         error.UnsafePath,
@@ -118,19 +133,22 @@ test "sandbox profile refuses copying a source from outside the prefix" {
     defer testing.allocator.free(keg);
     const share = try std.fmt.allocPrint(testing.allocator, "{s}/share", .{prefix});
     defer testing.allocator.free(share);
-    const victim = try std.fmt.allocPrint(testing.allocator, "{s}/private", .{root});
+    const home = try std.fmt.allocPrint(testing.allocator, "{s}/home", .{root});
+    defer testing.allocator.free(home);
+    const victim = try std.fmt.allocPrint(testing.allocator, "{s}/private", .{home});
     defer testing.allocator.free(victim);
     const leaked = try std.fmt.allocPrint(testing.allocator, "{s}/leaked", .{share});
     defer testing.allocator.free(leaked);
     try test_io.cwd().createDirPath(std.Options.debug_io, keg);
     try test_io.cwd().createDirPath(std.Options.debug_io, share);
+    try test_io.cwd().createDirPath(std.Options.debug_io, home);
     {
         const f = try test_io.createFileAbsolute(std.Options.debug_io, victim, .{});
         defer f.close(std.Options.debug_io);
         try f.writeStreamingAll(std.Options.debug_io, "PRIVATE");
     }
 
-    const profile = try sandbox.renderRubyProfile(testing.allocator, keg, prefix, .{});
+    const profile = try sandbox.renderRubyProfile(testing.allocator, keg, prefix, .{ .home = home });
     defer testing.allocator.free(profile);
     const argv = [_][]const u8{
         "/usr/bin/sandbox-exec", "-p", profile, "/bin/cp", victim, leaked,

--- a/tests/sandbox_macos_test.zig
+++ b/tests/sandbox_macos_test.zig
@@ -302,3 +302,102 @@ test "spawnFilteredWithHooks routes child stderr to the configured fd" {
     try testing.expect(n > 0);
     try testing.expectEqualStrings("err-via-fd", buf[0..@intCast(n)]);
 }
+
+/// Copy `src` to `dst` inside the rendered profile, returning the child's exit
+/// code. Reads that the profile denies fail here rather than in a substring.
+fn copyUnderProfile(profile: []const u8, prefix: []const u8, src: []const u8, dst: []const u8) !u8 {
+    const argv = [_][]const u8{ "/usr/bin/sandbox-exec", "-p", profile, "/bin/cp", src, dst };
+    const argv_z = try sandbox.buildArgv(testing.allocator, &argv);
+    defer sandbox.freeArgv(testing.allocator, argv_z);
+    const envp = try sandbox.buildEnvp(testing.allocator, .{
+        .home = prefix,
+        .path = sandbox.sandbox_path,
+        .malt_prefix = prefix,
+        .tmpdir = prefix,
+    });
+    defer sandbox.freeEnvp(testing.allocator, envp);
+    const sink = test_io.testSink();
+    return sandbox.spawnFilteredWithHooks(
+        argv_z,
+        envp,
+        .{},
+        .{ .out = sink.handle, .err = sink.handle },
+        .{},
+    );
+}
+
+test "sandbox profile grants reads inside the directories it names" {
+    if (builtin.os.tag != .macos) return error.SkipZigTest;
+    try test_io.skipIfNoSubprocess();
+
+    // The profile denies /private and /Library wholesale, so each read below
+    // depends on its grant covering directory *contents*. A rule matching only
+    // the directory node leaves local time and openssl silently broken, which
+    // no assertion on the rendered text can catch.
+    const root = try test_io.uniqueTempPath(testing.allocator, "sandbox_macos", "granted_reads");
+    defer testing.allocator.free(root);
+    test_io.deleteTreeAbsolute(std.Options.debug_io, root) catch {};
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, root) catch {};
+
+    const prefix = try std.fmt.allocPrint(testing.allocator, "{s}/prefix", .{root});
+    defer testing.allocator.free(prefix);
+    const keg = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/foo/1.0", .{prefix});
+    defer testing.allocator.free(keg);
+    const share = try std.fmt.allocPrint(testing.allocator, "{s}/share", .{prefix});
+    defer testing.allocator.free(share);
+    try test_io.cwd().createDirPath(std.Options.debug_io, keg);
+    try test_io.cwd().createDirPath(std.Options.debug_io, share);
+
+    const profile = try sandbox.renderRubyProfile(testing.allocator, keg, prefix, .{});
+    defer testing.allocator.free(profile);
+
+    const sources = [_][]const u8{
+        // Reading this is what makes a fenced child report local time.
+        "/private/var/db/timezone/zoneinfo/Europe/Rome",
+        // LibreSSL reads its config at startup, so openssl fails without it.
+        "/private/etc/ssl/openssl.cnf",
+    };
+    for (sources, 0..) |src, i| {
+        const dst = try std.fmt.allocPrint(testing.allocator, "{s}/copied{d}", .{ share, i });
+        defer testing.allocator.free(dst);
+        const code = try copyUnderProfile(profile, prefix, src, dst);
+        try testing.expect(code == 0);
+        try test_io.accessAbsolute(std.Options.debug_io, dst, .{});
+    }
+}
+
+test "sandbox profile grants ssl config without reopening the rest of /etc" {
+    if (builtin.os.tag != .macos) return error.SkipZigTest;
+    try test_io.skipIfNoSubprocess();
+
+    // The ssl grant is a subpath, so widening it to /private/etc would hand
+    // every fenced child the account and host databases as well.
+    const root = try test_io.uniqueTempPath(testing.allocator, "sandbox_macos", "etc_scope");
+    defer testing.allocator.free(root);
+    test_io.deleteTreeAbsolute(std.Options.debug_io, root) catch {};
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, root) catch {};
+
+    const prefix = try std.fmt.allocPrint(testing.allocator, "{s}/prefix", .{root});
+    defer testing.allocator.free(prefix);
+    const keg = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/foo/1.0", .{prefix});
+    defer testing.allocator.free(keg);
+    const share = try std.fmt.allocPrint(testing.allocator, "{s}/share", .{prefix});
+    defer testing.allocator.free(share);
+    try test_io.cwd().createDirPath(std.Options.debug_io, keg);
+    try test_io.cwd().createDirPath(std.Options.debug_io, share);
+
+    const profile = try sandbox.renderRubyProfile(testing.allocator, keg, prefix, .{});
+    defer testing.allocator.free(profile);
+
+    const denied = [_][]const u8{ "/private/etc/passwd", "/private/etc/hosts" };
+    for (denied, 0..) |src, i| {
+        const dst = try std.fmt.allocPrint(testing.allocator, "{s}/leaked{d}", .{ share, i });
+        defer testing.allocator.free(dst);
+        const code = try copyUnderProfile(profile, prefix, src, dst);
+        try testing.expect(code != 0);
+        try testing.expectError(
+            error.FileNotFound,
+            test_io.accessAbsolute(std.Options.debug_io, dst, .{}),
+        );
+    }
+}


### PR DESCRIPTION
## Description

A fenced post-install child could read any file the user could, including private keys under `$HOME`, because the profile granted file contents far more broadly than the fence intended. Reads are now confined to the roots a formula legitimately needs, with the standard user font directories granted explicitly so tools like fontconfig keep working.

## Related Issue

- Closes #847

- Supersedes #841 - both of the original author's commits are preserved, rebased onto current main.

## Notes for Reviewers

- Third commit is the review feedback from the original PR: two directory grants were written as rules matching only the directory node, which silently cost every fenced child its local time, plus the `/private/etc/ssl` grant LibreSSL needs to start.
- The profile tests asserted on rendered text, which is why that slipped through. `tests/sandbox_macos_test.zig` now runs `/bin/cp` under real `sandbox-exec` and asserts the outcome: reads under each granted root succeed, and `/private/etc/passwd` and `/private/etc/hosts` stay denied so the ssl grant cannot be widened unnoticed.
- Each of the three profile decisions was confirmed to fail its own test when reverted individually.
