### PR TITLE
chore(scripts): give smoke and demo runs their own throwaway prefixes

### DIFF
--- a/scripts/record-themes.sh
+++ b/scripts/record-themes.sh
@@ -82,7 +82,7 @@ mkdir -p "$OUT_DIR"
 # survives the per-theme wipe (warm installs ~3s instead of cold).
 PREFIX=/tmp/mt-th
 export MALT_PREFIX="$PREFIX"
-export MALT_CACHE=/tmp/mt-cache
+export MALT_CACHE=/tmp/mt-th-cache
 export PATH="$PWD/zig-out/bin:$PATH"
 export COLORTERM=truecolor        # satisfy malt's truecolor gate so hex themes don't degrade
 export MALT_NO_VERSION_NOTIFIER=1 # keep the update notice out of the install output

--- a/scripts/record-tui-demo.sh
+++ b/scripts/record-tui-demo.sh
@@ -39,8 +39,8 @@ fi
 
 # Throwaway prefix. 7 bytes, safely under malt's Mach-O patch budget (matches
 # scripts/record-demo.sh). The cache is a sibling so it survives the prefix wipe.
-PREFIX=/tmp/mt
-CACHE=/tmp/mt-cache
+PREFIX=/tmp/mt-tui
+CACHE=/tmp/mt-tui-cache
 
 export MALT_PREFIX="$PREFIX"
 export MALT_CACHE="$CACHE"

--- a/scripts/smokes/smoke_install_local.sh
+++ b/scripts/smokes/smoke_install_local.sh
@@ -25,9 +25,8 @@ FIX_DIR="$ROOT/scripts/fixtures/local_formulae"
 }
 
 # MALT_PREFIX must be ≤ 13 bytes (Mach-O in-place patching budget).
-PREFIX="/tmp/mt_smoke"
+PREFIX=$(mktemp -d /tmp/mt.XXX)
 export MALT_PREFIX="$PREFIX"
-rm -rf "$PREFIX"
 mkdir -p "$PREFIX"
 trap 'rm -rf "$PREFIX"' EXIT
 

--- a/scripts/smokes/smoke_isolate_deps_yt_dlp.sh
+++ b/scripts/smokes/smoke_isolate_deps_yt_dlp.sh
@@ -39,9 +39,8 @@ BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
   exit 2
 }
 
-PREFIX="/tmp/mt_yt"
+PREFIX=$(mktemp -d /tmp/mt.XXX)
 export MALT_PREFIX="$PREFIX"
-rm -rf "$PREFIX"
 mkdir -p "$PREFIX"
 trap 'rm -rf "$PREFIX"' EXIT
 

--- a/scripts/smokes/smoke_migrate_parallel.sh
+++ b/scripts/smokes/smoke_migrate_parallel.sh
@@ -10,7 +10,7 @@
 # CLI, and a second `--output-format=ndjson` pass that asserts workers
 # actually fanned out (events from distinct kegs interleave).
 #
-# Working dirs live under /tmp/mt_mp / /tmp/mt_mp2 / /tmp/mt-mp-work so
+# Working dirs live under throwaway mktemp prefixes so
 # `just clean` (clean.sh /tmp/mt_* + /tmp/mt-* globs) reaps them.
 #
 # Usage:
@@ -49,9 +49,9 @@ command -v jq >/dev/null 2>&1 || {
 }
 
 # MALT_PREFIX must be <= 13 bytes (Mach-O in-place patching budget).
-PREFIX="/tmp/mt_mp"
-PREFIX_NDJSON="/tmp/mt_mp2"
-WORKDIR="/tmp/mt-mp-work"
+PREFIX=$(mktemp -d /tmp/mt.XXX)
+PREFIX_NDJSON=$(mktemp -d /tmp/mt.XXX)
+WORKDIR=$(mktemp -d /tmp/mt-mp.XXX)
 REPORT="$WORKDIR/migrate_parallel_report.txt"
 STDOUT_LOG="$WORKDIR/migrate.stdout.json"
 # `migrate --json` emits a JSONL stream: one line per per-keg

--- a/scripts/smokes/smoke_offline_mode.sh
+++ b/scripts/smokes/smoke_offline_mode.sh
@@ -29,9 +29,8 @@ BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
 
 # MALT_PREFIX must be ≤ 13 bytes (Mach-O in-place patching budget),
 # same constraint as smoke_install_local.sh.
-PREFIX="/tmp/mt_smoke_off"
+PREFIX=$(mktemp -d /tmp/mt.XXX)
 export MALT_PREFIX="$PREFIX"
-rm -rf "$PREFIX"
 mkdir -p "$PREFIX/cache/api" "$PREFIX/db"
 trap 'rm -rf "$PREFIX"' EXIT
 


### PR DESCRIPTION
## Description

The smoke scripts installed into fixed `/tmp` paths, so two sessions running the same smoke deleted each other's prefix mid-run. They now use `mktemp`, matching what the rest of the suite already does.

The two demo recorders shared one prefix and one cache path and both wiped them on entry, so recording one while the other ran corrupted the take. They keep stable paths - the recordings end up in published artefacts - but no longer share them.

## Related Issue

- None

## Notes for Reviewers

- None