### PR TITLE
ci: run the tar pre-scan guard on every pull request

### DIFF
--- a/justfile
+++ b/justfile
@@ -38,6 +38,7 @@ regressions-static:
     @./scripts/regressions/tap-resolution-contract.sh
     @./scripts/regressions/relocated-store-logic-version-pin.sh
     @./scripts/regressions/post-install-native-spawns-inherit-full-environment.sh
+    @./scripts/regressions/tar-prescan-followups-925-926-follow-up.sh
     @MALT_STATIC_ONLY=1 ./scripts/regressions/post-install-steps-live-artefacts.sh
     @./scripts/test/bench_release_resolution_test.sh
 


### PR DESCRIPTION
## Description

The tar pre-scan guard was only reachable through the manual regression pool, which needs a token and live installs, so in practice nothing ran it. It is static - no build, no network, well under a second - so it belongs in the fast set every pull request already gates on, alongside its siblings.

## Related Issue

- None

## Notes for Reviewers

- None