### PR TITLE
chore(regressions): keep a passing probe guard's CI log free of teardown noise

### DIFF
--- a/scripts/regressions/notifier-probe-unbounded-by-client-retry-backoff.sh
+++ b/scripts/regressions/notifier-probe-unbounded-by-client-retry-backoff.sh
@@ -52,6 +52,9 @@ cleanup() {
   # when the server is already gone, stranding the key in $WORK.
   if [[ -n "$SERVER_PID" ]]; then
     kill "$SERVER_PID" 2>/dev/null || true
+    # Reap it here, otherwise the shell prints its own "Terminated: 15" notice
+    # after the PASS line and a green run reads like a failure in CI logs.
+    wait "$SERVER_PID" 2>/dev/null || true
   fi
   rm -rf "$WORK"
 }


### PR DESCRIPTION
## Description

The notifier probe guard killed its background TLS fixture on exit without reaping it, so the shell printed a `Terminated: 15` notice right after the PASS line. A fully green CI run read like something had crashed. The guard now waits on the fixture after killing it, so a passing run says only that it passed.

No change to what the guard asserts.

## Related Issue

- None

## Notes for Reviewers

- None