### PR TITLE
chore(dsl): close the deep-copy stack-overflow risk with a standing guard

### DIFF
--- a/scripts/regressions/cp-r-deep-tree-copy-dir-recursive-has-no-depth-cap.sh
+++ b/scripts/regressions/cp-r-deep-tree-copy-dir-recursive-has-no-depth-cap.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Regression: recursive copy must stay bounded on a source tree deeper than a
+# path can address.
+#
+# `copyDirRecursive` recurses with no explicit depth counter. It is safe today
+# only because every level re-joins an absolute path and opens it with
+# `openDirAbsolute`, so the walk self-terminates once the joined path passes
+# PATH_MAX - roughly 470 frames, well inside the 8 MB main-thread stack. That
+# bound is incidental, not designed: the moment the walk is converted to
+# handle-relative descent (`openat`-style, the natural fix for the silent
+# truncation at the ceiling) the bound disappears and an explicit cap becomes
+# mandatory. This guard exists to fail loudly at that moment.
+#
+# No CLI subcommand exposes `cp_r` in isolation, so the invariant is exercised
+# by a colocated `test {}` block that builds a tree deeper than PATH_MAX can
+# address and asserts the copy terminates. This script builds the colocated
+# test binary and judges that test's line; it exits non-zero if the guard
+# regresses or the test goes missing.
+#
+# Exits 0 when the recursion is bounded, non-zero (with a clear message) when
+# it is not. No network required; finishes in about a minute.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+SRC="$ROOT/src/core/dsl/builtins/fileutils.zig"
+
+TEST_NAME='cp_r on a tree deeper than PATH_MAX terminates instead of overflowing'
+
+# If the guard test is ever deleted the name filter below would match nothing
+# and silently pass. Fail loudly instead.
+if ! grep -qs -- "$TEST_NAME" "$SRC"; then
+  echo "FAIL: recursion-bound guard test missing: $TEST_NAME" >&2
+  exit 1
+fi
+
+# Always rebuild: a stale binary from an earlier run cannot contain the guard.
+BIN="$ROOT/zig-out/test-bin/lib_tests"
+(cd "$ROOT" && zig build test-bin >/dev/null 2>&1) || {
+  echo "FAIL: could not build the test binary (zig build test-bin)" >&2
+  exit 1
+}
+
+# A stack overflow kills the test process instead of reporting a failure, so
+# judge the guard's own line and reject a crash signature anywhere in the run.
+OUT=$("$BIN" 2>&1 || true)
+
+if printf '%s\n' "$OUT" | grep -Eqi -- 'stack overflow|segmentation fault|SIGSEGV'; then
+  echo "FAIL: the deep-tree copy crashed - the path-length bound went away without a depth cap" >&2
+  exit 1
+fi
+
+LINE=$(printf '%s\n' "$OUT" | grep -F -- "$TEST_NAME" || true)
+if [[ -z "$LINE" ]]; then
+  echo "FAIL: recursion-bound guard test did not run: $TEST_NAME" >&2
+  exit 1
+fi
+if [[ "$LINE" != *OK ]]; then
+  echo "FAIL: recursive copy is no longer bounded on a tree deeper than PATH_MAX" >&2
+  exit 1
+fi
+
+echo "PASS: cp_r recursion stays bounded on a tree deeper than PATH_MAX"

--- a/src/core/dsl/builtins/fileutils.zig
+++ b/src/core/dsl/builtins/fileutils.zig
@@ -886,6 +886,53 @@ test "cp_r copies a directory tree within the keg" {
     try std.testing.expectEqualStrings("hello", rb[0..try df.readPositionalAll(io, &rb, 0)]);
 }
 
+test "cp_r on a tree deeper than PATH_MAX terminates instead of overflowing" {
+    const io = std.Options.debug_io;
+    var s = try Scratch.init("fileutils_cpr_deep");
+    defer s.deinit();
+    const keg = s.base;
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const src = try std.fs.path.join(alloc, &.{ keg, "src" });
+    const dst = try std.fs.path.join(alloc, &.{ keg, "dst" });
+
+    // 600 levels is 1200 path bytes, past what an absolute open can address.
+    // Descend by handle: createDirPath cannot build a tree it cannot name.
+    const depth = 600;
+    try std.Io.Dir.cwd().createDirPath(io, src);
+    {
+        var dir = try std.Io.Dir.cwd().openDir(io, src, .{});
+        defer dir.close(io);
+        for (0..depth) |_| {
+            try dir.createDir(io, "a", .default_dir);
+            const next = try dir.openDir(io, "a", .{});
+            dir.close(io);
+            dir = next;
+        }
+    }
+
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    // Reaching the next statement at all is half the guard: an unbounded walk
+    // would take the process down with it rather than return.
+    _ = try cpR(ctx, null, &.{ Value{ .string = src }, Value{ .string = dst } });
+
+    // The other half: the walk must stop short of the source depth. Copying the
+    // whole tree means the bound is gone and a real cap has to replace it.
+    var copied: usize = 0;
+    var dir = try std.Io.Dir.cwd().openDir(io, dst, .{});
+    defer dir.close(io);
+    while (dir.openDir(io, "a", .{})) |next| : (copied += 1) {
+        dir.close(io);
+        dir = next;
+    } else |_| {}
+
+    try std.testing.expect(copied > 0);
+    try std.testing.expect(copied < depth);
+}
+
 test "mv refuses a source under an intermediate-directory symlink out of the keg" {
     const io = std.Options.debug_io;
     const alloc = std.testing.allocator;


### PR DESCRIPTION
## Description

A review flagged `cp_r` as able to blow the stack on a deep enough source tree. It cannot - the walk runs out of addressable path long before it runs out of stack, so no fix was needed and none was made.

What was missing is that this safety is incidental rather than designed, so nothing stopped a future refactor from removing it silently. This adds the test and the regression guard that make that fail loudly instead of being rediscovered by the next static pass.

## Related Issue

- None

## Notes for Reviewers

- None
