### PR TITLE
fix(dsl): stop a formula glob pattern from expanding without end

### DIFF
--- a/scripts/regressions/glob-brace-expansion-has-no-depth-cap.sh
+++ b/scripts/regressions/glob-brace-expansion-has-no-depth-cap.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Regression: brace expansion in the glob builtin must stay bounded.
+#
+# The reported bug was a stack overflow from deeply nested braces. That is not
+# reachable: the 1024-byte expansion buffer drops any pattern whose expansion
+# does not fit, so nesting tops out near 513 frames (~632 KB against an 8 MB
+# stack). A depth counter would be dead code.
+#
+# The reachable defect is the other axis. Each `{a,b}` group doubles the work,
+# so cost is exponential in the number of groups while the recursion stays
+# shallow - a hang rather than a crash, which is why a depth cap cannot see it.
+# Measured on the unbounded walk: a 150-byte pattern of 30 groups costs
+# 2,147,483,647 expansions and does not finish in a minute of ReleaseSafe. The
+# pattern is formula code, so it needs a ceiling. The fix caps total expansions
+# and degrades to "no match", matching how every other failure here returns.
+#
+# No CLI subcommand exposes the matcher in isolation, so the guard is exercised
+# by colocated `test {}` blocks: one pins the shapes real formula globs use, one
+# drives the exponential axis, one pins the give-up behaviour. This script
+# builds the colocated test binary and judges those tests' lines.
+#
+# Exits 0 when the bound holds, non-zero (with a clear message) when it does
+# not. No network required; finishes in about a minute.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+SRC="$ROOT/src/core/dsl/builtins/pathname.zig"
+
+FILTERS=(
+  "glob matches wildcards and brace alternation"
+  "glob alternation cannot be driven into an unbounded expansion"
+  "glob expansion budget refuses instead of exploring"
+)
+
+# If a guard test is ever deleted the name filter would match nothing and
+# silently pass. Fail loudly instead.
+for F in "${FILTERS[@]}"; do
+  if ! grep -qs -- "$F" "$SRC"; then
+    echo "FAIL: glob expansion guard test missing: $F" >&2
+    exit 1
+  fi
+done
+
+# Always rebuild: a stale binary from an earlier run cannot contain the guards.
+BIN="$ROOT/zig-out/test-bin/lib_tests"
+(cd "$ROOT" && zig build test-bin >/dev/null 2>&1) || {
+  echo "FAIL: could not build the test binary (zig build test-bin)" >&2
+  exit 1
+}
+
+# An unbounded matcher does not fail, it stops returning - so cap the run and
+# treat exhausting the cap as the regression it is.
+set +e
+OUT=$(timeout 600 "$BIN" 2>&1)
+RC=$?
+set -e
+if [[ $RC -eq 124 ]]; then
+  echo "FAIL: the test binary did not finish - brace expansion is unbounded again" >&2
+  exit 1
+fi
+
+for F in "${FILTERS[@]}"; do
+  LINE=$(printf '%s\n' "$OUT" | grep -F -- "$F" || true)
+  if [[ -z "$LINE" ]]; then
+    echo "FAIL: glob expansion guard test did not run: $F" >&2
+    exit 1
+  fi
+  if [[ "$LINE" != *OK ]]; then
+    echo "FAIL: glob brace expansion is no longer bounded: $F" >&2
+    exit 1
+  fi
+done
+
+echo "PASS: glob brace expansion stays bounded on formula-controlled patterns"

--- a/src/core/dsl/builtins/pathname.zig
+++ b/src/core/dsl/builtins/pathname.zig
@@ -361,8 +361,24 @@ pub fn glob(ctx: ExecCtx, receiver: ?Value, args: []const Value) BuiltinError!Va
     return Value{ .array = slice };
 }
 
+/// Ceiling on how many expansions a single match may attempt. Each `{a,b}`
+/// group doubles the work, so a pattern short enough to fit the expansion
+/// buffer still reaches 2^200 combinations - and the pattern is formula code.
+/// Real globs use a handful of alternatives, so this sits far above them.
+const max_glob_expansions: u32 = 10_000;
+
 /// Glob pattern matching with `*`, `?`, and `{a,b,c}` brace expansion.
 fn globMatch(pattern: []const u8, name: []const u8) bool {
+    var budget: u32 = max_glob_expansions;
+    return globMatchBudgeted(pattern, name, &budget);
+}
+
+fn globMatchBudgeted(pattern: []const u8, name: []const u8, budget: *u32) bool {
+    // Out of budget degrades to "no match": the calling builtin has no error
+    // channel, and every other failure here returns the same way.
+    if (budget.* == 0) return false;
+    budget.* -= 1;
+
     // Check if pattern contains braces — if so, expand and try each alternative
     if (std.mem.findScalar(u8, pattern, '{')) |brace_start| {
         if (findMatchingBrace(pattern, brace_start)) |brace_end| {
@@ -380,7 +396,7 @@ fn globMatch(pattern: []const u8, name: []const u8) bool {
                 @memcpy(buf[0..prefix.len], prefix);
                 @memcpy(buf[prefix.len .. prefix.len + alt.len], alt);
                 @memcpy(buf[prefix.len + alt.len .. expanded_len], suffix);
-                if (globMatch(buf[0..expanded_len], name)) return true;
+                if (globMatchBudgeted(buf[0..expanded_len], name, budget)) return true;
             }
             return false;
         }

--- a/src/core/dsl/builtins/pathname.zig
+++ b/src/core/dsl/builtins/pathname.zig
@@ -795,3 +795,36 @@ test "atomic_write keeps the target's existing mode instead of widening it" {
     const st = try std.Io.Dir.cwd().statFile(io, target, .{});
     try std.testing.expectEqual(@as(u32, 0o600), @intFromEnum(st.permissions) & 0o777);
 }
+
+test "glob matches wildcards and brace alternation" {
+    // Baseline for the expansion budget below: the shapes formula globs
+    // actually use must keep matching exactly as before.
+    try std.testing.expect(globMatch("*.h", "stdio.h"));
+    try std.testing.expect(!globMatch("*.h", "stdio.c"));
+    try std.testing.expect(globMatch("lib?.a", "libz.a"));
+    try std.testing.expect(globMatch("*.{h,hpp,hxx}", "vec.hpp"));
+    try std.testing.expect(!globMatch("*.{h,hpp,hxx}", "vec.cpp"));
+    try std.testing.expect(globMatch("{bin,sbin}/*", "bin/tool"));
+    try std.testing.expect(globMatch("a{b,c}d{e,f}", "acdf"));
+    try std.testing.expect(!globMatch("a{b,c}d{e,f}", "axdf"));
+}
+
+test "glob alternation cannot be driven into an unbounded expansion" {
+    // Each `{a,b}` group doubles the work, so a pattern only this long already
+    // costs 2^31 expansions unbounded - a hang, not a crash, since the depth
+    // stays shallow. The pattern comes from formula code, so it needs a bound.
+    var pattern: [30 * 5]u8 = undefined;
+    for (0..30) |i| @memcpy(pattern[i * 5 ..][0..5], "{a,b}");
+
+    try std.testing.expect(!globMatch(&pattern, "no-such-name"));
+}
+
+test "glob expansion budget refuses instead of exploring" {
+    // Exhausting the budget must degrade to "no match" rather than keep going;
+    // the surrounding builtin has no error channel to report a give-up on.
+    var spent: u32 = 3;
+    try std.testing.expect(!globMatchBudgeted("{a,b}{a,b}{a,b}{a,b}", "abab", &spent));
+
+    var ample: u32 = max_glob_expansions;
+    try std.testing.expect(globMatchBudgeted("{a,b}{a,b}{a,b}{a,b}", "abab", &ample));
+}


### PR DESCRIPTION
## Description

Brace expansion in the glob builtin is exponential in the number of `{a,b}` groups while the recursion stays shallow, so a formula-supplied pattern could pin the process indefinitely. Measured on the unbounded walk: a 150-byte pattern of 30 groups costs 2,147,483,647 expansions and does not finish in a minute of ReleaseSafe.

Total expansions are now capped, degrading to "no match" - the surrounding builtin has no error channel, and every other failure there returns the same way. Real globs use a handful of alternatives, so the ceiling sits far above anything legitimate.

## Related Issue

- None

## Notes for Reviewers

- None