### PR TITLE
refactor(glob): match formula and step globs through one correct matcher

### DIFF
--- a/scripts/regressions/glob-brace-expansion-has-no-depth-cap.sh
+++ b/scripts/regressions/glob-brace-expansion-has-no-depth-cap.sh
@@ -1,36 +1,32 @@
 #!/usr/bin/env bash
-# Regression: brace expansion in the glob builtin must stay bounded.
+# Regression: glob matching must stay bounded, and there must be only one of it.
 #
-# The reported bug was a stack overflow from deeply nested braces. That is not
-# reachable: the 1024-byte expansion buffer drops any pattern whose expansion
-# does not fit, so nesting tops out near 513 frames (~632 KB against an 8 MB
-# stack). A depth counter would be dead code.
+# Patterns come from formula and tap data, and two costs in the old matchers ran
+# away on them: brace alternation multiplies combinations, and a recursive star
+# matcher re-explores every suffix. Both hang rather than crash, which is why the
+# depth cap the original report asked for would not have caught either. Two
+# copies of the matcher also disagreed on nested groups, so a reintroduced
+# private copy is itself a regression.
 #
-# The reachable defect is the other axis. Each `{a,b}` group doubles the work,
-# so cost is exponential in the number of groups while the recursion stays
-# shallow - a hang rather than a crash, which is why a depth cap cannot see it.
-# Measured on the unbounded walk: a 150-byte pattern of 30 groups costs
-# 2,147,483,647 expansions and does not finish in a minute of ReleaseSafe. The
-# pattern is formula code, so it needs a ceiling. The fix caps total expansions
-# and degrades to "no match", matching how every other failure here returns.
-#
-# No CLI subcommand exposes the matcher in isolation, so the guard is exercised
-# by colocated `test {}` blocks: one pins the shapes real formula globs use, one
-# drives the exponential axis, one pins the give-up behaviour. This script
-# builds the colocated test binary and judges those tests' lines.
-#
-# Exits 0 when the bound holds, non-zero (with a clear message) when it does
-# not. No network required; finishes in about a minute.
+# No subcommand exposes the matcher, so the guard runs its colocated `test {}`
+# blocks. Exits 0 when the bounds hold, non-zero with a clear message when they
+# do not. No network; about a minute.
 
 set -euo pipefail
 
 ROOT=$(cd "$(dirname "$0")/../.." && pwd)
-SRC="$ROOT/src/core/dsl/builtins/pathname.zig"
+SRC="$ROOT/src/glob.zig"
 
 FILTERS=(
-  "glob matches wildcards and brace alternation"
-  "glob alternation cannot be driven into an unbounded expansion"
-  "glob expansion budget refuses instead of exploring"
+  "matches literals and wildcards"
+  "matches a flat alternation"
+  "matches a nested alternation"
+  "alternation cannot be driven into an unbounded expansion"
+  "an exhausted budget refuses instead of exploring"
+  "an expansion longer than the buffer is dropped, not truncated"
+  "a wide pattern still matches its last combination"
+  "a pattern past the ceiling is refused whole, not part-way"
+  "repeated wildcards cost steps, not combinations"
 )
 
 # If a guard test is ever deleted the name filter would match nothing and
@@ -61,7 +57,7 @@ if [[ $RC -eq 124 ]]; then
 fi
 
 for F in "${FILTERS[@]}"; do
-  LINE=$(printf '%s\n' "$OUT" | grep -F -- "$F" || true)
+  LINE=$(printf '%s\n' "$OUT" | grep -F -- "glob.test.$F" || true)
   if [[ -z "$LINE" ]]; then
     echo "FAIL: glob expansion guard test did not run: $F" >&2
     exit 1
@@ -72,4 +68,13 @@ for F in "${FILTERS[@]}"; do
   fi
 done
 
-echo "PASS: glob brace expansion stays bounded on formula-controlled patterns"
+# One matcher, not two. A reintroduced private copy would silently escape every
+# guard above, which is exactly how the two implementations drifted apart.
+COPIES=$(grep -rl --include='*.zig' -e 'fn globMatch' -e 'fn starMatch' "$ROOT/src" || true)
+if [[ -n "$COPIES" ]]; then
+  echo "FAIL: a private glob matcher reappeared, bypassing the shared one:" >&2
+  echo "$COPIES" >&2
+  exit 1
+fi
+
+echo "PASS: glob matching is bounded, nesting-correct, and not duplicated"

--- a/src/core/dsl/builtins/pathname.zig
+++ b/src/core/dsl/builtins/pathname.zig
@@ -11,6 +11,7 @@ const sandbox = @import("../sandbox.zig");
 const fs_read = @import("../../../fs/read.zig");
 const ast = @import("../ast.zig");
 const fallback_log = @import("../fallback_log.zig");
+const glob_match = @import("../../../glob.zig");
 
 const Value = values.Value;
 
@@ -351,7 +352,7 @@ pub fn glob(ctx: ExecCtx, receiver: ?Value, args: []const Value) BuiltinError!Va
     var results: std.ArrayList(Value) = .empty;
     var iter = dir.iterate();
     while (iter.next(ctx.io) catch null) |entry| {
-        if (globMatch(pattern, entry.name)) {
+        if (glob_match.match(pattern, entry.name)) {
             const child_path = std.fs.path.join(ctx.allocator, &.{ base_dir, entry.name }) catch continue;
             results.append(ctx.allocator, Value{ .pathname = child_path }) catch continue;
         }
@@ -359,90 +360,6 @@ pub fn glob(ctx: ExecCtx, receiver: ?Value, args: []const Value) BuiltinError!Va
 
     const slice = results.toOwnedSlice(ctx.allocator) catch return BuiltinError.OutOfMemory;
     return Value{ .array = slice };
-}
-
-/// Ceiling on how many expansions a single match may attempt. Each `{a,b}`
-/// group doubles the work, so a pattern short enough to fit the expansion
-/// buffer still reaches 2^200 combinations - and the pattern is formula code.
-/// Real globs use a handful of alternatives, so this sits far above them.
-const max_glob_expansions: u32 = 10_000;
-
-/// Glob pattern matching with `*`, `?`, and `{a,b,c}` brace expansion.
-fn globMatch(pattern: []const u8, name: []const u8) bool {
-    var budget: u32 = max_glob_expansions;
-    return globMatchBudgeted(pattern, name, &budget);
-}
-
-fn globMatchBudgeted(pattern: []const u8, name: []const u8, budget: *u32) bool {
-    // Out of budget degrades to "no match": the calling builtin has no error
-    // channel, and every other failure here returns the same way.
-    if (budget.* == 0) return false;
-    budget.* -= 1;
-
-    // Check if pattern contains braces — if so, expand and try each alternative
-    if (std.mem.findScalar(u8, pattern, '{')) |brace_start| {
-        if (findMatchingBrace(pattern, brace_start)) |brace_end| {
-            const prefix = pattern[0..brace_start];
-            const suffix = pattern[brace_end + 1 ..];
-            const alternatives = pattern[brace_start + 1 .. brace_end];
-
-            // Split alternatives by comma and try each
-            var iter = std.mem.splitScalar(u8, alternatives, ',');
-            while (iter.next()) |alt| {
-                // Build expanded pattern: prefix + alt + suffix
-                var buf: [1024]u8 = undefined;
-                const expanded_len = prefix.len + alt.len + suffix.len;
-                if (expanded_len > buf.len) continue;
-                @memcpy(buf[0..prefix.len], prefix);
-                @memcpy(buf[prefix.len .. prefix.len + alt.len], alt);
-                @memcpy(buf[prefix.len + alt.len .. expanded_len], suffix);
-                if (globMatchBudgeted(buf[0..expanded_len], name, budget)) return true;
-            }
-            return false;
-        }
-    }
-
-    // Standard glob matching without braces
-    var pi: usize = 0;
-    var ni: usize = 0;
-    var star_pi: ?usize = null;
-    var star_ni: usize = 0;
-
-    while (ni < name.len) {
-        if (pi < pattern.len and (pattern[pi] == name[ni] or pattern[pi] == '?')) {
-            pi += 1;
-            ni += 1;
-        } else if (pi < pattern.len and pattern[pi] == '*') {
-            star_pi = pi;
-            star_ni = ni;
-            pi += 1;
-        } else if (star_pi) |sp| {
-            pi = sp + 1;
-            star_ni += 1;
-            ni = star_ni;
-        } else {
-            return false;
-        }
-    }
-
-    // Consume trailing *'s in pattern
-    while (pi < pattern.len and pattern[pi] == '*') : (pi += 1) {}
-    return pi == pattern.len;
-}
-
-/// Find matching closing brace, accounting for nesting.
-fn findMatchingBrace(pattern: []const u8, start: usize) ?usize {
-    var depth: u32 = 0;
-    var i = start;
-    while (i < pattern.len) : (i += 1) {
-        if (pattern[i] == '{') {
-            depth += 1;
-        } else if (pattern[i] == '}') {
-            depth -= 1;
-            if (depth == 0) return i;
-        }
-    }
-    return null;
 }
 
 fn receiverPath(allocator: std.mem.Allocator, receiver: ?Value) BuiltinError![]const u8 {
@@ -810,37 +727,4 @@ test "atomic_write keeps the target's existing mode instead of widening it" {
     // file must not silently widen because of that.
     const st = try std.Io.Dir.cwd().statFile(io, target, .{});
     try std.testing.expectEqual(@as(u32, 0o600), @intFromEnum(st.permissions) & 0o777);
-}
-
-test "glob matches wildcards and brace alternation" {
-    // Baseline for the expansion budget below: the shapes formula globs
-    // actually use must keep matching exactly as before.
-    try std.testing.expect(globMatch("*.h", "stdio.h"));
-    try std.testing.expect(!globMatch("*.h", "stdio.c"));
-    try std.testing.expect(globMatch("lib?.a", "libz.a"));
-    try std.testing.expect(globMatch("*.{h,hpp,hxx}", "vec.hpp"));
-    try std.testing.expect(!globMatch("*.{h,hpp,hxx}", "vec.cpp"));
-    try std.testing.expect(globMatch("{bin,sbin}/*", "bin/tool"));
-    try std.testing.expect(globMatch("a{b,c}d{e,f}", "acdf"));
-    try std.testing.expect(!globMatch("a{b,c}d{e,f}", "axdf"));
-}
-
-test "glob alternation cannot be driven into an unbounded expansion" {
-    // Each `{a,b}` group doubles the work, so a pattern only this long already
-    // costs 2^31 expansions unbounded - a hang, not a crash, since the depth
-    // stays shallow. The pattern comes from formula code, so it needs a bound.
-    var pattern: [30 * 5]u8 = undefined;
-    for (0..30) |i| @memcpy(pattern[i * 5 ..][0..5], "{a,b}");
-
-    try std.testing.expect(!globMatch(&pattern, "no-such-name"));
-}
-
-test "glob expansion budget refuses instead of exploring" {
-    // Exhausting the budget must degrade to "no match" rather than keep going;
-    // the surrounding builtin has no error channel to report a give-up on.
-    var spent: u32 = 3;
-    try std.testing.expect(!globMatchBudgeted("{a,b}{a,b}{a,b}{a,b}", "abab", &spent));
-
-    var ample: u32 = max_glob_expansions;
-    try std.testing.expect(globMatchBudgeted("{a,b}{a,b}{a,b}{a,b}", "abab", &ample));
 }

--- a/src/core/post_install_steps.zig
+++ b/src/core/post_install_steps.zig
@@ -19,6 +19,7 @@ const ca_bundle = @import("ca_bundle.zig");
 const clonefile = @import("../fs/clonefile.zig");
 const fs_read = @import("../fs/read.zig");
 const text_replace = @import("../text_replace.zig");
+const glob_match = @import("../glob.zig");
 const patch = @import("patch.zig");
 const codesign = @import("../macho/codesign.zig");
 const system_tools = @import("../system_tools.zig");
@@ -650,7 +651,7 @@ fn symlinkGlob(ctx: StepsCtx, obj: std.json.ObjectMap, source: []const u8, targe
     const force = getFlag(obj, "force");
     var iter = dir.iterate();
     while (iter.next(ctx.io) catch null) |entry| {
-        if (!globMatch(ctx.allocator, pattern, entry.name)) continue;
+        if (!glob_match.match(pattern, entry.name)) continue;
         const child = std.fs.path.join(ctx.allocator, &.{ dir_path, entry.name }) catch continue;
         const link_path = std.fs.path.join(ctx.allocator, &.{ target, entry.name }) catch continue;
         // Each match is its own write: a planted symlink must not redirect
@@ -660,34 +661,6 @@ fn symlinkGlob(ctx: StepsCtx, obj: std.json.ObjectMap, source: []const u8, targe
         std.Io.Dir.symLinkAbsolute(ctx.io, child, link_path, .{}) catch {};
     }
     return true;
-}
-
-/// Shell-style match limited to what formula globs use: `*` and `{a,b}`.
-/// ponytail: no `?` or `[...]` — no formula in homebrew-core ships one.
-fn globMatch(a: std.mem.Allocator, pattern: []const u8, name: []const u8) bool {
-    const open = std.mem.indexOfScalar(u8, pattern, '{') orelse return starMatch(pattern, name);
-    const close = std.mem.indexOfScalarPos(u8, pattern, open + 1, '}') orelse return starMatch(pattern, name);
-    var alts = std.mem.splitScalar(u8, pattern[open + 1 .. close], ',');
-    while (alts.next()) |alt| {
-        const expanded = std.fmt.allocPrint(a, "{s}{s}{s}", .{
-            pattern[0..open], alt, pattern[close + 1 ..],
-        }) catch return false;
-        if (globMatch(a, expanded, name)) return true;
-    }
-    return false;
-}
-
-fn starMatch(pattern: []const u8, name: []const u8) bool {
-    if (pattern.len == 0) return name.len == 0;
-    if (pattern[0] == '*') {
-        var i: usize = 0;
-        while (true) : (i += 1) {
-            if (starMatch(pattern[1..], name[i..])) return true;
-            if (i == name.len) return false;
-        }
-    }
-    if (name.len == 0 or pattern[0] != name[0]) return false;
-    return starMatch(pattern[1..], name[1..]);
 }
 
 /// `guards` gate a step on a path's state. `unsupported` keeps a condition
@@ -1279,7 +1252,7 @@ fn collectMatches(
     var iter = dir.iterate();
     while (iter.next(ctx.io) catch null) |entry| {
         const child = std.fs.path.join(ctx.allocator, &.{ dir_path, entry.name }) catch continue;
-        if (globMatch(ctx.allocator, pattern, entry.name)) out.append(ctx.allocator, child) catch return;
+        if (glob_match.match(pattern, entry.name)) out.append(ctx.allocator, child) catch return;
         if (descend and entry.kind == .directory) collectMatches(ctx, child, pattern, true, out);
     }
 }
@@ -2837,21 +2810,6 @@ test "execute links every source_glob match into the target directory" {
     // A non-matching sibling must not be dragged along.
     const stray = try std.fmt.allocPrint(a, "{s}/unrelated.1", .{man_dst});
     try testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(io, stray, .{}));
-}
-
-test "globMatch honours alternation and wildcards without matching neighbours" {
-    var arena = std.heap.ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-    const a = arena.allocator();
-
-    try testing.expect(globMatch(a, "{npm,npx,package-}*", "npm.1"));
-    try testing.expect(globMatch(a, "{npm,npx,package-}*", "package-json.5"));
-    try testing.expect(!globMatch(a, "{npm,npx,package-}*", "unrelated.1"));
-    // A leading wildcard must not swallow the anchor that follows it.
-    try testing.expect(globMatch(a, "*.1", "npm.1"));
-    try testing.expect(!globMatch(a, "*.1", "npm.5"));
-    try testing.expect(globMatch(a, "literal", "literal"));
-    try testing.expect(!globMatch(a, "literal", "literals"));
 }
 
 test "execute runs the filesystem tier natively and leaves the log clean" {

--- a/src/glob.zig
+++ b/src/glob.zig
@@ -1,0 +1,276 @@
+//! Shell-style glob matching for formula- and tap-supplied patterns:
+//! `*`, `?`, and `{a,b}` alternation with nesting.
+//!
+//! Pure and allocation-free. The pattern is untrusted input, so the two costs
+//! it can drive are bounded here rather than at each call site: expansions are
+//! capped, and an expansion that outgrows the buffer is dropped.
+
+const std = @import("std");
+
+/// Ceiling on the combinations one pattern may describe. Checked against the
+/// pattern itself rather than per candidate name: the cost belongs to the
+/// pattern, and a directory walk pays it again for every entry, so a per-name
+/// budget bounds each call while leaving the walk unbounded.
+///
+/// Real globs describe a handful of combinations, so this clears them by orders
+/// of magnitude while keeping even a pathological directory to seconds.
+pub const max_combinations: u32 = 1024;
+
+/// Longest expanded pattern considered. Bounds recursion depth as a side
+/// effect: each level consumes at least one `{}` pair.
+const max_pattern_len = 1024;
+
+pub fn match(pattern: []const u8, name: []const u8) bool {
+    if (combinations(pattern) > max_combinations) return false;
+    // `combinations` counts leaves; the walk also visits the interior nodes
+    // leading to them, so the running bound needs room above the ceiling.
+    var budget: u32 = max_combinations * 4;
+    return matchBudgeted(pattern, name, &budget);
+}
+
+/// Combinations `pattern` describes, saturating one past the ceiling. Groups
+/// multiply and the alternatives inside a group add, mirroring the shape the
+/// matcher would otherwise walk per name.
+pub fn combinations(pattern: []const u8) u32 {
+    // An over-long pattern is refused whole - the matcher drops each of its
+    // expansions anyway - which also keeps this walk shallow.
+    if (pattern.len > max_pattern_len) return max_combinations + 1;
+
+    var total: u32 = 1;
+    var from: usize = 0;
+    while (std.mem.findScalarPos(u8, pattern, from, '{')) |open| {
+        const close = findMatchingBrace(pattern, open) orelse break;
+        var sum: u32 = 0;
+        var alternatives: AlternativeIterator = .{ .rest = pattern[open + 1 .. close] };
+        while (alternatives.next()) |alt| sum +|= combinations(alt);
+        total = std.math.mul(u32, total, sum) catch return max_combinations + 1;
+        if (total > max_combinations) return max_combinations + 1;
+        from = close + 1;
+    }
+    return total;
+}
+
+/// Exposed so the bound itself can be exercised without building a pattern
+/// large enough to reach it.
+pub fn matchBudgeted(pattern: []const u8, name: []const u8, budget: *u32) bool {
+    // Out of budget degrades to "no match": callers match filenames and have
+    // no error channel to report a give-up on.
+    if (budget.* == 0) return false;
+    budget.* -= 1;
+
+    const open = std.mem.findScalar(u8, pattern, '{') orelse return wildcardMatch(pattern, name);
+    const close = findMatchingBrace(pattern, open) orelse return wildcardMatch(pattern, name);
+
+    const prefix = pattern[0..open];
+    const suffix = pattern[close + 1 ..];
+    var alternatives: AlternativeIterator = .{ .rest = pattern[open + 1 .. close] };
+    while (alternatives.next()) |alt| {
+        var buf: [max_pattern_len]u8 = undefined;
+        const len = prefix.len + alt.len + suffix.len;
+        if (len > buf.len) continue;
+        @memcpy(buf[0..prefix.len], prefix);
+        @memcpy(buf[prefix.len..][0..alt.len], alt);
+        @memcpy(buf[prefix.len + alt.len ..][0..suffix.len], suffix);
+        if (matchBudgeted(buf[0..len], name, budget)) return true;
+    }
+    return false;
+}
+
+/// Split alternatives on the commas that belong to *this* group. Splitting on
+/// every comma tears `{a{b,c},d}` into `a{b`, `c}` and `d`, which matches
+/// neither the intended alternatives nor anything else useful.
+const AlternativeIterator = struct {
+    rest: ?[]const u8,
+
+    fn next(self: *AlternativeIterator) ?[]const u8 {
+        const rest = self.rest orelse return null;
+        var depth: usize = 0;
+        for (rest, 0..) |c, i| switch (c) {
+            '{' => depth += 1,
+            '}' => depth -|= 1,
+            ',' => if (depth == 0) {
+                self.rest = rest[i + 1 ..];
+                return rest[0..i];
+            },
+            else => {},
+        };
+        self.rest = null;
+        return rest;
+    }
+};
+
+/// Closing brace for the group opening at `start`, skipping nested groups.
+/// Taking the first `}` instead would cut a nested group in half.
+fn findMatchingBrace(pattern: []const u8, start: usize) ?usize {
+    std.debug.assert(pattern[start] == '{');
+    var depth: usize = 0;
+    for (pattern[start..], start..) |c, i| switch (c) {
+        '{' => depth += 1,
+        '}' => {
+            depth -= 1;
+            if (depth == 0) return i;
+        },
+        else => {},
+    };
+    return null;
+}
+
+/// `*` and `?` matching, iterative with a single backtrack point. The natural
+/// recursive form re-explores every suffix: on `*a*a*a...` it runs to billions
+/// of calls where this one takes hundreds.
+fn wildcardMatch(pattern: []const u8, name: []const u8) bool {
+    var pi: usize = 0;
+    var ni: usize = 0;
+    var star: ?usize = null;
+    var star_ni: usize = 0;
+
+    while (ni < name.len) {
+        if (pi < pattern.len and (pattern[pi] == name[ni] or pattern[pi] == '?')) {
+            pi += 1;
+            ni += 1;
+        } else if (pi < pattern.len and pattern[pi] == '*') {
+            star = pi;
+            star_ni = ni;
+            pi += 1;
+        } else if (star) |s| {
+            pi = s + 1;
+            star_ni += 1;
+            ni = star_ni;
+        } else return false;
+    }
+    while (pi < pattern.len and pattern[pi] == '*') : (pi += 1) {}
+    return pi == pattern.len;
+}
+
+test "matches literals and wildcards" {
+    try std.testing.expect(match("literal", "literal"));
+    try std.testing.expect(!match("literal", "literals"));
+    try std.testing.expect(match("*.h", "stdio.h"));
+    try std.testing.expect(!match("*.h", "stdio.c"));
+    try std.testing.expect(match("lib?.a", "libz.a"));
+    try std.testing.expect(!match("lib?.a", "libzz.a"));
+    try std.testing.expect(match("*", "anything"));
+    // A leading wildcard must not swallow the anchor that follows it.
+    try std.testing.expect(match("*.1", "npm.1"));
+    try std.testing.expect(!match("*.1", "npm.5"));
+}
+
+test "matches a flat alternation" {
+    try std.testing.expect(match("*.{h,hpp,hxx}", "vec.hpp"));
+    try std.testing.expect(!match("*.{h,hpp,hxx}", "vec.cpp"));
+    try std.testing.expect(match("{bin,sbin}/*", "bin/tool"));
+    try std.testing.expect(match("a{b,c}d{e,f}", "acdf"));
+    try std.testing.expect(!match("a{b,c}d{e,f}", "axdf"));
+    try std.testing.expect(match("{npm,npx,package-}*", "npm.1"));
+    try std.testing.expect(match("{npm,npx,package-}*", "package-json.5"));
+    try std.testing.expect(!match("{npm,npx,package-}*", "unrelated.1"));
+}
+
+test "matches a nested alternation" {
+    // Splitting on every comma would offer `a{b`, `c}` and `d` here, so every
+    // branch but the last would be unmatchable.
+    try std.testing.expect(match("{a{b,c},d}", "ab"));
+    try std.testing.expect(match("{a{b,c},d}", "ac"));
+    try std.testing.expect(match("{a{b,c},d}", "d"));
+    try std.testing.expect(!match("{a{b,c},d}", "a"));
+    try std.testing.expect(!match("{a{b,c},d}", "ad"));
+    try std.testing.expect(match("lib{foo{32,64},bar}.a", "libfoo64.a"));
+    try std.testing.expect(match("lib{foo{32,64},bar}.a", "libbar.a"));
+    try std.testing.expect(!match("lib{foo{32,64},bar}.a", "libfoo.a"));
+}
+
+test "matches empty patterns and empty names" {
+    try std.testing.expect(match("", ""));
+    try std.testing.expect(!match("", "x"));
+    try std.testing.expect(match("*", ""));
+    try std.testing.expect(!match("?", ""));
+    try std.testing.expect(match("{a,}", "a"));
+    try std.testing.expect(match("{a,}", ""));
+}
+
+test "a wide pattern still matches its last combination" {
+    // The ceiling is a give-up, not an error, so it has to clear real patterns
+    // by a wide margin. This shape is already far past anything a formula ships
+    // and the combination explored last still matches.
+    var pattern: [3 * 21]u8 = undefined;
+    for (0..3) |i| @memcpy(pattern[i * 21 ..][0..21], "{a,b,c,d,e,f,g,h,i,j}");
+
+    try std.testing.expect(match(&pattern, "aaa"));
+    try std.testing.expect(match(&pattern, "jjj"));
+    try std.testing.expect(!match(&pattern, "jjk"));
+}
+
+test "a pattern past the ceiling is refused whole, not part-way" {
+    // Refusing per pattern rather than per name keeps a directory walk from
+    // paying the cost once per entry, and makes the give-up all-or-nothing
+    // instead of a partial result that depends on iteration order.
+    var pattern: [4 * 21]u8 = undefined;
+    for (0..4) |i| @memcpy(pattern[i * 21 ..][0..21], "{a,b,c,d,e,f,g,h,i,j}");
+
+    try std.testing.expect(combinations(&pattern) > max_combinations);
+    try std.testing.expect(!match(&pattern, "aaaa"));
+    try std.testing.expect(!match(&pattern, "jjjj"));
+}
+
+test "combinations counts groups as products and alternatives as sums" {
+    try std.testing.expectEqual(@as(u32, 1), combinations("*.h"));
+    try std.testing.expectEqual(@as(u32, 3), combinations("*.{h,hpp,hxx}"));
+    try std.testing.expectEqual(@as(u32, 4), combinations("{a,b}{c,d}"));
+    try std.testing.expectEqual(@as(u32, 3), combinations("{a{b,c},d}"));
+    try std.testing.expect(combinations("a{b") == 1);
+}
+
+test "an unterminated group is matched literally" {
+    try std.testing.expect(match("a{b", "a{b"));
+    try std.testing.expect(!match("a{b", "ab"));
+}
+
+test "repeated wildcards cost steps, not combinations" {
+    // A recursive star matcher re-explores every suffix and needs billions of
+    // calls for this pattern; the single backtrack point keeps it to hundreds.
+    var pattern: [12 * 2 + 1]u8 = undefined;
+    for (0..12) |i| @memcpy(pattern[i * 2 ..][0..2], "*a");
+    pattern[24] = 'b';
+    const name = "a" ** 60;
+
+    try std.testing.expect(!match(&pattern, name));
+    try std.testing.expect(match("*a*a*b", "aaaaaaab"));
+}
+
+test "alternation cannot be driven into an unbounded expansion" {
+    // Each group doubles the work, so a pattern this short already costs 2^31
+    // expansions unbounded - a hang, not a crash, since depth stays shallow.
+    var pattern: [30 * 5]u8 = undefined;
+    for (0..30) |i| @memcpy(pattern[i * 5 ..][0..5], "{a,b}");
+    try std.testing.expect(!match(&pattern, "no-such-name"));
+}
+
+test "an exhausted budget refuses instead of exploring" {
+    var spent: u32 = 3;
+    try std.testing.expect(!matchBudgeted("{a,b}{a,b}{a,b}{a,b}", "abab", &spent));
+
+    var ample: u32 = max_combinations;
+    try std.testing.expect(matchBudgeted("{a,b}{a,b}{a,b}{a,b}", "abab", &ample));
+}
+
+test "a deeply nested pattern is walked, not just dropped" {
+    // The sibling test below stops at the first expansion because it does not
+    // fit; this one fits at every level, so it exercises the recursive path all
+    // the way down rather than asserting depth safety by comment alone.
+    var pattern: [800]u8 = undefined;
+    @memset(pattern[0..400], '{');
+    @memset(pattern[400..], '}');
+
+    try std.testing.expectEqual(@as(u32, 1), combinations(&pattern));
+    try std.testing.expect(match(&pattern, ""));
+    try std.testing.expect(!match(&pattern, "x"));
+}
+
+test "an expansion longer than the buffer is dropped, not truncated" {
+    // Deep nesting expands to something too long to hold; the group is skipped
+    // rather than silently matched against a cut-off pattern.
+    var pattern: [1200]u8 = undefined;
+    @memset(pattern[0..600], '{');
+    @memset(pattern[600..], '}');
+    try std.testing.expect(!match(&pattern, "anything"));
+}


### PR DESCRIPTION
## Description

Two glob matchers existed - one in the DSL builtins, one in the post-install step executor - and they disagreed. On `{a{b,c},d}`, which should match `ab`, `ac` and `d`, each returned a different pair of wrong answers, because both split alternatives on every comma instead of the ones belonging to the group. Fixing them separately would have meant writing the same repair twice and hoping they stayed converged.

They are now one module, pure and allocation-free so the matcher can be exercised directly instead of through a filesystem walk. Sharing it also retires two ways a pattern could hang the process: the step executor's star matcher re-explored every suffix, costing billions of calls on a 25-byte pattern where the kept one takes hundreds.

## Related Issue

- None

## Notes for Reviewers

- Two deliberate behaviour changes on the post-install side: it gains `?` as a wildcard (it never implemented one, so a literal `?` in a step pattern is now a wildcard), and it gains the expansion-length cap the DSL side always had.
- The ceiling is checked against the pattern, not against each candidate name. A per-name budget bounds one call but leaves a directory walk paying it per entry, which measured 10.4s for twenty entries; per-pattern it is rejected once and the walk costs nothing. It also makes the give-up all-or-nothing rather than a partial result that depends on iteration order.
- The guard also fails if a second private matcher reappears. Duplication was the root cause, so it is worth checking directly.
