### PR TITLE
fix(install): keep a formula installable when a recommended dependency cannot be built

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -416,6 +416,9 @@ pub const InstallAllOpts = struct {
     /// Tap whose formula declared these packages as dependencies. Lets an
     /// unqualified sibling resolve inside that tap after core misses.
     dep_tap: ?[]const u8 = null,
+    /// Of `packages`, the ones the parent marked `:recommended`. Their absence
+    /// is survivable, so a source-build refusal on one is a warning.
+    recommended: []const []const u8 = &.{},
 };
 
 /// Non-argv primitive used by `core/bundle/runner.zig` via its injected
@@ -436,6 +439,7 @@ pub fn installAll(
         .skip_lock = opts.skip_lock,
         .sink = opts.sink,
         .dep_tap = opts.dep_tap,
+        .recommended = opts.recommended,
     });
 }
 
@@ -457,7 +461,21 @@ const ExecuteOpts = struct {
     /// See `InstallAllOpts.dep_tap`. Never set on the argv path: a name the
     /// user typed is theirs to qualify.
     dep_tap: ?[]const u8 = null,
+    /// See `InstallAllOpts.recommended`. Empty on the argv path: a package the
+    /// user asked for by name is never skipped on their behalf.
+    recommended: []const []const u8 = &.{},
 };
+
+/// A recommended dep malt cannot build is a warning, not a failure - refusing
+/// would make the parent uninstallable over a dependency it works without.
+/// Scoped to the source-build refusal: every other error still fails.
+fn skippableRecommended(recommended: []const []const u8, pkg_name: []const u8, e: anyerror) bool {
+    if (e != InstallError.BuildFromSourceUnsupported) return false;
+    for (recommended) |name| {
+        if (std.mem.eql(u8, name, pkg_name)) return true;
+    }
+    return false;
+}
 
 /// `allocator` must be an arena (see `installAll`).
 pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u8) !void {
@@ -731,10 +749,14 @@ fn runInstall(
                 // generic summary that just repeats the error enum name.
                 // (installTapFormula's error set is wider than InstallError,
                 // so this checks the one value rather than localErrorIsAnnounced.)
-                if (e != InstallError.BuildFromSourceUnsupported) {
-                    sink.err("Failed to install {s}: {s}", .{ pkg_name, @errorName(e) });
+                if (skippableRecommended(exec_opts.recommended, pkg_name, e)) {
+                    sink.warn("{s} is recommended, not required — continuing without it.", .{pkg_name});
+                } else {
+                    if (e != InstallError.BuildFromSourceUnsupported) {
+                        sink.err("Failed to install {s}: {s}", .{ pkg_name, @errorName(e) });
+                    }
+                    failed_count += 1;
                 }
-                failed_count += 1;
             };
             continue;
         }
@@ -768,8 +790,20 @@ fn runInstall(
                         var slug_buf: [256]u8 = undefined;
                         const slug = args_mod.tapSiblingSlug(&slug_buf, exec_opts.dep_tap orelse "", pkg_name) orelse
                             break :sibling;
-                        installTapFormula(ctx, allocator, slug, &db, &linker, prefix, flags.dry_run, flags.force, flags.download_only, sink) catch
-                            break :sibling;
+                        installTapFormula(ctx, allocator, slug, &db, &linker, prefix, flags.dry_run, flags.force, flags.download_only, sink) catch |tap_err| {
+                            if (skippableRecommended(exec_opts.recommended, pkg_name, tap_err)) {
+                                sink.warn("{s} is recommended, not required — continuing without it.", .{pkg_name});
+                                continue;
+                            }
+                            // The sibling is where it was actually found, so its
+                            // error is the useful one; the cask miss above is
+                            // just how we got here.
+                            if (tap_err != InstallError.BuildFromSourceUnsupported) {
+                                sink.err("Failed to install {s}: {s}", .{ slug, @errorName(tap_err) });
+                            }
+                            failed_count += 1;
+                            continue;
+                        };
                         continue;
                     }
                     if (e == api_mod.ApiError.OfflineRequired) {
@@ -2007,4 +2041,17 @@ test "pruneOtherCellarVersionsForReinstall tolerates keep_version absent on disk
 
     const stale_root = s.p("/Cellar/pcre2/10.47");
     try testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(ctx.io, stale_root, .{}));
+}
+
+test "skippableRecommended only downgrades the source-build refusal" {
+    const rec = [_][]const u8{ "mongodb-database-tools", "mongosh" };
+    // The one tolerable failure, for a dep the parent called recommended.
+    try std.testing.expect(skippableRecommended(&rec, "mongodb-database-tools", InstallError.BuildFromSourceUnsupported));
+    // Any other failure still fails the parent - a bad checksum or a dead
+    // mirror is not something to install around.
+    try std.testing.expect(!skippableRecommended(&rec, "mongodb-database-tools", InstallError.CaskNotFound));
+    // A required dep is never skipped, whatever it failed with.
+    try std.testing.expect(!skippableRecommended(&rec, "openssl@3", InstallError.BuildFromSourceUnsupported));
+    // Empty list: the argv path, where nothing is skipped on the user's behalf.
+    try std.testing.expect(!skippableRecommended(&.{}, "mongosh", InstallError.BuildFromSourceUnsupported));
 }

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -76,6 +76,9 @@ pub const ResolvedRubyFormula = struct {
     /// `:build`/`:optional`. Borrowed from the formula source, which
     /// outlives the install. Empty when the formula declares none.
     dependencies: []const []const u8 = &.{},
+    /// The `:recommended` subset of `dependencies` - the ones the formula
+    /// works without if malt cannot install them.
+    recommended: []const []const u8 = &.{},
     /// When set, the tap is registered in the DB (mirrors the original
     /// tap install behaviour). Local installs leave this null so they
     /// never pollute the tap list.
@@ -384,6 +387,8 @@ fn installTapRb(
 
     // Borrows from `resp.body`, which outlives the materialise call below.
     var dep_buf: [64][]const u8 = undefined;
+    var rec_buf: [64][]const u8 = undefined;
+    const recommended = formula_mod.declaredRecommendedDependencies(&rec_buf, resp.body) catch &.{};
     const deps = formula_mod.declaredInstallDependencies(&dep_buf, resp.body) catch {
         sink.err("{s} declares more than {d} dependencies", .{ parts.formula, dep_buf.len });
         return InstallError.DependencyFailed;
@@ -404,6 +409,7 @@ fn installTapRb(
         .binary_name = parseCaskBinary(resp.body),
         .app_name = parseCaskApp(resp.body),
         .dependencies = deps,
+        .recommended = recommended,
         .tap_registration = .{
             .url = urls.repo_url,
             .commit_sha = commit_sha,
@@ -526,6 +532,8 @@ pub fn installLocalFormula(
     const final_url = args.interpolateUrl(&final_url_buf, rb.url, rb.version, rb.arch_token);
 
     var dep_buf: [64][]const u8 = undefined;
+    var rec_buf: [64][]const u8 = undefined;
+    const recommended = formula_mod.declaredRecommendedDependencies(&rec_buf, body) catch &.{};
     const deps = formula_mod.declaredInstallDependencies(&dep_buf, body) catch {
         sink.err("{s} declares more than {d} dependencies", .{ name, dep_buf.len });
         return InstallError.DependencyFailed;
@@ -540,6 +548,7 @@ pub fn installLocalFormula(
         .sha256 = rb.sha256,
         // Borrows from `body`, which outlives the materialise call below.
         .dependencies = deps,
+        .recommended = recommended,
         // No tap_registration — never pollute `mt tap` with a local path.
     };
 
@@ -600,6 +609,7 @@ fn installDeclaredDeps(
         .sink = sink,
         // Only a real tap owns siblings; a `--local` .rb has none to search.
         .dep_tap = if (resolved.tap_registration != null) resolved.tap_label else null,
+        .recommended = resolved.recommended,
     }) catch {
         sink.err("Failed to install dependencies for {s}", .{resolved.name});
         return InstallError.DependencyFailed;

--- a/src/core/formula.zig
+++ b/src/core/formula.zig
@@ -86,7 +86,7 @@ const dependency_placeholders = [_]struct {
 /// this is for paths without one, where the DB rows describe a different
 /// version than the keg on disk.
 pub fn declaredDependencies(out: [][]const u8, rb_source: []const u8) []const []const u8 {
-    const total = scanDeclaredDeps(out, rb_source, false);
+    const total = scanDeclaredDeps(out, rb_source, .runtime);
     // Truncates rather than fails: these callers describe a keg already on
     // disk, where a short list costs a placeholder, not a broken install.
     return out[0..@min(total, out.len)];
@@ -104,16 +104,38 @@ pub fn declaredInstallDependencies(
     out: [][]const u8,
     rb_source: []const u8,
 ) error{TooManyDependencies}![]const []const u8 {
-    const total = scanDeclaredDeps(out, rb_source, true);
+    const total = scanDeclaredDeps(out, rb_source, .install);
     // Refuses rather than truncates: silently installing a prefix of the list
     // lands a keg missing libraries, which surfaces far from the cause.
     if (total > out.len) return error.TooManyDependencies;
     return out[0..total];
 }
 
+/// The `:recommended` subset of `declaredInstallDependencies`. These still get
+/// installed; the list only tells the installer whose failure it may downgrade
+/// to a warning rather than fail the parent over.
+pub fn declaredRecommendedDependencies(
+    out: [][]const u8,
+    rb_source: []const u8,
+) error{TooManyDependencies}![]const []const u8 {
+    const total = scanDeclaredDeps(out, rb_source, .recommended);
+    if (total > out.len) return error.TooManyDependencies;
+    return out[0..total];
+}
+
 /// Fill `out` with dependency names. Returns how many were *found*, which may
 /// exceed `out.len` — the wrappers above differ only in what they do about that.
-fn scanDeclaredDeps(out: [][]const u8, rb_source: []const u8, drop_optional: bool) usize {
+/// Which subset of `depends_on` lines a scan keeps.
+const DepScan = enum {
+    /// Everything the keg links at runtime.
+    runtime,
+    /// What an installer must pull in; `:optional` is opt-in only.
+    install,
+    /// The `:recommended` subset - the deps whose absence is survivable.
+    recommended,
+};
+
+fn scanDeclaredDeps(out: [][]const u8, rb_source: []const u8, scan: DepScan) usize {
     const decl = "depends_on ";
     var n: usize = 0;
     var lines = std.mem.tokenizeScalar(u8, rb_source, '\n');
@@ -127,9 +149,16 @@ fn scanDeclaredDeps(out: [][]const u8, rb_source: []const u8, drop_optional: boo
         if (rest.len == 0 or rest[0] != '"') continue;
         const close = std.mem.indexOfScalarPos(u8, rest, 1, '"') orelse continue;
 
-        const tail = rest[close..];
+        // Trailing comments are prose, not markers - a `:recommended` mentioned
+        // there once made a required dep's failure look survivable.
+        const full_tail = rest[close..];
+        const tail = if (std.mem.indexOfScalar(u8, full_tail, '#')) |h| full_tail[0..h] else full_tail;
         if (std.mem.indexOf(u8, tail, ":build") != null) continue;
-        if (drop_optional and std.mem.indexOf(u8, tail, ":optional") != null) continue;
+        switch (scan) {
+            .runtime => {},
+            .install => if (std.mem.indexOf(u8, tail, ":optional") != null) continue,
+            .recommended => if (std.mem.indexOf(u8, tail, ":recommended") == null) continue,
+        }
 
         if (n < out.len) out[n] = rest[1..close];
         n += 1;
@@ -1330,4 +1359,72 @@ test "dependencyPlaceholder does not mistake a lookalike dependency name" {
     var buf: [256]u8 = undefined;
     const deps = [_][]const u8{"openjdk-doc"};
     try testing.expect(dependencyPlaceholder(&buf, "/opt/malt", &deps) == null);
+}
+
+test "declaredRecommendedDependencies returns only the recommended subset" {
+    const rb =
+        \\class Foo < Formula
+        \\  depends_on "required-one"
+        \\  depends_on "mongodb-database-tools" => :recommended
+        \\  depends_on "mongosh" => :recommended
+        \\  depends_on "cmake" => :build
+        \\  depends_on "extra" => :optional
+        \\end
+    ;
+    var buf: [8][]const u8 = undefined;
+    const got = try declaredRecommendedDependencies(&buf, rb);
+    try std.testing.expectEqual(@as(usize, 2), got.len);
+    try std.testing.expectEqualStrings("mongodb-database-tools", got[0]);
+    try std.testing.expectEqualStrings("mongosh", got[1]);
+}
+
+test "declaredRecommendedDependencies is empty when nothing is recommended" {
+    const rb =
+        \\class Foo < Formula
+        \\  depends_on "required-one"
+        \\  depends_on "cmake" => :build
+        \\end
+    ;
+    var buf: [8][]const u8 = undefined;
+    try std.testing.expectEqual(@as(usize, 0), (try declaredRecommendedDependencies(&buf, rb)).len);
+}
+
+test "declaredRecommendedDependencies refuses rather than truncate an overlong list" {
+    // A short list would silently mark a dep non-recommended, turning a
+    // survivable skip into a hard failure (or the reverse).
+    const rb =
+        \\class Foo < Formula
+        \\  depends_on "a" => :recommended
+        \\  depends_on "b" => :recommended
+        \\end
+    ;
+    var buf: [1][]const u8 = undefined;
+    try std.testing.expectError(error.TooManyDependencies, declaredRecommendedDependencies(&buf, rb));
+}
+
+test "declaredRecommendedDependencies ignores a marker mentioned in a comment" {
+    // Downgrading a required dep's failure to a warning would report a broken
+    // install as a success.
+    const rb =
+        \\class Foo < Formula
+        \\  depends_on "libfoo" # unlike the :recommended one, this is mandatory
+        \\  depends_on "libbar" => :recommended
+        \\end
+    ;
+    var buf: [8][]const u8 = undefined;
+    const got = try declaredRecommendedDependencies(&buf, rb);
+    try std.testing.expectEqual(@as(usize, 1), got.len);
+    try std.testing.expectEqualStrings("libbar", got[0]);
+}
+
+test "declaredInstallDependencies keeps a dep whose comment mentions :optional" {
+    const rb =
+        \\class Foo < Formula
+        \\  depends_on "libfoo" # not :optional despite the word
+        \\end
+    ;
+    var buf: [8][]const u8 = undefined;
+    const got = try declaredInstallDependencies(&buf, rb);
+    try std.testing.expectEqual(@as(usize, 1), got.len);
+    try std.testing.expectEqualStrings("libfoo", got[0]);
 }


### PR DESCRIPTION
## Description

A `depends_on ... => :recommended` dependency whose archive builds from source made the whole install fail, taking the primary package down with a dependency it works without. Such a dependency is now skipped with a warning that names it and points at the command that installs it, while the parent continues.

Deliberately narrow: only the source-build refusal is downgraded. Every other failure, and every required dependency, still fails the install.

## Related Issue

- None

## Notes for Reviewers

- None
