### PR TITLE
fix(install): keep a Ruby-DSL formula's keg inside the Cellar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Security smoke
         run: ./scripts/smokes/smoke_security.sh
 
+      - name: Regression guard - Ruby-DSL Cellar confinement
+        run: ./scripts/regressions/ruby-dsl-name-version-escape-cellar.sh
+
       - name: Build universal binary
         run: just build-universal
 

--- a/scripts/regressions/ruby-dsl-name-version-escape-cellar.sh
+++ b/scripts/regressions/ruby-dsl-name-version-escape-cellar.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Regression: a Ruby-DSL formula must not be able to steer its own keg out of
+# the Cellar through `name` or `version`.
+#
+# The bug: the tap/`--local` `.rb` install path built the Cellar destination as
+# `<prefix>/Cellar/<name>/<version>` straight from the DSL, with no predicate
+# between parse and use. A `..` in either field is a real path hop to the
+# kernel, so a third-party tap could extract its payload, relocate it, and
+# record the keg row anywhere the invoking user can write - and under
+# `--force` the same string reached a `deleteTree`.
+#
+# The fix screens both fields with the existing `isPathComponent` predicate at
+# the two points where the resolved formula is constructed, and makes
+# `parseTapName` refuse a formula segment that is not a safe path component.
+#
+# Usage: scripts/regressions/ruby-dsl-name-version-escape-cellar.sh
+# Requirements: built malt at $MALT_BIN or zig-out/bin/malt. No network: the
+# archive is seeded into the SHA-keyed tap cache so the download is a warm hit.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+# MALT_PREFIX must be <= 13 bytes (Mach-O in-place patching budget).
+SB=$(mktemp -d /tmp/mt.XXX)
+trap 'rm -rf "$SB"' EXIT
+
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+export MALT_OFFLINE=1
+
+pass() { printf '  ✓ %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+# Run malt and fail unless it refused. Callers add their own filesystem
+# assertions, then report the pass.
+refuse() {
+  local label=$1
+  shift
+  local st=0
+  MALT_PREFIX="$PREFIX" "$BIN" "$@" >"$SB/log" 2>&1 || st=$?
+  if [[ "$st" -eq 0 ]]; then
+    cat "$SB/log" >&2
+    fail "$label accepted (exit 0)"
+  fi
+}
+
+PREFIX="$SB/p"
+mkdir -p "$PREFIX/cache/Tap" "$SB/work/bin"
+
+printf '#!/bin/sh\necho hi\n' >"$SB/work/bin/probe"
+chmod +x "$SB/work/bin/probe"
+tar czf "$SB/probe.tar.gz" -C "$SB/work" bin
+SHA=$(shasum -a 256 "$SB/probe.tar.gz" | cut -d' ' -f1)
+cp "$SB/probe.tar.gz" "$PREFIX/cache/Tap/$SHA.tar.gz"
+
+# `version` walks the keg out of the prefix and into this directory, which
+# stands in for anything the invoking user happens to own.
+mkdir -p "$SB/victim"
+: >"$SB/victim/keepme"
+
+printf 'class Probe < Formula\n  version "../../../victim"\n  url "https://example.invalid/probe.tar.gz"\n  sha256 "%s"\nend\n' \
+  "$SHA" >"$SB/probe.rb"
+
+refuse "a traversal \`version\`" install --local "$SB/probe.rb"
+[[ -e "$SB/victim/bin" ]] && fail "keg extracted outside the prefix at $SB/victim"
+pass "a traversal \`version\` is refused before anything is written"
+
+# The sharper half: under --force the same string reaches a deleteTree, so the
+# refusal is what keeps an unrelated directory from being pruned away.
+refuse "a traversal \`version\` under --force" install --local --force "$SB/probe.rb"
+[[ -f "$SB/victim/keepme" ]] || fail "--force pruned a directory outside the prefix"
+pass "--force cannot prune outside the prefix through a traversal \`version\`"
+
+# The `name` side needs no slash to escape: a local formula's name is its
+# basename minus `.rb`, so a file called `...rb` is simply named `..`. Its
+# version is benign, so only the name can refuse this one.
+printf 'class Probe < Formula\n  version "1.2.3"\n  url "https://example.invalid/probe.tar.gz"\n  sha256 "%s"\nend\n' \
+  "$SHA" >"$SB/...rb"
+
+refuse "a local formula named \`..\`" install --local "$SB/...rb"
+pass "a local formula whose basename is \`..\` is refused"
+
+# Same guard from the slug side: the formula segment reaches both the Cellar
+# path and a raw-file URL, so it must be refused at parse, before any fetch.
+MALT_PREFIX="$PREFIX" "$BIN" install --dry-run 'evil/tap/..' >"$SB/log2" 2>&1 || true
+grep -q "Invalid tap formula format" "$SB/log2" ||
+  fail "'evil/tap/..' was not refused at parse"
+pass "a traversal formula segment is refused at parse"

--- a/src/cli/install/args.zig
+++ b/src/cli/install/args.zig
@@ -50,7 +50,7 @@ pub fn isTapFormula(name: []const u8) bool {
 /// deliberately charset-agnostic - safe for a directory component, but this
 /// name is also spliced unescaped into a raw-file URL path, where a space or
 /// a CR would malform the request line.
-fn isFormulaNameCharset(name: []const u8) bool {
+pub fn isFormulaNameCharset(name: []const u8) bool {
     for (name) |c| switch (c) {
         'a'...'z', 'A'...'Z', '0'...'9', '-', '_', '+', '.', '@' => {},
         else => return false,
@@ -96,15 +96,21 @@ pub fn isLocalFormulaPath(arg: []const u8) bool {
     return false;
 }
 
-/// Parse a tap formula name into user, repo, formula components.
+/// Parse a tap formula name into user, repo, formula components. Null when
+/// the formula leaf is not safe to use as a path component or a URL segment.
 pub fn parseTapName(name: []const u8) ?struct { user: []const u8, repo: []const u8, formula: []const u8 } {
     const first_slash = std.mem.findScalar(u8, name, '/') orelse return null;
     const rest = name[first_slash + 1 ..];
     const second_slash = std.mem.findScalar(u8, rest, '/') orelse return null;
+    const formula = rest[second_slash + 1 ..];
+    // The leaf reaches both a Cellar path and an unescaped raw-file URL path,
+    // so it clears the same two bars `tapSiblingSlug` applies to a dep name.
+    if (!path_component.isPathComponent(formula)) return null;
+    if (!isFormulaNameCharset(formula)) return null;
     return .{
         .user = name[0..first_slash],
         .repo = rest[0..second_slash],
-        .formula = rest[second_slash + 1 ..],
+        .formula = formula,
     };
 }
 
@@ -703,4 +709,24 @@ test "tapSiblingSlug declines rather than truncate when the name will not fit" {
     // would resolve to some other formula.
     var buf: [8]u8 = undefined;
     try std.testing.expect(tapSiblingSlug(&buf, "mongodb/brew", "mongodb-database-tools") == null);
+}
+
+test "parseTapName keeps the punctuation real formula names use" {
+    try std.testing.expectEqualStrings("python@3.14", parseTapName("a/b/python@3.14").?.formula);
+    try std.testing.expectEqualStrings("libc++", parseTapName("a/b/libc++").?.formula);
+    try std.testing.expectEqualStrings("mongodb_tools", parseTapName("a/b/mongodb_tools").?.formula);
+}
+
+test "parseTapName refuses a formula segment that is not a safe leaf" {
+    // The leaf lands in `<prefix>/Cellar/<name>/...` and, unescaped, in a
+    // raw-file URL path, so it has to clear both bars.
+    try std.testing.expect(parseTapName("evil/tap/..") == null);
+    try std.testing.expect(parseTapName("evil/tap/../../etc") == null);
+    try std.testing.expect(parseTapName("evil/tap/.") == null);
+    try std.testing.expect(parseTapName("evil/tap/") == null);
+    try std.testing.expect(parseTapName("evil/tap/a\x00b") == null);
+    try std.testing.expect(parseTapName("evil/tap/evil dep") == null);
+    try std.testing.expect(parseTapName("evil/tap/evil\rdep") == null);
+    try std.testing.expect(parseTapName("evil/tap/evil?dep") == null);
+    try std.testing.expect(parseTapName("evil/tap/evil%2edep") == null);
 }

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -18,6 +18,7 @@ const forge = @import("../../core/forge.zig");
 const tap_cache = @import("../../core/tap_cache.zig");
 const sqlite = @import("../../db/sqlite.zig");
 const atomic = @import("../../fs/atomic.zig");
+const path_component = @import("../../fs/path_component.zig");
 const macho_parser = @import("../../macho/parser.zig");
 const client_mod = @import("../../net/client.zig");
 const output = @import("../../ui/output.zig");
@@ -84,6 +85,21 @@ pub const ResolvedRubyFormula = struct {
     /// never pollute the tap list.
     tap_registration: ?TapRegistration = null,
 };
+
+/// The Ruby DSL is tap-controlled and both fields land raw in
+/// `<prefix>/Cellar/<name>/<version>` - and, under `--force`, in the
+/// `deleteTree` that prunes it. Screening at construction rather than at the
+/// path sites keeps the refusal next to the malformed input.
+fn screenRubyIdentity(sink: OutputSink, name: []const u8, version: []const u8) InstallError!void {
+    if (!path_component.isPathComponent(name)) {
+        sink.err("Formula declares an unsafe name: {s}", .{name});
+        return InstallError.FormulaNotFound;
+    }
+    if (!path_component.isPathComponent(version)) {
+        sink.err("Formula declares an unsafe version: {s}", .{version});
+        return InstallError.FormulaNotFound;
+    }
+}
 
 const TapRegistration = struct {
     url: []const u8,
@@ -394,6 +410,8 @@ fn installTapRb(
         return InstallError.DependencyFailed;
     };
 
+    try screenRubyIdentity(sink, parts.formula, rb.version);
+
     // Substitute #{version} and #{arch} so the SHA-verified fetch
     // hits the right per-platform asset.
     var final_url_buf: [512]u8 = undefined;
@@ -527,6 +545,8 @@ pub fn installLocalFormula(
         return InstallError.LocalFormulaNotReadable;
     }
     const name = base[0 .. base.len - 3];
+
+    try screenRubyIdentity(sink, name, rb.version);
 
     var final_url_buf: [512]u8 = undefined;
     const final_url = args.interpolateUrl(&final_url_buf, rb.url, rb.version, rb.arch_token);
@@ -1826,4 +1846,33 @@ test "hoistSingleWrapperDir will not replace a dangling dotfile symlink at the k
     const link_path = try std.fmt.bufPrint(&target_buf, "{s}/.malt-reloc-version", .{keg});
     const n = try std.Io.Dir.readLinkAbsolute(test_io, link_path, &link_buf);
     try std.testing.expectEqualStrings("nowhere", link_buf[0..n]);
+}
+
+test "screenRubyIdentity refuses a name or version that escapes the Cellar" {
+    // `isPathComponent` owns its own contract; this pins the wiring - both
+    // fields screened, both refusals tagged the same.
+    try std.testing.expectError(InstallError.FormulaNotFound, screenRubyIdentity(sink_mod.silent, "..", "1.0"));
+    try std.testing.expectError(InstallError.FormulaNotFound, screenRubyIdentity(sink_mod.silent, "probe", "../../../escaped"));
+}
+
+test "screenRubyIdentity also screens a version derived from the URL" {
+    // A formula with no `version` line still gets one, from a URL path
+    // segment that only has to start with a digit - so the screen has to sit
+    // at construction, not on the `version "..."` extractor.
+    const body =
+        \\class Probe < Formula
+        \\  url "https://example.invalid/r/releases/download/1../../../escaped/probe.tar.gz"
+        \\  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+        \\end
+    ;
+    const rb = parseRubyFormula(body).?;
+    try std.testing.expectEqualStrings("1..", rb.version);
+    try std.testing.expectError(InstallError.FormulaNotFound, screenRubyIdentity(sink_mod.silent, "probe", rb.version));
+}
+
+test "screenRubyIdentity accepts the shapes real formula versions take" {
+    // Refusing a legitimate version would be its own bug: the predicate is
+    // charset-agnostic on purpose.
+    try screenRubyIdentity(sink_mod.silent, "python@3.14", "3.14.0");
+    try screenRubyIdentity(sink_mod.silent, "probe", "3.2.1+dfsg");
 }


### PR DESCRIPTION
## Description

Adding a third-party tap should not hand it write access to the whole filesystem. It did: a tap or local `.rb` declares its own `name` and `version`, and a `..` in either walked the keg out of `$MALT_PREFIX` to anywhere the invoking user can write - and under `--force` deleted there too.

Both fields now clear the same path-component predicate the JSON and cask paths already use. 

## Related Issue

- None

## Notes for Reviewers

- Both fields have a second, less obvious source: a formula with no `version` line derives one from the URL, and a local formula named `...rb` is simply named `..`. That is why the screen sits at construction rather than on the `version "..."` extractor.