### PR TITLE
fix(bundle): keep the bundle lock inside the bundles directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
           SMOKE_SKIP_NETWORK: "1"
         run: ./scripts/smokes/smoke_test.sh
 
+      - name: Regression guard - bundle lock confinement
+        run: ./scripts/regressions/bundle-lock-name-guard-bundle-lock-path-from-unvalidated-manifest-name.sh
+
       # Security smoke: flag-scope enforcement, argv-only lint,
       # pins-manifest shape, install.sh fail-closed regression suite.
       # Subsumes the individual install.sh step that used to live in

--- a/scripts/regressions/bundle-lock-name-guard-bundle-lock-path-from-unvalidated-manifest-name.sh
+++ b/scripts/regressions/bundle-lock-name-guard-bundle-lock-path-from-unvalidated-manifest-name.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Regression: a Maltfile `name` is author-controlled text, so it must be
+# screened before it is formatted into the bundle lock path.
+#
+# The bug: `run` interpolated the manifest name straight into
+# "<prefix>/var/malt/bundles/<name>.lock" and handed that to the lock file,
+# which creates the path and truncates it to zero bytes on release. A name
+# carrying `..` therefore created — or clobbered — any `*.lock` on disk, and a
+# name carrying `/` silently re-targeted the lock, voiding the mutual
+# exclusion it exists to provide.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+# `zig build test` never refreshes the CLI binary; build it so this exercises
+# current source rather than a stale artefact.
+if ! zig build >/dev/null 2>&1; then
+  echo "FAIL: could not build the malt binary (zig build)" >&2
+  exit 1
+fi
+
+MT="${MT:-$ROOT/zig-out/bin/mt}"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/px/var/malt/bundles" "$TMP/out" "$TMP/wd"
+
+# Canary outside the prefix; a truncating lock would leave it at 0 bytes.
+printf 'CANARY\n' >"$TMP/out/victim.lock"
+
+fail=0
+
+# Empty `formulas` keeps this offline: the lock is taken before any member
+# would be dispatched.
+for name in "../../escape" "../../../../out/victim" "a/b" ".." "."; do
+  printf '{"name": "%s", "version": 1, "formulas": []}\n' "$name" >"$TMP/wd/Maltfile.json"
+  if (cd "$TMP/wd" && MALT_PREFIX="$TMP/px" "$MT" bundle install Maltfile.json >/dev/null 2>&1); then
+    echo "FAIL: bundle install accepted hostile manifest name '$name'" >&2
+    fail=1
+  fi
+done
+
+# The refusal must name the cause, not leak an error tag.
+printf '{"name": "../../escape", "version": 1, "formulas": []}\n' >"$TMP/wd/Maltfile.json"
+msg=$(cd "$TMP/wd" && MALT_PREFIX="$TMP/px" "$MT" bundle install Maltfile.json 2>&1 || true)
+if ! printf '%s' "$msg" | grep -Fq 'bundle name is not a valid path component'; then
+  echo "FAIL: refusal did not explain why the bundle name was rejected" >&2
+  fail=1
+fi
+
+stray=$(find "$TMP/px" "$TMP/out" -name '*.lock' \
+  ! -path "$TMP/px/var/malt/bundles/*" ! -path "$TMP/out/victim.lock" || true)
+if [[ -n "$stray" ]]; then
+  echo "FAIL: lock created outside the bundles directory: $stray" >&2
+  fail=1
+fi
+
+if [[ "$(wc -c <"$TMP/out/victim.lock" | tr -d ' ')" -ne 7 ]]; then
+  echo "FAIL: a lock release truncated a file outside the bundles directory" >&2
+  fail=1
+fi
+
+# A legitimate name, and the absent-name fallback, must still install.
+for body in '{"name": "tiny", "version": 1, "formulas": []}' '{"version": 1, "formulas": []}'; do
+  printf '%s\n' "$body" >"$TMP/wd/Maltfile.json"
+  if ! (cd "$TMP/wd" && MALT_PREFIX="$TMP/px" "$MT" bundle install Maltfile.json >/dev/null 2>&1); then
+    echo "FAIL: guard rejects a legitimate bundle: $body" >&2
+    fail=1
+  fi
+done
+
+if [[ "$fail" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "PASS: bundle lock path stays inside the bundles directory"

--- a/src/cli/bundle.zig
+++ b/src/cli/bundle.zig
@@ -189,7 +189,7 @@ fn cmdInstall(ctx: *const AppCtx, allocator: std.mem.Allocator, rest: []const []
         .dry_run = dry_run,
         .dispatcher = &dispatcher,
     }) catch |e| {
-        output.err("bundle install failed: {s}", .{@errorName(e)});
+        output.err("bundle install failed: {s}", .{runner_mod.describeError(e)});
         return BundleError.RunnerFailed;
     };
     defer report.deinit();

--- a/src/core/bundle/runner.zig
+++ b/src/core/bundle/runner.zig
@@ -21,6 +21,7 @@ const sqlite = @import("../../db/sqlite.zig");
 const schema = @import("../../db/schema.zig");
 const lock_mod = @import("../../db/lock.zig");
 const atomic = @import("../../fs/atomic.zig");
+const path_component = @import("../../fs/path_component.zig");
 const signals = @import("../signals.zig");
 const manifest_mod = @import("manifest.zig");
 
@@ -33,6 +34,9 @@ pub const RunnerError = error{
     /// absence means the caller forgot to provide one and we refuse to
     /// silently do nothing.
     NoDispatcher,
+    /// The manifest name would leave the bundles directory once formatted
+    /// into the lock path.
+    UnsafeName,
 };
 
 /// Closed error set every dispatcher exit must land on. Kept in
@@ -59,6 +63,7 @@ pub fn describeError(err: RunnerError) []const u8 {
         RunnerError.IoFailed => "filesystem error during bundle install",
         RunnerError.OutOfMemory => "out of memory during bundle install",
         RunnerError.NoDispatcher => "bundle runner called without a dispatcher and without malt_bin",
+        RunnerError.UnsafeName => "bundle name is not a valid path component",
     };
 }
 
@@ -138,6 +143,9 @@ pub fn run(
     opts: Options,
 ) RunnerError!Report {
     const bundle_name = if (manifest.name.len > 0) manifest.name else "unnamed";
+    // Manifest-supplied, and it lands in the lock path below; refuse outright
+    // rather than sanitise, before createDirPath grants it any side effect.
+    if (!path_component.isPathComponent(bundle_name)) return RunnerError.UnsafeName;
 
     // Bundles directory + advisory lock for idempotency.
     const prefix: []const u8 = opts.prefix orelse atomic.maltPrefixOrAbort();
@@ -357,4 +365,17 @@ fn recordBundle(
     }
 
     try db.commit();
+}
+
+test "describeError gives every tag a distinct, non-empty message" {
+    const tags = [_]RunnerError{
+        RunnerError.DatabaseError, RunnerError.LockFailed,   RunnerError.IoFailed,
+        RunnerError.OutOfMemory,   RunnerError.NoDispatcher, RunnerError.UnsafeName,
+    };
+    for (tags, 0..) |a, i| {
+        try std.testing.expect(describeError(a).len > 0);
+        for (tags[i + 1 ..]) |b| {
+            try std.testing.expect(!std.mem.eql(u8, describeError(a), describeError(b)));
+        }
+    }
 }

--- a/tests/bundle_test.zig
+++ b/tests/bundle_test.zig
@@ -568,3 +568,73 @@ test "silent-sink dispatcher: member failure surfaces via Report with no stderr 
     // ...while the per-keg lines never reach the global stderr channel.
     try testing.expectEqual(@as(usize, 0), out_buf.items.len);
 }
+
+/// Manifest with no members: `run` takes the lock before dispatching, so the
+/// name check is reached without any network or subprocess.
+fn buildNamedManifest(parent: std.mem.Allocator, name: []const u8) !manifest_mod.Manifest {
+    var m = manifest_mod.Manifest.init(parent);
+    m.name = try m.allocator().dupe(u8, name);
+    m.version = manifest_mod.schema_version;
+    return m;
+}
+
+fn lockCountOutsideBundlesDir(dir: []const u8) !usize {
+    var root = try std.Io.Dir.cwd().openDir(std.Options.debug_io, dir, .{ .iterate = true });
+    defer root.close(std.Options.debug_io);
+    var walker = try root.walk(testing.allocator);
+    defer walker.deinit();
+    var n: usize = 0;
+    while (try walker.next(std.Options.debug_io)) |entry| {
+        if (entry.kind != .file) continue;
+        if (!std.mem.endsWith(u8, entry.path, ".lock")) continue;
+        if (!std.mem.startsWith(u8, entry.path, "var/malt/bundles/")) n += 1;
+    }
+    return n;
+}
+
+test "runner rejects a manifest name that is not a single path component" {
+    // A Maltfile name is author-controlled, and it reaches disk as the lock
+    // path; anything that hops out of the bundles directory must be refused
+    // rather than sanitised, so a hostile manifest fails loudly.
+    const hostile = [_][]const u8{ "../../escape", "../../../../out/victim", "a/b", "..", ".", "a\x00b", "foo/" };
+    for (hostile) |name| {
+        var t = try TempDb.init("unsafe_name");
+        defer t.deinit();
+
+        var m = try buildNamedManifest(testing.allocator, name);
+        defer m.deinit();
+
+        // Dry run too: previewing a hostile bundle as installable would let it
+        // pass review before the real run ever takes the lock.
+        for ([_]bool{ false, true }) |dry| {
+            try testing.expectError(
+                runner.RunnerError.UnsafeName,
+                runner.run(std.Options.debug_io, testing.allocator, &t.db, m, .{
+                    .dry_run = dry,
+                    .prefix = t.dir,
+                }),
+            );
+        }
+        try testing.expectEqual(@as(usize, 0), try lockCountOutsideBundlesDir(t.dir));
+    }
+}
+
+test "runner still accepts legitimate names and the absent-name fallback" {
+    // The guard must not narrow the charset real bundle names use, and an
+    // absent name keeps falling back to "unnamed".
+    const ok = [_][]const u8{ "tiny", "devtools", "my bundle@2", "" };
+    for (ok) |name| {
+        var t = try TempDb.init("safe_name");
+        defer t.deinit();
+
+        var m = try buildNamedManifest(testing.allocator, name);
+        defer m.deinit();
+
+        var report = try runner.run(std.Options.debug_io, testing.allocator, &t.db, m, .{
+            .dry_run = false,
+            .prefix = t.dir,
+        });
+        defer report.deinit();
+        try testing.expect(!report.hasFailure());
+    }
+}


### PR DESCRIPTION
## Description

A Maltfile's `name` is author-controlled and was formatted straight into the
lock path, so a name carrying `..` could create - and on release truncate to
zero bytes - any `*.lock` file on the machine, including outside `MALT_PREFIX`.
A name carrying `/` silently re-targeted the lock and voided the mutual
exclusion it exists to provide.

The name is now screened as a single path component before it reaches disk,
the same guard the repo already applies to formula names and cask tokens. A
hostile manifest is refused rather than sanitised, and the refusal says why.

## Related Issue

- None

## Notes for Reviewers

- Stacked on `chore/repair-static-regression-guards`, which this branch's CI
  needs to go green.