### PR TITLE
chore(clean): reclaim test scratch that mktemp leaves outside /tmp

### DIFF
--- a/justfile
+++ b/justfile
@@ -37,6 +37,7 @@ install:
 regressions-static:
     @./scripts/regressions/tap-resolution-contract.sh
     @./scripts/regressions/relocated-store-logic-version-pin.sh
+    @./scripts/regressions/clean-misses-tmpdir-test-scratch.sh
     @./scripts/regressions/post-install-native-spawns-inherit-full-environment.sh
     @./scripts/regressions/tar-prescan-followups-925-926-follow-up.sh
     @MALT_STATIC_ONLY=1 ./scripts/regressions/post-install-steps-live-artefacts.sh

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -2,12 +2,13 @@
 # scripts/clean.sh — remove Zig build artifacts and test scratch dirs.
 #
 # Clears `.zig-cache`, `zig-out`, and `coverage/`, plus any leftover
-# test / e2e / smoke / bench directories under `/tmp`. Covers every
-# variant used by the project:
+# test / e2e / smoke / bench directories under `/tmp` and `$TMPDIR`.
+# Covers every variant used by the project:
 #   malt_* / malt-*            Zig test scratch + bench work dir
 #   mt_* / mt-* / mt.*         CLI test dirs, bench prefix, smoke PREFIX
 #   ml_* / ml.*                LOGDIR (smoke + e2e security)
 #   mc_* / mc.*                CACHE  (smoke + e2e security)
+#   probe-budget.*             notifier probe-budget regression
 # and the bench peer-tool prefixes (/tmp/nb, /tmp/zb, /tmp/malt-bench),
 # honouring BENCH_WORK_DIR / MALT_BENCH_PREFIX / NB_BENCH_PREFIX /
 # ZB_BENCH_PREFIX env overrides so tweaked paths still get cleaned.
@@ -84,27 +85,41 @@ remove_tree .zig-cache
 remove_tree zig-out
 remove_tree coverage
 
-echo "▸ Test scratch under /tmp"
 # Patterns cover every mktemp/fixture prefix across tests + e2e + smoke +
 # bench. The underscore / dot / hyphen variants are intentional - smoke
 # uses `mktemp -d /tmp/mt.XXX`, e2e security uses `mt_sec.XXX`, bench
 # uses `/tmp/malt-bench`. Missing one variant leaks multi-GB Cellar or
 # cache dirs on every crashed run.
-for pattern in \
-  '/tmp/malt_*' \
-  '/tmp/malt-*' \
-  '/tmp/mt_*' \
-  '/tmp/mt-*' \
-  '/tmp/mt.*' \
-  '/tmp/ml_*' \
-  '/tmp/ml.*' \
-  '/tmp/mc_*' \
-  '/tmp/mc.*'; do
-  # Unquoted on purpose so the shell glob-expands the pattern.
+patterns='malt_* malt-* mt_* mt-* mt.* ml_* ml.* mc_* mc.* probe-budget.*'
+
+# `mktemp -d -t <prefix>` resolves against $TMPDIR, which on macOS is a
+# per-user dir under /var/folders - most of the shell suite lands there
+# rather than in /tmp, so sweeping /tmp alone leaves it to grow forever.
+# A bare `mktemp -d` lands there too, but as `tmp.XXXXXXXX`, a name shared
+# with every other app on the machine; it stays out of the sweep.
+roots=/tmp
+scratch_tmpdir=${TMPDIR:-}
+scratch_tmpdir=${scratch_tmpdir%/}
+case "$scratch_tmpdir" in
+# Already swept, or nothing to sweep.
+"" | /tmp) ;;
+# The patterns are malt-specific, but a $TMPDIR pointing at a home or the
+# root would still aim them at real work. Sweep only a genuine temp root.
+/tmp/* | /private/tmp/* | /var/* | /private/var/*) roots="$roots $scratch_tmpdir" ;;
+*) printf "  ⚠ refusing to sweep \$TMPDIR outside a temp root: %s\n" "$scratch_tmpdir" >&2 ;;
+esac
+
+# shellcheck disable=SC2086
+for root in $roots; do
+  echo "▸ Test scratch under $root"
   # shellcheck disable=SC2086
-  for path in $pattern; do
-    [ -e "$path" ] || continue
-    remove_tree "$path"
+  for pattern in $patterns; do
+    # Unquoted on purpose so the shell glob-expands the pattern.
+    # shellcheck disable=SC2086
+    for path in $root/$pattern; do
+      [ -e "$path" ] || continue
+      remove_tree "$path"
+    done
   done
 done
 

--- a/scripts/regressions/clean-misses-tmpdir-test-scratch.sh
+++ b/scripts/regressions/clean-misses-tmpdir-test-scratch.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Regression: `just clean` must sweep test scratch under $TMPDIR, not only /tmp.
+#
+# The bug: `mktemp -d -t <prefix>` resolves against $TMPDIR, which on macOS is
+# a per-user dir under /var/folders. Around fifty shell-suite call sites use
+# that form, so their scratch trees never landed in /tmp - and clean.sh globbed
+# /tmp alone. Every crashed or killed run leaked its prefix, Cellar and cache
+# there permanently, invisible to the one command meant to reclaim them.
+#
+# Static only, on purpose: clean.sh deletes /tmp scratch by design, so actually
+# running it here would wipe the fixtures of any suite running alongside it.
+# The behavioural proof belongs in a manual run, not in a shared CI worker.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+CLEAN="$ROOT/scripts/clean.sh"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+# The sweep must derive a second root from $TMPDIR and loop over both. All
+# three parts are pinned: dropping any one narrows the sweep back to /tmp
+# without changing a single visible behaviour.
+# The literal `$` is the point here - these match clean.sh's source, not values.
+# shellcheck disable=SC2016
+required=(
+  'scratch_tmpdir=${TMPDIR:-}'
+  'roots="$roots $scratch_tmpdir"'
+  'for root in $roots; do'
+)
+for literal in "${required[@]}"; do
+  grep -Fq -- "$literal" "$CLEAN" ||
+    fail "clean.sh no longer sweeps \$TMPDIR - missing: $literal"
+done
+
+# Every prefix the suite mints must stay in the pattern list; a missing variant
+# leaks a multi-GB Cellar or cache tree on each crashed run.
+for pattern in 'malt_\*' 'malt-\*' 'mt_\*' 'mt-\*' 'mt\.\*' 'ml_\*' 'ml\.\*' \
+  'mc_\*' 'mc\.\*' 'probe-budget\.\*'; do
+  grep -qE "^patterns=.*${pattern}" "$CLEAN" ||
+    fail "clean.sh dropped the '${pattern}' scratch prefix"
+done
+
+echo "PASS: clean sweeps test scratch under both /tmp and \$TMPDIR"

--- a/scripts/regressions/tar-prescan-followups-925-926-follow-up.sh
+++ b/scripts/regressions/tar-prescan-followups-925-926-follow-up.sh
@@ -81,8 +81,11 @@ ${fixed//$'\n'/$'\n'        }"
 
 # 4. a fixture root is only reclaimable if `just clean` sweeps its namespace,
 # and the corpus logs only survive CI if the artifact glob matches the root.
-mapfile -t swept < <(grep -oE "'/tmp/[^']+'" "$ROOT/scripts/clean.sh" | tr -d "'")
-((${#swept[@]} > 0)) || fail "no /tmp patterns found in clean.sh; this check is inert"
+# clean.sh holds one pattern list and sweeps it under every scratch root, so
+# re-attach the /tmp prefix the templates below are written with.
+mapfile -t swept < <(sed -nE "s/^patterns='(.*)'\$/\1/p" "$ROOT/scripts/clean.sh" |
+  tr ' ' '\n' | sed 's|^|/tmp/|')
+((${#swept[@]} > 0)) || fail "no scratch patterns found in clean.sh; this check is inert"
 while IFS= read -r tmpl; do
   [[ -n "$tmpl" ]] || continue
   sample=${tmpl//X/a}


### PR DESCRIPTION
## Description

`just clean` swept `/tmp` only, but `mktemp -d -t <prefix>` resolves against `$TMPDIR` - a per-user directory under `/var/folders` on macOS - and around fifty call sites across the shell suite use that form. Every crashed or killed run leaked its prefix, Cellar and cache there permanently, invisible to the one command meant to reclaim them. The sweep now covers both roots, and picks up the `probe-budget.*` prefix that matched no pattern in either.

A bare `mktemp -d` also lands in `$TMPDIR`, but as `tmp.XXXXXXXX` - a name shared with every other application on the machine - so it stays out of the sweep deliberately.

## Related Issue

- None

## Notes for Reviewers

- `$TMPDIR` is accepted only when it points at a real temp root, mirroring the guard the bench-prefix block already applies. A hostile or misconfigured value warns and is skipped rather than aiming the globs at a home directory.
- The new guard is static by design: running `clean.sh` for real in CI would delete the scratch of any suite running alongside it.