### PR TITLE
refactor(store): build every store path through one validating constructor

### DIFF
--- a/src/cli/doctor/fix.zig
+++ b/src/cli/doctor/fix.zig
@@ -254,6 +254,8 @@ const reap_name_attempts: u8 = 16;
 /// iteration, same filesystem → no CrossDevice) and probed for a free slot so a
 /// prior stranded leftover cannot block an otherwise-deletable entry.
 fn removeEntry(io: std.Io, prefix: []const u8, db: *sqlite.Database, name: []const u8) bool {
+    // `name` is a dirent, not a caller-supplied key, so it stays hand-formatted:
+    // this sweep is what reaps an entry whose row `store.remove` now rejects.
     var entry_buf: [768]u8 = undefined;
     const entry_path = std.fmt.bufPrint(&entry_buf, "{s}/store/{s}", .{ prefix, name }) catch return false;
 

--- a/src/cli/migrate/keg.zig
+++ b/src/cli/migrate/keg.zig
@@ -1038,8 +1038,8 @@ test "incrementRef under db_mu keeps each worker's keg_id bound to its own kegs 
             var i: usize = 0;
             while (i < 2_000_000 and !c.done.load(.acquire)) : (i += 1) {
                 const n = c.ref_seq.fetchAdd(1, .monotonic);
-                var sha_buf: [32]u8 = undefined;
-                const sha = std.fmt.bufPrint(&sha_buf, "ref-{d}", .{n}) catch unreachable;
+                var sha_buf: [64]u8 = undefined;
+                const sha = std.fmt.bufPrint(&sha_buf, "{x:0>64}", .{n}) catch unreachable;
                 incrementRefLocked(c.io, c.store, c.db_mu, sha, "race");
             }
         }
@@ -1065,11 +1065,12 @@ test "incrementRefLocked on the serial path (db_mu null) still bumps the refcoun
 
     var store = store_mod.Store.init(io, std.testing.allocator, &db, "");
     // Serial callers pass db_mu == null: no lock, no deadlock, ref still lands.
-    incrementRefLocked(io, &store, null, "deadbeef", "solo");
+    const sha = "deadbeef" ** 8;
+    incrementRefLocked(io, &store, null, sha, "solo");
 
     var stmt = try db.prepare("SELECT refcount FROM store_refs WHERE store_sha256 = ?1;");
     defer stmt.finalize();
-    try stmt.bindText(1, "deadbeef");
+    try stmt.bindText(1, sha);
     try std.testing.expect(try stmt.step());
     try std.testing.expectEqual(@as(i64, 1), stmt.columnInt(0));
 }

--- a/src/cli/purge/scopes.zig
+++ b/src/cli/purge/scopes.zig
@@ -17,6 +17,7 @@ const formula_mod = @import("../../core/formula.zig");
 const cask_mod = @import("../../core/cask.zig");
 const relocated_store = @import("../../core/relocated_store.zig");
 const symlink = @import("../../fs/symlink.zig");
+const store_path = @import("../../fs/store_path.zig");
 const util = @import("util.zig");
 const report = @import("report.zig");
 
@@ -73,9 +74,11 @@ pub fn runStoreOrphans(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix:
     // Stat the entry before remove() so we can credit freed bytes — the
     // path disappears as soon as `store.remove` returns.
     for (orphans_list.items) |sha| {
-        var path_buf: [512]u8 = undefined;
-        const store_path = std.fmt.bufPrint(&path_buf, "{s}/store/{s}", .{ prefix, sha }) catch continue;
-        const sz = util.pathSize(io, allocator, store_path);
+        var path_buf: [store_path.entry_buf_len]u8 = undefined;
+        // A row whose key is not a store key is skipped, not fatal: the run
+        // still reaps its neighbours, and doctor --fix sweeps the disk side.
+        const entry_path = store_path.entry(&path_buf, prefix, sha) catch continue;
+        const sz = util.pathSize(io, allocator, entry_path);
 
         rep.item(sha);
         if (!dry_run) {

--- a/src/core/store.zig
+++ b/src/core/store.zig
@@ -1,10 +1,11 @@
 const std = @import("std");
 const sqlite = @import("../db/sqlite.zig");
 const atomic = @import("../fs/atomic.zig");
+const store_path = @import("../fs/store_path.zig");
 const testing = std.testing;
 const schema = @import("../db/schema.zig");
 
-pub const StoreError = error{ CommitFailed, RemoveFailed, NotFound, OutOfMemory, RefCountError };
+pub const StoreError = error{ CommitFailed, RemoveFailed, NotFound, OutOfMemory, RefCountError, InvalidSha256, PathTooLong };
 
 pub const Store = struct {
     allocator: std.mem.Allocator,
@@ -34,10 +35,10 @@ pub const Store = struct {
         // src_buf must outlive any subsequent stack-buf write below — if a
         // future optimizer overlays it with dst_buf, the rename target
         // could be clobbered.
-        var src_buf: [512]u8 = undefined;
-        var dst_buf: [512]u8 = undefined;
-        const src = src_path orelse std.fmt.bufPrint(&src_buf, "{s}/tmp/{s}", .{ self.prefix, sha256 }) catch return StoreError.OutOfMemory;
-        const dst = std.fmt.bufPrint(&dst_buf, "{s}/store/{s}", .{ self.prefix, sha256 }) catch return StoreError.OutOfMemory;
+        var src_buf: [store_path.entry_buf_len]u8 = undefined;
+        var dst_buf: [store_path.entry_buf_len]u8 = undefined;
+        const src = src_path orelse try store_path.tmpEntry(&src_buf, self.prefix, sha256);
+        const dst = try store_path.entry(&dst_buf, self.prefix, sha256);
 
         // Check if already committed (idempotent)
         std.Io.Dir.cwd().access(self.io, dst, .{}) catch {
@@ -48,15 +49,20 @@ pub const Store = struct {
         // Already exists — idempotent success
     }
 
+    /// A probe, not a validator: a key that cannot form a path is simply not
+    /// in the store, so the caller downloads instead of failing here. The
+    /// terminal methods below are where a bad key must be loud.
     pub fn exists(self: *Store, sha256: []const u8) bool {
-        var buf: [512]u8 = undefined;
-        const p = std.fmt.bufPrint(&buf, "{s}/store/{s}", .{ self.prefix, sha256 }) catch return false;
+        var buf: [store_path.entry_buf_len]u8 = undefined;
+        const p = store_path.entry(&buf, self.prefix, sha256) catch return false;
         std.Io.Dir.cwd().access(self.io, p, .{}) catch return false;
         return true;
     }
 
     pub fn path(self: *Store, sha256: []const u8) StoreError![]const u8 {
-        return std.fmt.allocPrint(self.allocator, "{s}/store/{s}", .{ self.prefix, sha256 }) catch return StoreError.OutOfMemory;
+        var buf: [store_path.entry_buf_len]u8 = undefined;
+        const p = try store_path.entry(&buf, self.prefix, sha256);
+        return self.allocator.dupe(u8, p) catch return StoreError.OutOfMemory;
     }
 
     /// Removes both the on-disk path AND the store_refs row.  Without the
@@ -69,8 +75,10 @@ pub const Store = struct {
         self.mutex.lockUncancelable(self.io);
         defer self.mutex.unlock(self.io);
 
-        var buf: [512]u8 = undefined;
-        const p = std.fmt.bufPrint(&buf, "{s}/store/{s}", .{ self.prefix, sha256 }) catch return StoreError.OutOfMemory;
+        // Built before the transaction opens so a bad key can never reach
+        // deleteTree or leave a transaction behind.
+        var buf: [store_path.entry_buf_len]u8 = undefined;
+        const p = try store_path.entry(&buf, self.prefix, sha256);
 
         self.db.beginTransaction() catch return StoreError.RefCountError;
         errdefer self.db.rollback();

--- a/src/core/store.zig
+++ b/src/core/store.zig
@@ -20,13 +20,6 @@ pub const Store = struct {
         return .{ .allocator = allocator, .io = io, .db = db, .prefix = prefix, .mutex = .init };
     }
 
-    /// Atomic rename from tmp/{sha256} to store/{sha256}. Idempotent.
-    /// Atomic rename from a source path to store/{sha256}. Idempotent.
-    /// If src_path is null, defaults to {prefix}/tmp/{sha256}.
-    pub fn commit(self: *Store, sha256: []const u8) StoreError!void {
-        return self.commitFrom(sha256, null);
-    }
-
     /// Atomic rename from a specific source path to store/{sha256}. Idempotent.
     /// Thread-safe: serialized by internal mutex.
     pub fn commitFrom(self: *Store, sha256: []const u8, src_path: ?[]const u8) StoreError!void {
@@ -57,12 +50,6 @@ pub const Store = struct {
         const p = store_path.entry(&buf, self.prefix, sha256) catch return false;
         std.Io.Dir.cwd().access(self.io, p, .{}) catch return false;
         return true;
-    }
-
-    pub fn path(self: *Store, sha256: []const u8) StoreError![]const u8 {
-        var buf: [store_path.entry_buf_len]u8 = undefined;
-        const p = try store_path.entry(&buf, self.prefix, sha256);
-        return self.allocator.dupe(u8, p) catch return StoreError.OutOfMemory;
     }
 
     /// Removes both the on-disk path AND the store_refs row.  Without the

--- a/src/core/store.zig
+++ b/src/core/store.zig
@@ -93,7 +93,14 @@ pub const Store = struct {
         self.db.commit() catch return StoreError.RefCountError;
     }
 
+    /// The sole ingress for a store key. A row whose key names no
+    /// constructible store path is one `remove` could never reap, so it is
+    /// refused at birth rather than stranded. `decrementRef` stays permissive
+    /// on purpose: rejecting there would strand a legacy row, not protect it.
     pub fn incrementRef(self: *Store, sha256: []const u8) StoreError!void {
+        var buf: [store_path.entry_buf_len]u8 = undefined;
+        _ = try store_path.entry(&buf, self.prefix, sha256);
+
         self.mutex.lockUncancelable(self.io);
         defer self.mutex.unlock(self.io);
         var stmt = self.db.prepare(

--- a/src/fs/store_path.zig
+++ b/src/fs/store_path.zig
@@ -1,0 +1,96 @@
+//! One definition of the content-addressable store's on-disk layout.
+//! Construction validates the key, so a traversal sequence, a case variant
+//! or an empty string cannot reach the filesystem through a caller that
+//! forgot to check first.
+
+const std = @import("std");
+const prefix_path = @import("prefix_path.zig");
+
+pub const Error = error{ InvalidSha256, PathTooLong };
+
+/// A validated prefix plus the longest shape this module formats
+/// (`/store/` + 64 hex). The one buffer size every call site reserves.
+pub const entry_buf_len: usize = prefix_path.max_prefix_len + "/store/".len + 64;
+
+fn isValidSha256(sha: []const u8) bool {
+    if (sha.len != 64) return false;
+    for (sha) |ch| {
+        const ok = (ch >= '0' and ch <= '9') or (ch >= 'a' and ch <= 'f');
+        if (!ok) return false;
+    }
+    return true;
+}
+
+/// `{prefix}/store/{sha}` - the committed entry.
+pub fn entry(buf: []u8, prefix: []const u8, sha: []const u8) Error![]u8 {
+    if (!isValidSha256(sha)) return Error.InvalidSha256;
+    return std.fmt.bufPrint(buf, "{s}/store/{s}", .{ prefix, sha }) catch Error.PathTooLong;
+}
+
+/// `{prefix}/tmp/{sha}` - the staging path a commit renames from.
+pub fn tmpEntry(buf: []u8, prefix: []const u8, sha: []const u8) Error![]u8 {
+    if (!isValidSha256(sha)) return Error.InvalidSha256;
+    return std.fmt.bufPrint(buf, "{s}/tmp/{s}", .{ prefix, sha }) catch Error.PathTooLong;
+}
+
+const valid_sha = "a" ** 64;
+
+test "formats both shapes for a valid key" {
+    var buf: [entry_buf_len]u8 = undefined;
+    try std.testing.expectEqualStrings(
+        "/opt/malt/store/" ++ valid_sha,
+        try entry(&buf, "/opt/malt", valid_sha),
+    );
+    try std.testing.expectEqualStrings(
+        "/opt/malt/tmp/" ++ valid_sha,
+        try tmpEntry(&buf, "/opt/malt", valid_sha),
+    );
+}
+
+test "rejects a key of the wrong length" {
+    var buf: [entry_buf_len]u8 = undefined;
+    try std.testing.expectError(Error.InvalidSha256, entry(&buf, "/opt/malt", "a" ** 63));
+    try std.testing.expectError(Error.InvalidSha256, entry(&buf, "/opt/malt", "a" ** 65));
+    try std.testing.expectError(Error.InvalidSha256, tmpEntry(&buf, "/opt/malt", "a" ** 63));
+}
+
+test "rejects the empty key instead of yielding the store root" {
+    var buf: [entry_buf_len]u8 = undefined;
+    try std.testing.expectError(Error.InvalidSha256, entry(&buf, "/opt/malt", ""));
+    try std.testing.expectError(Error.InvalidSha256, tmpEntry(&buf, "/opt/malt", ""));
+}
+
+test "rejects out-of-charset keys, traversal included" {
+    var buf: [entry_buf_len]u8 = undefined;
+    const bad = [_][]const u8{
+        "../../../etc/passwd" ++ "a" ** 45, // 64 chars, still hops out
+        "/" ++ "a" ** 63,
+        "." ++ "a" ** 63,
+        "z" ++ "a" ** 63,
+        "A" ** 64,
+        "a" ** 63 ++ "\x00",
+    };
+    for (bad) |sha| {
+        try std.testing.expectError(Error.InvalidSha256, entry(&buf, "/opt/malt", sha));
+        try std.testing.expectError(Error.InvalidSha256, tmpEntry(&buf, "/opt/malt", sha));
+    }
+}
+
+test "overflow is PathTooLong, not an allocation failure" {
+    const formatted = "/opt/malt/store/".len + 64;
+    var buf: [formatted - 1]u8 = undefined;
+    try std.testing.expectError(Error.PathTooLong, entry(&buf, "/opt/malt", valid_sha));
+}
+
+test "tmpEntry overflows into PathTooLong too" {
+    const formatted = "/opt/malt/tmp/".len + 64;
+    var buf: [formatted - 1]u8 = undefined;
+    try std.testing.expectError(Error.PathTooLong, tmpEntry(&buf, "/opt/malt", valid_sha));
+}
+
+test "entry_buf_len holds the longest prefix the tree accepts" {
+    var buf: [entry_buf_len]u8 = undefined;
+    const prefix = "/" ++ "p" ** (prefix_path.max_prefix_len - 1);
+    const p = try entry(&buf, prefix, valid_sha);
+    try std.testing.expectEqual(entry_buf_len, p.len);
+}

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -87,6 +87,7 @@ pub const clonefile = @import("fs/clonefile.zig");
 pub const dirsize = @import("fs/dirsize.zig");
 pub const path_write = @import("fs/path_write.zig");
 pub const prefix_path = @import("fs/prefix_path.zig");
+pub const store_path = @import("fs/store_path.zig");
 pub const read = @import("fs/read.zig");
 pub const theme_file = @import("fs/theme_file.zig");
 pub const codesign = @import("macho/codesign.zig");

--- a/tests/install_keg_from_bottle_test.zig
+++ b/tests/install_keg_from_bottle_test.zig
@@ -87,7 +87,7 @@ test "installKegFromBottle skips the download branch when the store already hold
     // expects clonefile-copied into Cellar. The bottle declares
     // `cellar = ":any"` so the Mach-O patcher + codesign step both skip,
     // letting a plain text file through without faking a real binary.
-    const sha = "warm" ** 16; // 64 chars
+    const sha = "ba5e" ** 16; // 64 hex chars
     const inner_dir = try std.fmt.allocPrint(testing.allocator, "{s}/store/{s}/warmpkg/1.0", .{ prefix, sha });
     defer testing.allocator.free(inner_dir);
     try test_io.cwd().createDirPath(std.Options.debug_io, inner_dir);

--- a/tests/purge_scopes_test.zig
+++ b/tests/purge_scopes_test.zig
@@ -343,6 +343,60 @@ test "--store-orphans --dry-run iterates store entries with refcount=0" {
     try purge.execute(&ctx, allocator, &.{"--store-orphans"});
 }
 
+test "--store-orphans skips a store_refs row whose key is not a store key" {
+    const allocator = testing.allocator;
+    var prefix = try ScratchPrefix.init(allocator, "store_orphans_bad_key");
+    defer prefix.deinit(allocator);
+
+    const good = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+    const legacy = "../../../etc";
+
+    {
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix.path}, 0);
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        try schema.initSchema(&db);
+
+        for ([_][]const u8{ good, legacy }) |key| {
+            var stmt = try db.prepare("INSERT INTO store_refs (store_sha256, refcount) VALUES (?1, 0);");
+            defer stmt.finalize();
+            try stmt.bindText(1, key);
+            _ = try stmt.step();
+        }
+    }
+    try writeFileAt(allocator, &.{ prefix.path, "store", good, "marker" }, "x");
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setMode(.json);
+    output.setDryRun(true);
+    output.setNdjson(false);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(allocator);
+    output.beginStdoutCapture(allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    const ctx = malt.app_ctx.debug_ctx;
+    try purge.execute(&ctx, allocator, &.{"--store-orphans"});
+
+    const parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        allocator,
+        std.mem.trim(u8, stdout_buf.items, " \r\n\t"),
+        .{},
+    );
+    defer parsed.deinit();
+
+    // The run completes and reaps the real orphan; the legacy row is skipped,
+    // not counted and not aborting the pass.
+    const scope = parsed.value.object.get("scopes").?.array.items[0].object;
+    try testing.expectEqualStrings("store-orphans", scope.get("name").?.string);
+    try testing.expectEqualStrings("ok", scope.get("status").?.string);
+    try testing.expectEqual(@as(i64, 1), scope.get("removed").?.integer);
+}
+
 // --- --unused-deps ------------------------------------------------------
 
 test "--unused-deps --dry-run iterates kegs whose install_reason is dep" {

--- a/tests/store_test.zig
+++ b/tests/store_test.zig
@@ -9,6 +9,16 @@ const sqlite = @import("malt").sqlite;
 const schema = @import("malt").schema;
 const store_mod = @import("malt").store;
 
+// One distinct 64-hex key per fixture: collapsing them onto a shared constant
+// would quietly void the idempotent-commit and refcount assertions below.
+const sha_missing = "1" ** 64;
+const sha_commit_src = "2" ** 64;
+const sha_default_src = "3" ** 64;
+const sha_missing_src = "4" ** 64;
+const sha_dup = "5" ** 64;
+const sha_orphan = "6" ** 64;
+const sha_txn = "7" ** 64;
+
 fn setupTestStore(allocator: std.mem.Allocator) !struct { db: sqlite.Database, store: store_mod.Store, prefix: []const u8 } {
     // Create temp directory as prefix
     const prefix = try std.fmt.allocPrint(allocator, "/tmp/malt_test_{x}", .{test_io.randomInt(std.Options.debug_io, u64)});
@@ -35,7 +45,7 @@ test "exists returns false for missing entry" {
         testing.allocator.free(ctx.prefix);
     }
 
-    try testing.expect(!ctx.store.exists("nonexistent_sha256"));
+    try testing.expect(!ctx.store.exists(sha_missing));
 }
 
 test "commit moves directory to store and exists returns true" {
@@ -57,8 +67,8 @@ test "commit moves directory to store and exists returns true" {
     try f.writeStreamingAll(std.Options.debug_io, "hello");
     f.close(std.Options.debug_io);
 
-    try ctx.store.commitFrom("abc123sha", src);
-    try testing.expect(ctx.store.exists("abc123sha"));
+    try ctx.store.commitFrom(sha_commit_src, src);
+    try testing.expect(ctx.store.exists(sha_commit_src));
 }
 
 test "commitFrom with null src renames from {prefix}/tmp/{sha}" {
@@ -69,7 +79,7 @@ test "commitFrom with null src renames from {prefix}/tmp/{sha}" {
         testing.allocator.free(ctx.prefix);
     }
 
-    const sha = "default_src_sha";
+    const sha = sha_default_src;
 
     const tmp_dir = try std.fmt.allocPrint(testing.allocator, "{s}/tmp", .{ctx.prefix});
     defer testing.allocator.free(tmp_dir);
@@ -107,7 +117,7 @@ test "commitFrom with null src returns CommitFailed when default tmp path is mis
     // atomicRename surfaces the missing source as CommitFailed.
     try testing.expectError(
         store_mod.StoreError.CommitFailed,
-        ctx.store.commitFrom("missing_default_src_sha", null),
+        ctx.store.commitFrom(sha_missing_src, null),
     );
 }
 
@@ -124,10 +134,10 @@ test "duplicate commit is idempotent" {
     defer testing.allocator.free(src);
     test_io.makeDirAbsolute(std.Options.debug_io, src) catch {};
 
-    try ctx.store.commitFrom("dup_sha", src);
+    try ctx.store.commitFrom(sha_dup, src);
     // Second commit should succeed (idempotent)
-    try ctx.store.commitFrom("dup_sha", null);
-    try testing.expect(ctx.store.exists("dup_sha"));
+    try ctx.store.commitFrom(sha_dup, null);
+    try testing.expect(ctx.store.exists(sha_dup));
 }
 
 test "remove also drops the store_refs row so the orphan does not return" {
@@ -139,8 +149,8 @@ test "remove also drops the store_refs row so the orphan does not return" {
     }
     ctx.store.db = &ctx.db;
 
-    try ctx.store.incrementRef("orphan_sha");
-    try ctx.store.decrementRef("orphan_sha"); // refcount → 0
+    try ctx.store.incrementRef(sha_orphan);
+    try ctx.store.decrementRef(sha_orphan); // refcount → 0
 
     // Pre-condition: enumerate sees the orphan.
     {
@@ -154,7 +164,7 @@ test "remove also drops the store_refs row so the orphan does not return" {
 
     // remove() with no on-disk path must still clear the DB row — otherwise
     // the same row keeps reappearing on every purge run.
-    try ctx.store.remove("orphan_sha");
+    try ctx.store.remove(sha_orphan);
 
     var orphans = try ctx.store.orphans();
     defer {
@@ -173,7 +183,7 @@ test "remove drops FS path and store_refs row in one transactional pass" {
     }
     ctx.store.db = &ctx.db;
 
-    const sha = "txn_sha";
+    const sha = sha_txn;
     const dir = try std.fmt.allocPrint(testing.allocator, "{s}/store/{s}", .{ ctx.prefix, sha });
     defer testing.allocator.free(dir);
     test_io.makeDirAbsolute(std.Options.debug_io, dir) catch {};
@@ -222,4 +232,107 @@ test "incrementRef and decrementRef update refcount" {
     for (orphans.items) |o| {
         try testing.expect(!std.mem.eql(u8, o, "ref_test"));
     }
+}
+
+// ── Key validation ─────────────────────────────────────────────────────────
+
+test "exists probes false for a key it cannot form a path from" {
+    var ctx = try setupTestStore(testing.allocator);
+    defer {
+        ctx.db.close();
+        test_io.deleteTreeAbsolute(std.Options.debug_io, ctx.prefix) catch {};
+        testing.allocator.free(ctx.prefix);
+    }
+
+    // "" used to probe the store root itself and answer "already warm".
+    try testing.expect(!ctx.store.exists(""));
+    try testing.expect(!ctx.store.exists("../.."));
+    try testing.expect(!ctx.store.exists("A" ** 64));
+}
+
+test "terminal methods reject a malformed key loudly" {
+    var ctx = try setupTestStore(testing.allocator);
+    defer {
+        ctx.db.close();
+        test_io.deleteTreeAbsolute(std.Options.debug_io, ctx.prefix) catch {};
+        testing.allocator.free(ctx.prefix);
+    }
+    ctx.store.db = &ctx.db;
+
+    try testing.expectError(store_mod.StoreError.InvalidSha256, ctx.store.commitFrom("", null));
+    try testing.expectError(store_mod.StoreError.InvalidSha256, ctx.store.commitFrom("A" ** 64, null));
+    try testing.expectError(store_mod.StoreError.InvalidSha256, ctx.store.remove("not-hex"));
+    try testing.expectError(store_mod.StoreError.InvalidSha256, ctx.store.remove("A" ** 64));
+    try testing.expectError(store_mod.StoreError.InvalidSha256, ctx.store.path("../etc"));
+}
+
+test "an explicit source path does not buy a caller past the key check" {
+    var ctx = try setupTestStore(testing.allocator);
+    defer {
+        ctx.db.close();
+        test_io.deleteTreeAbsolute(std.Options.debug_io, ctx.prefix) catch {};
+        testing.allocator.free(ctx.prefix);
+    }
+
+    // Supplying src_path skips the tmp-path formation, which is the one way
+    // the destination check could plausibly be bypassed.
+    const src = try std.fmt.allocPrint(testing.allocator, "{s}/tmp/donor", .{ctx.prefix});
+    defer testing.allocator.free(src);
+    try test_io.cwd().createDirPath(std.Options.debug_io, src);
+
+    try testing.expectError(store_mod.StoreError.InvalidSha256, ctx.store.commitFrom("", src));
+    try testing.expectError(store_mod.StoreError.InvalidSha256, ctx.store.commitFrom("../evil", src));
+
+    // The donor is still where it was: nothing was renamed.
+    try test_io.accessAbsolute(std.Options.debug_io, src, .{});
+}
+
+test "path returns the store entry for a valid key" {
+    var ctx = try setupTestStore(testing.allocator);
+    defer {
+        ctx.db.close();
+        test_io.deleteTreeAbsolute(std.Options.debug_io, ctx.prefix) catch {};
+        testing.allocator.free(ctx.prefix);
+    }
+
+    const p = try ctx.store.path(sha_txn);
+    defer testing.allocator.free(p);
+
+    const want = try std.fmt.allocPrint(testing.allocator, "{s}/store/{s}", .{ ctx.prefix, sha_txn });
+    defer testing.allocator.free(want);
+    try testing.expectEqualStrings(want, p);
+}
+
+test "remove rejects a malformed key before it can delete or transact" {
+    var ctx = try setupTestStore(testing.allocator);
+    defer {
+        ctx.db.close();
+        test_io.deleteTreeAbsolute(std.Options.debug_io, ctx.prefix) catch {};
+        testing.allocator.free(ctx.prefix);
+    }
+    ctx.store.db = &ctx.db;
+
+    // A hand-edited row: refcount 0, key not hex, entry present on disk.
+    const bad = "not-hex";
+    const dir = try std.fmt.allocPrint(testing.allocator, "{s}/store/{s}", .{ ctx.prefix, bad });
+    defer testing.allocator.free(dir);
+    test_io.makeDirAbsolute(std.Options.debug_io, dir) catch {};
+    try ctx.store.incrementRef(bad);
+    try ctx.store.decrementRef(bad);
+
+    try testing.expectError(store_mod.StoreError.InvalidSha256, ctx.store.remove(bad));
+
+    // Neither side effect happened: the tree is intact and the row survives.
+    try test_io.accessAbsolute(std.Options.debug_io, dir, .{});
+
+    var orphans = try ctx.store.orphans();
+    defer {
+        for (orphans.items) |o| testing.allocator.free(o);
+        orphans.deinit(testing.allocator);
+    }
+    try testing.expectEqual(@as(usize, 1), orphans.items.len);
+
+    // No transaction was left open.
+    try ctx.db.beginTransaction();
+    try ctx.db.commit();
 }

--- a/tests/store_test.zig
+++ b/tests/store_test.zig
@@ -18,6 +18,7 @@ const sha_missing_src = "4" ** 64;
 const sha_dup = "5" ** 64;
 const sha_orphan = "6" ** 64;
 const sha_txn = "7" ** 64;
+const sha_ref = "8" ** 64;
 
 fn setupTestStore(allocator: std.mem.Allocator) !struct { db: sqlite.Database, store: store_mod.Store, prefix: []const u8 } {
     // Create temp directory as prefix
@@ -218,9 +219,9 @@ test "incrementRef and decrementRef update refcount" {
     // a freed frame.
     ctx.store.db = &ctx.db;
 
-    try ctx.store.incrementRef("ref_test");
-    try ctx.store.incrementRef("ref_test");
-    try ctx.store.decrementRef("ref_test");
+    try ctx.store.incrementRef(sha_ref);
+    try ctx.store.incrementRef(sha_ref);
+    try ctx.store.decrementRef(sha_ref);
 
     // After 2 increments and 1 decrement, refcount should be 1
     // Verify via orphans — should NOT be an orphan
@@ -230,7 +231,7 @@ test "incrementRef and decrementRef update refcount" {
         orphans.deinit(testing.allocator);
     }
     for (orphans.items) |o| {
-        try testing.expect(!std.mem.eql(u8, o, "ref_test"));
+        try testing.expect(!std.mem.eql(u8, o, sha_ref));
     }
 }
 
@@ -303,6 +304,54 @@ test "path returns the store entry for a valid key" {
     try testing.expectEqualStrings(want, p);
 }
 
+test "incrementRef refuses to create a row a store key could never name" {
+    var ctx = try setupTestStore(testing.allocator);
+    defer {
+        ctx.db.close();
+        test_io.deleteTreeAbsolute(std.Options.debug_io, ctx.prefix) catch {};
+        testing.allocator.free(ctx.prefix);
+    }
+    ctx.store.db = &ctx.db;
+
+    // The sole DB ingress for a store key. A row born here that `remove`
+    // would later refuse is a row nothing can reap.
+    try testing.expectError(store_mod.StoreError.InvalidSha256, ctx.store.incrementRef("not-hex"));
+    try testing.expectError(store_mod.StoreError.InvalidSha256, ctx.store.incrementRef(""));
+    try testing.expectError(store_mod.StoreError.InvalidSha256, ctx.store.incrementRef("A" ** 64));
+
+    var stmt = try ctx.db.prepare("SELECT count(*) FROM store_refs;");
+    defer stmt.finalize();
+    try testing.expect(try stmt.step());
+    try testing.expectEqual(@as(i64, 0), stmt.columnInt(0));
+}
+
+test "decrementRef stays permissive so a legacy row can still be wound down" {
+    var ctx = try setupTestStore(testing.allocator);
+    defer {
+        ctx.db.close();
+        test_io.deleteTreeAbsolute(std.Options.debug_io, ctx.prefix) catch {};
+        testing.allocator.free(ctx.prefix);
+    }
+    ctx.store.db = &ctx.db;
+
+    // Seed the way a legacy or hand-edited row got there, bypassing the guard.
+    {
+        var ins = try ctx.db.prepare("INSERT INTO store_refs (store_sha256, refcount) VALUES ('legacy-row', 1);");
+        defer ins.finalize();
+        _ = try ins.step();
+    }
+
+    // Rejecting here would strand the row instead of protecting anything.
+    try ctx.store.decrementRef("legacy-row");
+
+    var orphans = try ctx.store.orphans();
+    defer {
+        for (orphans.items) |o| testing.allocator.free(o);
+        orphans.deinit(testing.allocator);
+    }
+    try testing.expectEqual(@as(usize, 1), orphans.items.len);
+}
+
 test "remove rejects a malformed key before it can delete or transact" {
     var ctx = try setupTestStore(testing.allocator);
     defer {
@@ -317,8 +366,11 @@ test "remove rejects a malformed key before it can delete or transact" {
     const dir = try std.fmt.allocPrint(testing.allocator, "{s}/store/{s}", .{ ctx.prefix, bad });
     defer testing.allocator.free(dir);
     test_io.makeDirAbsolute(std.Options.debug_io, dir) catch {};
-    try ctx.store.incrementRef(bad);
-    try ctx.store.decrementRef(bad);
+    {
+        var ins = try ctx.db.prepare("INSERT INTO store_refs (store_sha256, refcount) VALUES ('not-hex', 0);");
+        defer ins.finalize();
+        _ = try ins.step();
+    }
 
     try testing.expectError(store_mod.StoreError.InvalidSha256, ctx.store.remove(bad));
 

--- a/tests/store_test.zig
+++ b/tests/store_test.zig
@@ -264,7 +264,6 @@ test "terminal methods reject a malformed key loudly" {
     try testing.expectError(store_mod.StoreError.InvalidSha256, ctx.store.commitFrom("A" ** 64, null));
     try testing.expectError(store_mod.StoreError.InvalidSha256, ctx.store.remove("not-hex"));
     try testing.expectError(store_mod.StoreError.InvalidSha256, ctx.store.remove("A" ** 64));
-    try testing.expectError(store_mod.StoreError.InvalidSha256, ctx.store.path("../etc"));
 }
 
 test "an explicit source path does not buy a caller past the key check" {
@@ -286,22 +285,6 @@ test "an explicit source path does not buy a caller past the key check" {
 
     // The donor is still where it was: nothing was renamed.
     try test_io.accessAbsolute(std.Options.debug_io, src, .{});
-}
-
-test "path returns the store entry for a valid key" {
-    var ctx = try setupTestStore(testing.allocator);
-    defer {
-        ctx.db.close();
-        test_io.deleteTreeAbsolute(std.Options.debug_io, ctx.prefix) catch {};
-        testing.allocator.free(ctx.prefix);
-    }
-
-    const p = try ctx.store.path(sha_txn);
-    defer testing.allocator.free(p);
-
-    const want = try std.fmt.allocPrint(testing.allocator, "{s}/store/{s}", .{ ctx.prefix, sha_txn });
-    defer testing.allocator.free(want);
-    try testing.expectEqualStrings(want, p);
 }
 
 test "incrementRef refuses to create a row a store key could never name" {


### PR DESCRIPTION
## Description

A store key is 64 lowercase hex, but that rule lived in caller discipline rather than in code. An empty key resolved to the store root itself, so a warm-store probe answered "already there", and a hand-edited database row could point `remove`'s tree delete outside the store.

Path construction now owns the rule: a new std-only `fs/store_path.zig` leaf builds the store's two on-disk shapes and validates the key before it can produce either, so no order of calls yields an unchecked path. `Store` and the purge scope build their paths there, and `incrementRef` - the one door a key could enter the refcount table through - screens the same way, so no row is created that `remove` would later refuse to reap. Overflow is also reported as a path-length failure instead of an allocation one, and the buffer for this shape is finally large enough at the prefix bound.

## Related Issue

- None

## Notes for Reviewers

- `exists` stays a probe and answers false for a key it cannot form a path from; the terminal methods reject before touching disk or opening a transaction.
- An uppercase sha used to be a silent cache miss and is now a loud error. Intentional - the upstream API emits lowercase.
- `decrementRef` stays unvalidated on purpose: it is the way out, and rejecting there would strand a legacy row instead of protecting anything.
