### PR TITLE
refactor(fs): keep the prefix rule in the module that owns the bound

### DIFF
--- a/src/core/ruby_subprocess.zig
+++ b/src/core/ruby_subprocess.zig
@@ -9,8 +9,8 @@
 
 const std = @import("std");
 const sandbox = @import("sandbox/macos.zig");
-const fs_atomic = @import("../fs/atomic.zig");
 const prefix_path = @import("../fs/prefix_path.zig");
+const path_component = @import("../fs/path_component.zig");
 const detect = @import("ruby/detect.zig");
 const source = @import("ruby/source.zig");
 
@@ -132,8 +132,8 @@ pub fn generateWrapper(
 ) ![]const u8 {
     if (prefix.len == 0 or name.len == 0 or version.len == 0) return error.InvalidInput;
     for (prefix) |b| if (!prefix_path.isAllowedPrefixByte(b)) return error.InvalidInput;
-    for (name) |b| if (!fs_atomic.isAllowedNameByte(b)) return error.InvalidInput;
-    for (version) |b| if (!fs_atomic.isAllowedNameByte(b)) return error.InvalidInput;
+    for (name) |b| if (!path_component.isAllowedNameByte(b)) return error.InvalidInput;
+    for (version) |b| if (!path_component.isAllowedNameByte(b)) return error.InvalidInput;
 
     var aw: std.Io.Writer.Allocating = .init(allocator);
     errdefer aw.deinit();
@@ -276,8 +276,8 @@ pub fn runPostInstall(
 fn validateRunPostInstallInputs(name: []const u8, version: []const u8, prefix: []const u8) RubyError!void {
     if (prefix.len == 0 or name.len == 0 or version.len == 0) return RubyError.InvalidInput;
     for (prefix) |b| if (!prefix_path.isAllowedPrefixByte(b)) return RubyError.InvalidInput;
-    for (name) |b| if (!fs_atomic.isAllowedNameByte(b)) return RubyError.InvalidInput;
-    for (version) |b| if (!fs_atomic.isAllowedNameByte(b)) return RubyError.InvalidInput;
+    for (name) |b| if (!path_component.isAllowedNameByte(b)) return RubyError.InvalidInput;
+    for (version) |b| if (!path_component.isAllowedNameByte(b)) return RubyError.InvalidInput;
 }
 
 /// Tap-aware variant: caller has already extracted the post_install

--- a/src/core/ruby_subprocess.zig
+++ b/src/core/ruby_subprocess.zig
@@ -10,6 +10,7 @@
 const std = @import("std");
 const sandbox = @import("sandbox/macos.zig");
 const fs_atomic = @import("../fs/atomic.zig");
+const prefix_path = @import("../fs/prefix_path.zig");
 const detect = @import("ruby/detect.zig");
 const source = @import("ruby/source.zig");
 
@@ -130,7 +131,7 @@ pub fn generateWrapper(
     post_install_body: []const u8,
 ) ![]const u8 {
     if (prefix.len == 0 or name.len == 0 or version.len == 0) return error.InvalidInput;
-    for (prefix) |b| if (!fs_atomic.isAllowedPrefixByte(b)) return error.InvalidInput;
+    for (prefix) |b| if (!prefix_path.isAllowedPrefixByte(b)) return error.InvalidInput;
     for (name) |b| if (!fs_atomic.isAllowedNameByte(b)) return error.InvalidInput;
     for (version) |b| if (!fs_atomic.isAllowedNameByte(b)) return error.InvalidInput;
 
@@ -274,7 +275,7 @@ pub fn runPostInstall(
 
 fn validateRunPostInstallInputs(name: []const u8, version: []const u8, prefix: []const u8) RubyError!void {
     if (prefix.len == 0 or name.len == 0 or version.len == 0) return RubyError.InvalidInput;
-    for (prefix) |b| if (!fs_atomic.isAllowedPrefixByte(b)) return RubyError.InvalidInput;
+    for (prefix) |b| if (!prefix_path.isAllowedPrefixByte(b)) return RubyError.InvalidInput;
     for (name) |b| if (!fs_atomic.isAllowedNameByte(b)) return RubyError.InvalidInput;
     for (version) |b| if (!fs_atomic.isAllowedNameByte(b)) return RubyError.InvalidInput;
 }

--- a/src/fs/atomic.zig
+++ b/src/fs/atomic.zig
@@ -2,77 +2,18 @@ const std = @import("std");
 const clonefile = @import("clonefile.zig");
 const prefix_path = @import("prefix_path.zig");
 
-/// Re-exported from `fs/prefix_path.zig`, which owns the bound alongside the
-/// path-join buffer size so the two stay in lockstep.
+/// Re-exported from `fs/prefix_path.zig`, which owns the prefix bound, its
+/// charset and its validator alongside the path-join buffer size.
 pub const max_prefix_len = prefix_path.max_prefix_len;
 
-pub const PrefixError = error{
-    Empty,
-    NotAbsolute,
-    DotDotComponent,
-    EmbeddedNul,
-    TooLong,
-    EmptyComponent,
-    DisallowedByte,
-};
-
-/// Single source of truth for the prefix charset. Matches
-/// `validatePathForProfile` in `core/sandbox/macos.zig` so anything that
-/// passes here is safe to interpolate into a Ruby single-quoted literal,
-/// a sandbox-profile path string, or a shell argv.
-pub fn isAllowedPrefixByte(b: u8) bool {
-    return switch (b) {
-        'a'...'z', 'A'...'Z', '0'...'9', '.', '_', '+', '-', '/' => true,
-        else => false,
-    };
-}
-
-/// Charset for a formula `name` or `version`. Same alphabet as the prefix
+/// Charset for a formula `name` or `version`. Same alphabet as
+/// `prefix_path.isAllowedPrefixByte`
 /// minus `/` (a name with `/` would pierce a `{prefix}/Cellar/{name}/...`
 /// path) plus `@` (versioned formulae like `llvm@21`, `python@3.12`).
 pub fn isAllowedNameByte(b: u8) bool {
     return switch (b) {
         'a'...'z', 'A'...'Z', '0'...'9', '.', '_', '+', '-', '@' => true,
         else => false,
-    };
-}
-
-/// Validate a candidate install prefix. Called at the env boundary so
-/// downstream code can assume absolute, NUL-free, traversal-free.
-pub fn validatePrefix(prefix: []const u8) PrefixError!void {
-    if (prefix.len == 0) return PrefixError.Empty;
-    if (prefix.len > max_prefix_len) return PrefixError.TooLong;
-    if (prefix[0] != '/') return PrefixError.NotAbsolute;
-    if (std.mem.indexOfScalar(u8, prefix, 0) != null) return PrefixError.EmbeddedNul;
-    // Tight charset closes the BUG-007/BUG-019 injection class — quotes,
-    // backslashes, control bytes, parens etc. flow into single-quoted
-    // Ruby literals and sandbox-profile strings unchanged.
-    for (prefix) |b| if (!isAllowedPrefixByte(b)) return PrefixError.DisallowedByte;
-
-    // Strip one trailing slash; `/opt/malt/` is fine, `//` inside is not.
-    const trimmed = if (prefix.len > 1 and prefix[prefix.len - 1] == '/')
-        prefix[0 .. prefix.len - 1]
-    else
-        prefix;
-    if (trimmed.len == 1) return; // just "/" — no components to scan
-
-    var it = std.mem.splitScalar(u8, trimmed, '/');
-    _ = it.next(); // leading "/" yields an empty first slice
-    while (it.next()) |comp| {
-        if (comp.len == 0) return PrefixError.EmptyComponent;
-        if (std.mem.eql(u8, comp, "..")) return PrefixError.DotDotComponent;
-    }
-}
-
-pub fn describePrefixError(e: PrefixError) []const u8 {
-    return switch (e) {
-        PrefixError.Empty => "empty",
-        PrefixError.NotAbsolute => "not an absolute path",
-        PrefixError.DotDotComponent => "contains '..' component",
-        PrefixError.EmbeddedNul => "contains NUL byte",
-        PrefixError.TooLong => "exceeds 512 bytes",
-        PrefixError.EmptyComponent => "contains empty path component ('//')",
-        PrefixError.DisallowedByte => "contains a byte outside [a-zA-Z0-9._+-/]",
     };
 }
 
@@ -89,9 +30,9 @@ fn getenvLocal(name: []const u8) ?[:0]const u8 {
 
 /// Validated form of `maltPrefixOrAbort`, returns an error on bad env so tests
 /// can inspect the failure without the process exiting.
-pub fn maltPrefixChecked() PrefixError![:0]const u8 {
+pub fn maltPrefixChecked() prefix_path.PrefixError![:0]const u8 {
     const raw = getenvLocal("MALT_PREFIX") orelse return "/opt/malt";
-    try validatePrefix(raw);
+    try prefix_path.validatePrefix(raw);
     return raw;
 }
 
@@ -107,7 +48,7 @@ pub fn maltPrefixOrAbort() [:0]const u8 {
         const msg = std.fmt.bufPrint(
             &buf,
             "malt: refusing to use MALT_PREFIX='{s}': {s}\n",
-            .{ raw, describePrefixError(e) },
+            .{ raw, prefix_path.describePrefixError(e) },
         ) catch "malt: MALT_PREFIX rejected; refusing to proceed\n";
         _ = std.c.write(std.c.STDERR_FILENO, msg.ptr, msg.len);
         std.process.exit(78); // EX_CONFIG

--- a/src/fs/atomic.zig
+++ b/src/fs/atomic.zig
@@ -6,17 +6,6 @@ const prefix_path = @import("prefix_path.zig");
 /// charset and its validator alongside the path-join buffer size.
 pub const max_prefix_len = prefix_path.max_prefix_len;
 
-/// Charset for a formula `name` or `version`. Same alphabet as
-/// `prefix_path.isAllowedPrefixByte`
-/// minus `/` (a name with `/` would pierce a `{prefix}/Cellar/{name}/...`
-/// path) plus `@` (versioned formulae like `llvm@21`, `python@3.12`).
-pub fn isAllowedNameByte(b: u8) bool {
-    return switch (b) {
-        'a'...'z', 'A'...'Z', '0'...'9', '.', '_', '+', '-', '@' => true,
-        else => false,
-    };
-}
-
 /// Direct getenv from `std.c.environ`; the prefix/cache helpers are read at
 /// process startup so tying them to the parent block keeps the API
 /// arg-free without re-introducing a `fs/compat` shim dep.

--- a/src/fs/path_component.zig
+++ b/src/fs/path_component.zig
@@ -4,6 +4,17 @@
 
 const std = @import("std");
 
+/// Charset for a formula `name` or `version`. Same alphabet as
+/// `prefix_path.isAllowedPrefixByte` minus `/` (a name with `/` would pierce a
+/// `{prefix}/Cellar/{name}/...` path) plus `@` (versioned formulae like
+/// `llvm@21`, `python@3.12`).
+pub fn isAllowedNameByte(b: u8) bool {
+    return switch (b) {
+        'a'...'z', 'A'...'Z', '0'...'9', '.', '_', '+', '-', '@' => true,
+        else => false,
+    };
+}
+
 /// True when `s` is a usable single path component. Charset-agnostic so real
 /// names/versions (`@`, `+`, `,`, `:`, dots) pass — it bars only what hops out
 /// of a component: empty, `.`, an embedded `..`, a `/`, or a NUL.
@@ -62,4 +73,17 @@ test "isPathComponent rejects component-hopping shapes" {
 test "isPathComponent accepts real names and versions" {
     const ok = [_][]const u8{ "com.malt.redis", "openssl@3", "gtk+", "3.2.1+dfsg", "1.2,340:5", "a b" };
     for (ok) |s| try std.testing.expect(isPathComponent(s));
+}
+
+test "isAllowedNameByte: name/version charset extends prefix with @" {
+    // Cellar dir names embed the formula name + version (e.g. `llvm@21`,
+    // `gcc@13`, `python@3.12`) — `@` must pass for those, but `/` must
+    // not (it would let a hostile name pierce the Cellar path).
+    const allowed = "abcXYZ0123456789._+-@";
+    for (allowed) |b| try std.testing.expect(isAllowedNameByte(b));
+    const denied = "/'\"\\\n\t (){}[]$|;&<>*?#";
+    for (denied) |b| try std.testing.expect(!isAllowedNameByte(b));
+    var b: u8 = 0;
+    while (b < 0x20) : (b += 1) try std.testing.expect(!isAllowedNameByte(b));
+    try std.testing.expect(!isAllowedNameByte(0x7f));
 }

--- a/src/fs/prefix_path.zig
+++ b/src/fs/prefix_path.zig
@@ -1,13 +1,77 @@
+//! What a valid install prefix is, and how to build a path from one.
+//! The bound, the charset, the validator and the path-join primitives live
+//! together so the rule and the number it enforces cannot drift apart.
+
 const std = @import("std");
 
 /// 512 bytes: ~4× real Homebrew prefix length, still small enough that
-/// anything past it is either a bug or overflow bait. Single source of
-/// truth for the prefix bound; `fs/atomic.zig` re-exports it.
+/// anything past it is either a bug or overflow bait. `fs/atomic.zig`
+/// re-exports it for its env boundary.
 pub const max_prefix_len: usize = 512;
 
 /// Longest fixed suffix any caller appends (`/cache/migrate.progress.json`
 /// = 28 B today); 64 leaves ~2× headroom for new fixed suffixes.
 pub const max_path_suffix: usize = 64;
+
+pub const PrefixError = error{
+    Empty,
+    NotAbsolute,
+    DotDotComponent,
+    EmbeddedNul,
+    TooLong,
+    EmptyComponent,
+    DisallowedByte,
+};
+
+/// Single source of truth for the prefix charset. Matches
+/// `validatePathForProfile` in `core/sandbox/macos.zig` so anything that
+/// passes here is safe to interpolate into a Ruby single-quoted literal,
+/// a sandbox-profile path string, or a shell argv.
+pub fn isAllowedPrefixByte(b: u8) bool {
+    return switch (b) {
+        'a'...'z', 'A'...'Z', '0'...'9', '.', '_', '+', '-', '/' => true,
+        else => false,
+    };
+}
+
+/// Validate a candidate install prefix. Called at the env boundary so
+/// downstream code can assume absolute, NUL-free, traversal-free.
+pub fn validatePrefix(prefix: []const u8) PrefixError!void {
+    if (prefix.len == 0) return PrefixError.Empty;
+    if (prefix.len > max_prefix_len) return PrefixError.TooLong;
+    if (prefix[0] != '/') return PrefixError.NotAbsolute;
+    if (std.mem.indexOfScalar(u8, prefix, 0) != null) return PrefixError.EmbeddedNul;
+    // Tight charset closes the BUG-007/BUG-019 injection class — quotes,
+    // backslashes, control bytes, parens etc. flow into single-quoted
+    // Ruby literals and sandbox-profile strings unchanged.
+    for (prefix) |b| if (!isAllowedPrefixByte(b)) return PrefixError.DisallowedByte;
+
+    // Strip one trailing slash; `/opt/malt/` is fine, `//` inside is not.
+    const trimmed = if (prefix.len > 1 and prefix[prefix.len - 1] == '/')
+        prefix[0 .. prefix.len - 1]
+    else
+        prefix;
+    if (trimmed.len == 1) return; // just "/" — no components to scan
+
+    var it = std.mem.splitScalar(u8, trimmed, '/');
+    _ = it.next(); // leading "/" yields an empty first slice
+    while (it.next()) |comp| {
+        if (comp.len == 0) return PrefixError.EmptyComponent;
+        if (std.mem.eql(u8, comp, "..")) return PrefixError.DotDotComponent;
+    }
+}
+
+pub fn describePrefixError(e: PrefixError) []const u8 {
+    return switch (e) {
+        PrefixError.Empty => "empty",
+        PrefixError.NotAbsolute => "not an absolute path",
+        PrefixError.DotDotComponent => "contains '..' component",
+        PrefixError.EmbeddedNul => "contains NUL byte",
+        PrefixError.TooLong => "exceeds 512 bytes",
+        PrefixError.EmptyComponent => "contains empty path component ('//')",
+        PrefixError.DisallowedByte => "contains a byte outside [a-zA-Z0-9._+-/]",
+    };
+}
 
 /// Buffer size a call site must reserve so a validated prefix plus any
 /// fixed suffix always fits without overflow.
@@ -76,4 +140,152 @@ test "joinZ exact-fit boundary returns full slice" {
 test "bound constants are consistent" {
     try std.testing.expectEqual(@as(usize, 512), max_prefix_len);
     try std.testing.expectEqual(max_prefix_len + max_path_suffix, path_buf_len);
+}
+
+test "validatePrefix: default path is accepted" {
+    try validatePrefix("/opt/malt");
+}
+
+test "validatePrefix: tmp sandbox prefix is accepted" {
+    try validatePrefix("/tmp/malt_test_prefix");
+}
+
+test "validatePrefix: root '/' is accepted" {
+    // Root alone is technically absolute and has no bad components; we
+    // don't get to veto unusual-but-syntactically-valid prefixes.
+    try validatePrefix("/");
+}
+
+test "validatePrefix: trailing slash is tolerated" {
+    try validatePrefix("/opt/malt/");
+}
+
+test "validatePrefix: empty string rejected" {
+    try std.testing.expectError(error.Empty, validatePrefix(""));
+}
+
+test "validatePrefix: relative path rejected" {
+    try std.testing.expectError(error.NotAbsolute, validatePrefix("opt/malt"));
+    try std.testing.expectError(error.NotAbsolute, validatePrefix("./malt"));
+    try std.testing.expectError(error.NotAbsolute, validatePrefix("malt"));
+}
+
+test "validatePrefix: .. component rejected" {
+    try std.testing.expectError(error.DotDotComponent, validatePrefix("/opt/../etc"));
+    try std.testing.expectError(error.DotDotComponent, validatePrefix("/.."));
+    try std.testing.expectError(error.DotDotComponent, validatePrefix("/opt/malt/.."));
+}
+
+test "validatePrefix: NUL byte rejected" {
+    try std.testing.expectError(error.EmbeddedNul, validatePrefix("/opt/\x00malt"));
+    try std.testing.expectError(error.EmbeddedNul, validatePrefix("/opt/malt\x00"));
+}
+
+test "validatePrefix: length > max_prefix_len rejected" {
+    var buf: [max_prefix_len + 1]u8 = undefined;
+    @memset(&buf, 'a');
+    buf[0] = '/';
+    try std.testing.expectError(error.TooLong, validatePrefix(&buf));
+}
+
+test "validatePrefix: length == max_prefix_len accepted" {
+    var buf: [max_prefix_len]u8 = undefined;
+    @memset(&buf, 'a');
+    buf[0] = '/';
+    try validatePrefix(&buf);
+}
+
+test "validatePrefix: '//' inside rejected" {
+    try std.testing.expectError(error.EmptyComponent, validatePrefix("/opt//malt"));
+    try std.testing.expectError(error.EmptyComponent, validatePrefix("//opt/malt"));
+}
+
+test "validatePrefix: single dot component is permitted (not our job to canonicalise)" {
+    // A lone `.` is a valid filesystem path component; we only reject
+    // the traversal primitive `..`. Keeping this permissive avoids
+    // surprising users on paths like /opt/./malt.
+    try validatePrefix("/opt/./malt");
+}
+
+test "validatePrefix: dotdot-like-but-not-exact component accepted" {
+    // Make sure we don't over-match on .. — names like `foo..bar` are
+    // not path traversal.
+    try validatePrefix("/opt/foo..bar");
+    try validatePrefix("/opt/..malt");
+    try validatePrefix("/opt/malt..");
+}
+
+test "validatePrefix: single quote rejected" {
+    try std.testing.expectError(error.DisallowedByte, validatePrefix("/tmp/m'x"));
+}
+
+test "validatePrefix: double quote rejected" {
+    try std.testing.expectError(error.DisallowedByte, validatePrefix("/tmp/m\"x"));
+}
+
+test "validatePrefix: backslash rejected" {
+    try std.testing.expectError(error.DisallowedByte, validatePrefix("/tmp/m\\x"));
+}
+
+test "validatePrefix: newline rejected" {
+    try std.testing.expectError(error.DisallowedByte, validatePrefix("/tmp/m\nx"));
+}
+
+test "validatePrefix: control bytes rejected" {
+    // 0x01 .. 0x1f and 0x7f all constitute injection-grade noise in any
+    // shell-or-Ruby context the prefix flows into.
+    var path: [10]u8 = "/tmp/m_x_y".*;
+    inline for (.{ 0x01, 0x07, 0x1b, 0x1f, 0x7f }) |b| {
+        path[6] = b;
+        try std.testing.expectError(error.DisallowedByte, validatePrefix(&path));
+    }
+}
+
+test "validatePrefix: valid-but-unusual chars accepted (+ . - _)" {
+    // Real-world prefixes may include `+` (e.g. `/opt/malt+1.0`),
+    // `-` (`/opt/foo-bar`), `.`, `_`. They must keep passing.
+    try validatePrefix("/opt/malt+1.0");
+    try validatePrefix("/opt/foo-bar.baz_qux");
+    try validatePrefix("/opt/MALT");
+}
+
+test "describePrefixError: DisallowedByte has a descriptive string" {
+    const desc = describePrefixError(error.DisallowedByte);
+    try std.testing.expect(desc.len > 0);
+}
+
+// The charset is what closes the Ruby-wrapper / sandbox-profile injection
+// vector: a prefix carrying a quote, backslash or control byte breaks out of
+// the single-quoted literal each of those generators interpolates it into.
+test "isAllowedPrefixByte: charset matches the documented contract" {
+    // Centralised predicate used by prefix/name/version validation.
+    // Contract: [a-zA-Z0-9._+\-/].
+    const allowed = "abcXYZ0123456789._+-/";
+    for (allowed) |b| try std.testing.expect(isAllowedPrefixByte(b));
+    const denied = "'\"\\\n\t (){}[]$|;&<>*?#";
+    for (denied) |b| try std.testing.expect(!isAllowedPrefixByte(b));
+    // Control bytes: every byte below 0x20 plus DEL.
+    var b: u8 = 0;
+    while (b < 0x20) : (b += 1) try std.testing.expect(!isAllowedPrefixByte(b));
+    try std.testing.expect(!isAllowedPrefixByte(0x7f));
+    // High bit: not in the allowed set either.
+    try std.testing.expect(!isAllowedPrefixByte(0x80));
+    try std.testing.expect(!isAllowedPrefixByte(0xff));
+}
+
+test "describePrefixError: every error has a descriptive string" {
+    // Compile-time-ish coverage: every arm of the switch must return
+    // something non-empty so error output is useful.
+    const cases = [_]PrefixError{
+        error.Empty,
+        error.NotAbsolute,
+        error.DotDotComponent,
+        error.EmbeddedNul,
+        error.TooLong,
+        error.EmptyComponent,
+    };
+    for (cases) |e| {
+        const desc = describePrefixError(e);
+        try std.testing.expect(desc.len > 0);
+    }
 }

--- a/src/fs/theme_file.zig
+++ b/src/fs/theme_file.zig
@@ -9,6 +9,7 @@
 
 const std = @import("std");
 const atomic = @import("atomic.zig");
+const prefix_path = @import("prefix_path.zig");
 
 const default_suffix = "/etc/malt/themes.json";
 
@@ -19,11 +20,11 @@ const default_suffix = "/etc/malt/themes.json";
 /// written into `buf`.
 fn resolvePath(environ: std.process.Environ, buf: []u8) ?[]const u8 {
     if (environ.getPosix("MALT_THEMES_FILE")) |f| {
-        atomic.validatePrefix(f) catch return null;
+        prefix_path.validatePrefix(f) catch return null;
         return f;
     }
     const prefix = environ.getPosix("MALT_PREFIX") orelse "/opt/malt";
-    atomic.validatePrefix(prefix) catch return null;
+    prefix_path.validatePrefix(prefix) catch return null;
     return std.fmt.bufPrint(buf, "{s}" ++ default_suffix, .{prefix}) catch return null;
 }
 

--- a/tests/atomic_test.zig
+++ b/tests/atomic_test.zig
@@ -70,19 +70,6 @@ test "maltPrefixOrAbort honours MALT_PREFIX env var" {
     try testing.expectEqualStrings("/tmp/malt_atomic_prefix_env", got);
 }
 
-test "isAllowedNameByte: name/version charset extends prefix with @" {
-    // Cellar dir names embed the formula name + version (e.g. `llvm@21`,
-    // `gcc@13`, `python@3.12`) — `@` must pass for those, but `/` must
-    // not (it would let a hostile name pierce the Cellar path).
-    const allowed = "abcXYZ0123456789._+-@";
-    for (allowed) |b| try testing.expect(atomic.isAllowedNameByte(b));
-    const denied = "/'\"\\\n\t (){}[]$|;&<>*?#";
-    for (denied) |b| try testing.expect(!atomic.isAllowedNameByte(b));
-    var b: u8 = 0;
-    while (b < 0x20) : (b += 1) try testing.expect(!atomic.isAllowedNameByte(b));
-    try testing.expect(!atomic.isAllowedNameByte(0x7f));
-}
-
 test "maltPrefixChecked: empty MALT_PREFIX returns Empty error" {
     setPrefix("");
     defer unsetPrefix();

--- a/tests/atomic_test.zig
+++ b/tests/atomic_test.zig
@@ -70,122 +70,6 @@ test "maltPrefixOrAbort honours MALT_PREFIX env var" {
     try testing.expectEqualStrings("/tmp/malt_atomic_prefix_env", got);
 }
 
-// ────────────────────────────────────────────────────────────────────
-// validatePrefix — pure-function tests, exhaustive over the error set.
-// maltPrefixChecked() is exercised via these + the env-based tests
-// above, which establish the happy path through the same validator.
-// ────────────────────────────────────────────────────────────────────
-
-test "validatePrefix: default path is accepted" {
-    try atomic.validatePrefix("/opt/malt");
-}
-
-test "validatePrefix: tmp sandbox prefix is accepted" {
-    try atomic.validatePrefix("/tmp/malt_test_prefix");
-}
-
-test "validatePrefix: root '/' is accepted" {
-    // Root alone is technically absolute and has no bad components; we
-    // don't get to veto unusual-but-syntactically-valid prefixes.
-    try atomic.validatePrefix("/");
-}
-
-test "validatePrefix: trailing slash is tolerated" {
-    try atomic.validatePrefix("/opt/malt/");
-}
-
-test "validatePrefix: empty string rejected" {
-    try testing.expectError(error.Empty, atomic.validatePrefix(""));
-}
-
-test "validatePrefix: relative path rejected" {
-    try testing.expectError(error.NotAbsolute, atomic.validatePrefix("opt/malt"));
-    try testing.expectError(error.NotAbsolute, atomic.validatePrefix("./malt"));
-    try testing.expectError(error.NotAbsolute, atomic.validatePrefix("malt"));
-}
-
-test "validatePrefix: .. component rejected" {
-    try testing.expectError(error.DotDotComponent, atomic.validatePrefix("/opt/../etc"));
-    try testing.expectError(error.DotDotComponent, atomic.validatePrefix("/.."));
-    try testing.expectError(error.DotDotComponent, atomic.validatePrefix("/opt/malt/.."));
-}
-
-test "validatePrefix: NUL byte rejected" {
-    try testing.expectError(error.EmbeddedNul, atomic.validatePrefix("/opt/\x00malt"));
-    try testing.expectError(error.EmbeddedNul, atomic.validatePrefix("/opt/malt\x00"));
-}
-
-test "validatePrefix: length > max_prefix_len rejected" {
-    var buf: [atomic.max_prefix_len + 1]u8 = undefined;
-    @memset(&buf, 'a');
-    buf[0] = '/';
-    try testing.expectError(error.TooLong, atomic.validatePrefix(&buf));
-}
-
-test "validatePrefix: length == max_prefix_len accepted" {
-    var buf: [atomic.max_prefix_len]u8 = undefined;
-    @memset(&buf, 'a');
-    buf[0] = '/';
-    try atomic.validatePrefix(&buf);
-}
-
-test "validatePrefix: '//' inside rejected" {
-    try testing.expectError(error.EmptyComponent, atomic.validatePrefix("/opt//malt"));
-    try testing.expectError(error.EmptyComponent, atomic.validatePrefix("//opt/malt"));
-}
-
-test "validatePrefix: single dot component is permitted (not our job to canonicalise)" {
-    // A lone `.` is a valid filesystem path component; we only reject
-    // the traversal primitive `..`. Keeping this permissive avoids
-    // surprising users on paths like /opt/./malt.
-    try atomic.validatePrefix("/opt/./malt");
-}
-
-test "validatePrefix: dotdot-like-but-not-exact component accepted" {
-    // Make sure we don't over-match on .. — names like `foo..bar` are
-    // not path traversal.
-    try atomic.validatePrefix("/opt/foo..bar");
-    try atomic.validatePrefix("/opt/..malt");
-    try atomic.validatePrefix("/opt/malt..");
-}
-
-// Tighten the prefix charset to close the Ruby-wrapper / sandbox-profile
-// injection vector. A MALT_PREFIX with a quote, backslash, or control byte
-// breaks the generated single-quoted Ruby literal the wrapper interpolates.
-test "validatePrefix: single quote rejected" {
-    try testing.expectError(error.DisallowedByte, atomic.validatePrefix("/tmp/m'x"));
-}
-
-test "validatePrefix: double quote rejected" {
-    try testing.expectError(error.DisallowedByte, atomic.validatePrefix("/tmp/m\"x"));
-}
-
-test "validatePrefix: backslash rejected" {
-    try testing.expectError(error.DisallowedByte, atomic.validatePrefix("/tmp/m\\x"));
-}
-
-test "validatePrefix: newline rejected" {
-    try testing.expectError(error.DisallowedByte, atomic.validatePrefix("/tmp/m\nx"));
-}
-
-test "validatePrefix: control bytes rejected" {
-    // 0x01 .. 0x1f and 0x7f all constitute injection-grade noise in any
-    // shell-or-Ruby context the prefix flows into.
-    var path: [10]u8 = "/tmp/m_x_y".*;
-    inline for (.{ 0x01, 0x07, 0x1b, 0x1f, 0x7f }) |b| {
-        path[6] = b;
-        try testing.expectError(error.DisallowedByte, atomic.validatePrefix(&path));
-    }
-}
-
-test "validatePrefix: valid-but-unusual chars accepted (+ . - _)" {
-    // Real-world prefixes may include `+` (e.g. `/opt/malt+1.0`),
-    // `-` (`/opt/foo-bar`), `.`, `_`. They must keep passing.
-    try atomic.validatePrefix("/opt/malt+1.0");
-    try atomic.validatePrefix("/opt/foo-bar.baz_qux");
-    try atomic.validatePrefix("/opt/MALT");
-}
-
 test "isAllowedNameByte: name/version charset extends prefix with @" {
     // Cellar dir names embed the formula name + version (e.g. `llvm@21`,
     // `gcc@13`, `python@3.12`) — `@` must pass for those, but `/` must
@@ -197,27 +81,6 @@ test "isAllowedNameByte: name/version charset extends prefix with @" {
     var b: u8 = 0;
     while (b < 0x20) : (b += 1) try testing.expect(!atomic.isAllowedNameByte(b));
     try testing.expect(!atomic.isAllowedNameByte(0x7f));
-}
-
-test "describePrefixError: DisallowedByte has a descriptive string" {
-    const desc = atomic.describePrefixError(error.DisallowedByte);
-    try testing.expect(desc.len > 0);
-}
-
-test "isAllowedPrefixByte: charset matches the documented contract" {
-    // Centralised predicate used by prefix/name/version validation.
-    // Contract: [a-zA-Z0-9._+\-/].
-    const allowed = "abcXYZ0123456789._+-/";
-    for (allowed) |b| try testing.expect(atomic.isAllowedPrefixByte(b));
-    const denied = "'\"\\\n\t (){}[]$|;&<>*?#";
-    for (denied) |b| try testing.expect(!atomic.isAllowedPrefixByte(b));
-    // Control bytes: every byte below 0x20 plus DEL.
-    var b: u8 = 0;
-    while (b < 0x20) : (b += 1) try testing.expect(!atomic.isAllowedPrefixByte(b));
-    try testing.expect(!atomic.isAllowedPrefixByte(0x7f));
-    // High bit: not in the allowed set either.
-    try testing.expect(!atomic.isAllowedPrefixByte(0x80));
-    try testing.expect(!atomic.isAllowedPrefixByte(0xff));
 }
 
 test "maltPrefixChecked: empty MALT_PREFIX returns Empty error" {
@@ -242,23 +105,6 @@ test "maltPrefixChecked: unset returns default" {
     unsetPrefix();
     const got = try atomic.maltPrefixChecked();
     try testing.expectEqualStrings("/opt/malt", got);
-}
-
-test "describePrefixError: every error has a descriptive string" {
-    // Compile-time-ish coverage: every arm of the switch must return
-    // something non-empty so error output is useful.
-    const cases = [_]atomic.PrefixError{
-        error.Empty,
-        error.NotAbsolute,
-        error.DotDotComponent,
-        error.EmbeddedNul,
-        error.TooLong,
-        error.EmptyComponent,
-    };
-    for (cases) |e| {
-        const desc = atomic.describePrefixError(e);
-        try testing.expect(desc.len > 0);
-    }
 }
 
 test "maltTmpDir composes {prefix}/tmp" {

--- a/tests/migrate_smoke_test.zig
+++ b/tests/migrate_smoke_test.zig
@@ -213,7 +213,7 @@ test "long-but-valid MALT_PREFIX reaches the real db failure instead of exiting 
     // directory — and must surface Aborted.
     const prefix = try buildLongPrefix(testing.allocator, base, 512);
     defer testing.allocator.free(prefix);
-    try malt.atomic.validatePrefix(prefix); // precondition: this prefix is valid
+    try malt.prefix_path.validatePrefix(prefix); // precondition: this prefix is valid
     const db_as_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db/malt.db", .{prefix});
     defer testing.allocator.free(db_as_dir);
     try test_io.cwd().createDirPath(std.Options.debug_io, db_as_dir);


### PR DESCRIPTION
## Description

`prefix_path.zig` defined what a prefix may be as long as, while the validator enforcing that bound lived in `atomic.zig` - a filesystem module. So the rule and the number it checks against could drift apart, and anything wanting a pure yes/no about a string had to reach through an I/O module to get it.

The prefix bound, its charset, its validator and its error type now sit together in the std-only leaf, with their tests. `atomic.zig` keeps what is genuinely its own: the env boundary that reads `MALT_PREFIX` and aborts on a bad one.

## Related Issue

- None

## Notes for Reviewers

- Pure relocation - the test count is identical before and after, which is the signal that nothing was lost or invented on the way across.
- No compatibility re-exports were left behind, so there is one home and one access path rather than an alias to go stale.