### PR TITLE
fix(install): stop a package requested alongside its dependent from installing twice

### DIFF
--- a/src/cli/install/download.zig
+++ b/src/cli/install/download.zig
@@ -432,28 +432,42 @@ pub fn collectFormulaJobs(
         return InstallError.NoBottle;
     };
 
-    const main_strs = dupeJobStrings(allocator, formula, bottle) catch return InstallError.DownloadFailed;
-    errdefer main_strs.freeAll(allocator);
+    // A package can arrive as another job's dependency and then as its own
+    // request. Keyed on name + version, the pair that is the keg path two
+    // materialise workers would collide on.
+    const queued: ?*DownloadJob = for (jobs.items) |*existing| {
+        if (std.mem.eql(u8, existing.name, formula.name) and
+            std.mem.eql(u8, existing.version_str, formula.pkg_version)) break existing;
+    } else null;
 
-    jobs.append(allocator, .{
-        .name = main_strs.name,
-        // Same reason as the dep branch above: the cellar dir name
-        // must carry the `_N` suffix when revision > 0.
-        .version_str = main_strs.version_str,
-        .sha256 = main_strs.sha256,
-        .bottle_url = main_strs.bottle_url,
-        .is_dep = false,
-        .keg_only = formula.keg_only,
-        .wants_post_install = formula.hasPostInstallHook(),
-        .formula_json = formula_json,
-        .cellar_type = main_strs.cellar_type,
-        .label_width = 0,
-        .line_index = 0,
-        .multi = null,
-        .bar = null,
-        .store_sha256 = "",
-        .succeeded = false,
-    }) catch return InstallError.DownloadFailed;
+    if (queued) |job| {
+        // Promote rather than queue a second job: one keg, one worker, and a
+        // package the user named is no longer reclaimable as an unused dep.
+        job.is_dep = false;
+    } else {
+        const main_strs = dupeJobStrings(allocator, formula, bottle) catch return InstallError.DownloadFailed;
+        errdefer main_strs.freeAll(allocator);
+
+        jobs.append(allocator, .{
+            .name = main_strs.name,
+            // Same reason as the dep branch above: the cellar dir name
+            // must carry the `_N` suffix when revision > 0.
+            .version_str = main_strs.version_str,
+            .sha256 = main_strs.sha256,
+            .bottle_url = main_strs.bottle_url,
+            .is_dep = false,
+            .keg_only = formula.keg_only,
+            .wants_post_install = formula.hasPostInstallHook(),
+            .formula_json = formula_json,
+            .cellar_type = main_strs.cellar_type,
+            .label_width = 0,
+            .line_index = 0,
+            .multi = null,
+            .bar = null,
+            .store_sha256 = "",
+            .succeeded = false,
+        }) catch return InstallError.DownloadFailed;
+    }
 
     const pkg_word: []const u8 = if (jobs.items.len == 1) "package" else "packages";
     ctx.sink.info("Resolved {s} {s} ({d} {s})", .{ formula.name, formula.version, jobs.items.len, pkg_word });

--- a/tests/install_execute_test.zig
+++ b/tests/install_execute_test.zig
@@ -553,3 +553,103 @@ test "execute --dry-run routes a revisioned formula through the install pipeline
     const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
     try install.execute(&ctx, arena.allocator(), &.{ "--dry-run", "--quiet", "rev1" });
 }
+
+/// `beta` is a leaf; `alpha` depends on it. Distinct bottle checksums, because
+/// the job queue keys on identity and a shared placeholder would hide that.
+const beta_json =
+    \\{"name":"beta","full_name":"beta","tap":"homebrew/core","desc":"","homepage":"",
+    \\ "versions":{"stable":"1.0"},"revision":0,"dependencies":[],"oldnames":[],
+    \\ "keg_only":false,"post_install_defined":false,
+    \\ "bottle":{"stable":{"root_url":"https://ghcr.io/v2/homebrew/core/beta/blobs",
+    \\   "files":{
+    \\     "arm64_sequoia":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"bb"},
+    \\     "arm64_sonoma":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"bb"},
+    \\     "arm64_ventura":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"bb"},
+    \\     "arm64_monterey":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"bb"},
+    \\     "sequoia":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"bx"},
+    \\     "sonoma":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"bx"},
+    \\     "ventura":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"bx"},
+    \\     "monterey":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"bx"}
+    \\   }}}}
+;
+
+const alpha_json =
+    \\{"name":"alpha","full_name":"alpha","tap":"homebrew/core","desc":"","homepage":"",
+    \\ "versions":{"stable":"1.0"},"revision":0,"dependencies":["beta"],"oldnames":[],
+    \\ "keg_only":false,"post_install_defined":false,
+    \\ "bottle":{"stable":{"root_url":"https://ghcr.io/v2/homebrew/core/alpha/blobs",
+    \\   "files":{
+    \\     "arm64_sequoia":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"aa"},
+    \\     "arm64_sonoma":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"aa"},
+    \\     "arm64_ventura":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"aa"},
+    \\     "arm64_monterey":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"aa"},
+    \\     "sequoia":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"ax"},
+    \\     "sonoma":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"ax"},
+    \\     "ventura":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"ax"},
+    \\     "monterey":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"ax"}
+    \\   }}}}
+;
+
+/// Seed both fixtures under a scratch prefix and run `execute` with `argv`,
+/// returning what reached stderr. Caller frees.
+fn planFor(suffix: []const u8, argv: []const []const u8) !std.ArrayList(u8) {
+    const prefix_z = try setupPrefix(suffix);
+    defer testing.allocator.free(prefix_z);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    try seedFormulaCache(prefix_z, "beta", beta_json);
+    try seedFormulaCache(prefix_z, "alpha", alpha_json);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    // `output.quiet` is process-global and earlier tests leave it set.
+    const prior_quiet = malt.output.isQuiet();
+    malt.output.setQuiet(false);
+    defer malt.output.setQuiet(prior_quiet);
+
+    var captured: std.ArrayList(u8) = .empty;
+    errdefer captured.deinit(testing.allocator);
+    malt.output.beginStderrCapture(testing.allocator, &captured);
+    defer malt.output.endStderrCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try install.execute(&ctx, arena.allocator(), argv);
+    return captured;
+}
+
+test "a package requested alongside its dependent is planned once, as a request" {
+    // `beta` arrives twice: as `alpha`'s dependency, then as its own request.
+    // A second job for the same keg would send two workers at one directory.
+    var out = try planFor("dup", &.{ "--dry-run", "alpha", "beta" });
+    defer out.deinit(testing.allocator);
+
+    try testing.expect(std.mem.indexOf(u8, out.items, "would install 2 package") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "would install 3 package") == null);
+    // Promoted: an explicit request is not a dependency, so `purge
+    // --unused-deps` must not reclaim it.
+    try testing.expect(std.mem.indexOf(u8, out.items, "beta 1.0 (dependency)") == null);
+}
+
+test "the plan does not depend on the order the two names were typed" {
+    // Requesting the dependency first takes the other branch - the dep loop
+    // skips an already-queued job instead of the request promoting one - so
+    // both orders have to agree on count and on dependency marking.
+    var out = try planFor("dup_rev", &.{ "--dry-run", "beta", "alpha" });
+    defer out.deinit(testing.allocator);
+
+    try testing.expect(std.mem.indexOf(u8, out.items, "would install 2 package") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "beta 1.0 (dependency)") == null);
+}
+
+test "only-deps skips a dependency the user also asked for by name" {
+    // Both names are explicit requests, so --only-deps has nothing left to
+    // install: `beta` is not a bystander dependency once it is typed out.
+    var out = try planFor("dup_od", &.{ "--dry-run", "--only-deps", "alpha", "beta" });
+    defer out.deinit(testing.allocator);
+
+    try testing.expect(std.mem.indexOf(u8, out.items, "Dry run: would install") == null);
+}

--- a/tests/install_test.zig
+++ b/tests/install_test.zig
@@ -653,6 +653,56 @@ test "collectFormulaJobs deduplicates deps already queued by a prior call" {
     try testing.expectEqual(@as(usize, 3), jobs.items.len);
 }
 
+test "collectFormulaJobs promotes a queued dep that is later requested by name" {
+    var arena = testArena();
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var tdb = try TempDb.init("promote_dep");
+    defer tdb.deinit();
+
+    var cache_fx = try TempDir.init("promote_dep_cache");
+    defer cache_fx.deinit();
+    const cache_dir = cache_fx.path;
+
+    const dep_json = bottleJsonWithoutDeps("beta");
+    try seedCache(cache_dir, "beta", dep_json);
+    const root_json = formulaJsonWithDep("alpha", "beta");
+    try seedCache(cache_dir, "alpha", root_json);
+
+    var http_pool = try malt.client_pool.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 2);
+    defer http_pool.deinit();
+    var real_http = malt.client.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, alloc);
+    defer real_http.deinit();
+    var api = malt.api.BrewApi.init(std.Options.debug_io, alloc, &real_http, cache_dir);
+
+    var store_inst: malt.store.Store = undefined;
+    var jobs: std.ArrayList(install_download.DownloadJob) = .empty;
+    defer jobs.deinit(alloc);
+
+    var cache = malt.deps.FormulaCache.init(alloc);
+    defer cache.deinit();
+
+    const deps_ctx: install_download.InstallJobDeps = .{ .io = std.Options.debug_io, .allocator = alloc, .api = &api, .http_pool = &http_pool, .db = &tdb.db, .store = &store_inst, .cache = &cache, .worker_backing = alloc };
+    try install_download.collectFormulaJobs(deps_ctx, "alpha", root_json, false, &jobs);
+    try install_download.collectFormulaJobs(deps_ctx, "beta", dep_json, false, &jobs);
+
+    // Queueing beta twice would send two workers at one keg directory.
+    try testing.expectEqual(@as(usize, 2), jobs.items.len);
+
+    // `is_dep` is the flag the rest of the install reads: it decides
+    // `install_reason` (so `purge --unused-deps` cannot reclaim a package the
+    // user asked for), whether `--only-deps` drops it, and whether
+    // `--isolate-deps` withholds its binaries. A named request is not a dep.
+    for (jobs.items) |j| {
+        if (std.mem.eql(u8, j.name, "beta")) try testing.expect(!j.is_dep);
+    }
+
+    // Naming it a third time must still not grow the queue.
+    try install_download.collectFormulaJobs(deps_ctx, "beta", dep_json, false, &jobs);
+    try testing.expectEqual(@as(usize, 2), jobs.items.len);
+}
+
 test "collectFormulaJobs surfaces FormulaNotFound for unparseable JSON" {
     var arena = testArena();
     defer arena.deinit();


### PR DESCRIPTION
## Description

Installing a package that is also another requested package's dependency queued it twice, so two workers materialised into the same keg directory and one wiped the other mid-clone. A healthy install reported `CloneFailed` and took the whole transaction down with it; a tap formula listing both a library and one of its consumers is enough to hit it.

The dependency loop already refused to re-queue a package it had seen; the main-formula path had no such check. It now promotes the queued job instead, so the result no longer depends on the order the names were typed.

## Related Issue

- None

## Notes for Reviewers

- None