### PR TITLE
fix(cellar): explain a refused keg write and stop it claiming store bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ mt doctor --post-install-status          # check DSL support per installed formu
 | API reachable       | HEAD to `formulae.brew.sh` returns 2xx        | Warn: offline                            |
 | Orphaned store      | All store entries referenced by a keg         | Warn: suggest `mt purge --store-orphans` |
 | Missing kegs        | All DB keg paths exist on disk                | Error: suggest reinstall                 |
+| Cellar package dirs | No `Cellar/<name>` is a symlink               | Warn: installs there are refused         |
 | Broken symlinks     | All symlinks in bin/, lib/ etc. resolve       | Warn: suggest `mt cleanup`               |
 | Disk space          | > 1 GB free on prefix volume                  | Warn: low disk space                     |
 | Post-install DSL    | All installed post_install formulae parseable | Warn: unsupported construct              |

--- a/justfile
+++ b/justfile
@@ -70,6 +70,7 @@ regressions-hermetic:
 [group('test')]
 regressions-harness:
     @./scripts/regressions/cached-outdated-drops-revision-bumped-packages.sh
+    @./scripts/regressions/cellar-symlink-followups-3-follow-up.sh
     @./scripts/regressions/child-run-sequential-pipe-drain-deadlock.sh
     @./scripts/regressions/cosign-guard-fails-open-and-spawn-not-pinned.sh
     @./scripts/regressions/csi-whitelist-ignores-private-parameter-bytes.sh

--- a/scripts/regressions/cellar-symlink-followups-3-follow-up.sh
+++ b/scripts/regressions/cellar-symlink-followups-3-follow-up.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Regression: the three unclosed edges around the Cellar symlink guard.
+#
+# The guard refuses to materialise a keg into a symlinked
+# `<prefix>/Cellar/<name>`. Three things around that refusal were open:
+#
+#   1. `doctor` had no check that looks at a package dir, so the one
+#      command a user is sent to after the refusal was silent about it;
+#   2. a refused materialise still bumped the store refcount, pinning the
+#      bottle's bytes at `refcount = 1` with no keg row referencing them —
+#      unreclaimable, because an orphan is `refcount <= 0`;
+#   3. `upgrade` passed no `cellar_diag` sink, so it printed the bare
+#      `Failed to materialize <name>` while `install` named the variant.
+#
+# All three arms are offline and run against a scratch prefix.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+if [[ ! -x "$BIN" ]] && ! zig build >/dev/null 2>&1; then
+  echo "FAIL: could not build zig-out/bin/malt" >&2
+  exit 1
+fi
+
+# `pwd -P` normalizes the trailing slash TMPDIR may carry: MALT_PREFIX
+# refuses a path with an empty component.
+tmp="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$tmp"' EXIT
+
+prefix="$tmp/prefix"
+mkdir -p "$prefix"/{store,Cellar,Caskroom,opt,bin,lib,tmp,cache,db} "$tmp/victim"
+export MALT_PREFIX="$prefix" NO_COLOR=1 MALT_NO_EMOJI=1 MALT_OFFLINE=1
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+# --- Arm 1: doctor names a symlinked package dir ----------------------------
+# The clean half first: a check that always warns would satisfy the
+# symlinked half on its own.
+mkdir -p "$prefix/Cellar/real/1.0"
+"$BIN" doctor --json >"$tmp/clean.json" 2>/dev/null || true
+grep -q '"id":"cellar_package_directories","severity":"ok"' "$tmp/clean.json" ||
+  fail "a Cellar holding only real package dirs is not reported clean"
+
+ln -s "$tmp/victim" "$prefix/Cellar/planted"
+
+"$BIN" doctor >"$tmp/human.txt" 2>&1 || true
+grep -q 'Cellar package directories.*planted' "$tmp/human.txt" ||
+  fail "doctor did not name the symlinked package dir"
+grep -qi 'refused' "$tmp/human.txt" ||
+  fail "doctor did not say installs into it are refused"
+
+"$BIN" doctor --json >"$tmp/warn.json" 2>/dev/null || true
+grep -q '"id":"cellar_package_directories","severity":"warn"' "$tmp/warn.json" ||
+  fail "doctor --json did not report the symlinked package dir"
+grep -q 'planted' "$tmp/warn.json" ||
+  fail "doctor --json did not name the symlinked package dir"
+
+# --- Arm 2: a refused materialise claims no store bytes ---------------------
+# The bump only happens on a cold commit, which needs a registry; the
+# integration test drives one over loopback, so run it here rather than
+# reaching for the network.
+KEG_TEST="$ROOT/zig-out/test-bin/install_keg_from_bottle_test"
+if ! zig build test-bin >/dev/null 2>&1; then
+  fail "could not build the integration test binaries (zig build test-bin)"
+fi
+if ! OUT=$(MALT_PREFIX=/tmp/malt-test-prefix "$KEG_TEST" 2>&1); then
+  printf '%s\n' "$OUT" | grep -iE "failed|leaked|panic" >&2 || true
+  fail "a refused materialise left a claimed store refcount"
+fi
+
+# --- Arm 3: the upgrade failure line carries the variant --------------------
+# Seed a keg row at 1.0, a cached formula at 2.0, and the 2.0 bottle warm
+# in the store, so the upgrade reaches the cellar refusal with no network.
+sha="feed$(printf '0%.0s' $(seq 1 60))"
+mkdir -p "$prefix/store/$sha/planted/2.0" "$prefix/cache/api"
+echo warm >"$prefix/store/$sha/planted/2.0/README"
+cat >"$prefix/cache/api/formula_planted.json" <<EOF
+{"name":"planted","full_name":"planted","tap":"homebrew/core","desc":"","homepage":"",
+ "versions":{"stable":"2.0"},"revision":0,"dependencies":[],"keg_only":false,
+ "post_install_defined":false,"oldnames":[],
+ "bottle":{"stable":{"files":{"all":{"cellar":":any",
+   "url":"https://ghcr.io/v2/homebrew/core/planted/blobs/sha256:$sha","sha256":"$sha"}}}}}
+EOF
+sqlite3 "$prefix/db/malt.db" \
+  "INSERT INTO kegs (name, full_name, version, revision, tap, store_sha256, cellar_path)
+   VALUES ('planted','planted','1.0',0,'homebrew/core','$sha','$prefix/Cellar/planted/1.0');"
+
+"$BIN" upgrade planted >"$tmp/upgrade.txt" 2>&1 || true
+grep -q 'Failed to materialize planted: UnsafeCellarLink' "$tmp/upgrade.txt" ||
+  fail "upgrade's materialize failure line lost the CellarError variant"
+
+echo "PASS: the Cellar symlink refusal is diagnosed and claims no store bytes"

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -15,6 +15,7 @@ const lock_mod = @import("../db/lock.zig");
 const schema = @import("../db/schema.zig");
 const sqlite = @import("../db/sqlite.zig");
 const atomic = @import("../fs/atomic.zig");
+const symlink = @import("../fs/symlink.zig");
 const tap_cache_mod = @import("../core/tap_cache.zig");
 const tap_mod = @import("../core/tap.zig");
 const clonefile = @import("../fs/clonefile.zig");
@@ -125,6 +126,7 @@ pub const checks = [_]Check{
     .{ .name = "API reachable", .run = checkApiReachable },
     .{ .name = "Orphaned store entries", .run = checkOrphanedStore },
     .{ .name = "Missing kegs", .run = checkMissingKegs },
+    .{ .name = "Cellar package directories", .run = checkCellarPackageDirs },
     .{ .name = "Broken symlinks", .run = checkBrokenSymlinks },
     .{ .name = "Relocation placeholders", .run = checkMachOPlaceholders },
     .{ .name = "Relocated prefix paths", .run = checkUnrelocatedPrefix },
@@ -1028,6 +1030,60 @@ fn checkMissingKegs(ctx: CheckCtx, name: []const u8) CheckResult {
     return .err_status;
 }
 
+/// A symlinked `<prefix>/Cellar/<name>` is refused by every cellar sink, so
+/// installs into it fail with no other diagnosis on the machine. `doctor` is
+/// where the user is sent after that refusal, so it has to name the link.
+/// No `--fix` hint: unlinking a package dir the user planted is their call.
+fn checkCellarPackageDirs(ctx: CheckCtx, name: []const u8) CheckResult {
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cellar_root = std.fmt.bufPrint(&root_buf, "{s}/Cellar", .{ctx.prefix}) catch {
+        printCheck(name, .ok, null);
+        return .ok;
+    };
+    // A prefix with no Cellar yet is a fresh install, not a fault.
+    var dir = std.Io.Dir.openDirAbsolute(ctx.io, cellar_root, .{ .iterate = true }) catch {
+        printCheck(name, .ok, null);
+        return .ok;
+    };
+    defer dir.close(ctx.io);
+
+    var offenders: std.ArrayList([]u8) = .empty;
+    defer freeOwnedStringList(ctx.allocator, &offenders);
+
+    var iter = dir.iterate();
+    while (iter.next(ctx.io) catch null) |entry| {
+        var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const path = std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ cellar_root, entry.name }) catch continue;
+        // The same predicate the cellar guard refuses on, so report and
+        // refusal can never disagree.
+        if (!symlink.isSymlinkOrUnreadable(ctx.io, path)) continue;
+        const row = ctx.allocator.dupe(u8, entry.name) catch continue;
+        offenders.append(ctx.allocator, row) catch {
+            ctx.allocator.free(row);
+            continue;
+        };
+    }
+
+    if (offenders.items.len == 0) {
+        printCheck(name, .ok, null);
+        return .ok;
+    }
+    if (ctx.op_in_flight) {
+        printCheck(name, .info_status, op_in_flight_note);
+        return .info_status;
+    }
+    var msg_buf: [256]u8 = undefined;
+    const msg = std.fmt.bufPrint(
+        &msg_buf,
+        "{d} package dir(s) under Cellar are symlinks; installs into them are refused. First: {s}",
+        .{ offenders.items.len, offenders.items[0] },
+    ) catch "Symlinked package dir(s) under Cellar; installs into them are refused";
+    printCheck(name, .warn_status, msg);
+    armVerboseHint();
+    writeVerboseList(offenders.items);
+    return .warn_status;
+}
+
 fn checkBrokenSymlinks(ctx: CheckCtx, name: []const u8) CheckResult {
     var offenders: std.ArrayList([]u8) = .empty;
     defer freeOwnedStringList(ctx.allocator, &offenders);
@@ -1859,6 +1915,91 @@ test "checkBrokenSymlinks: an intact link with an inaccessible target is not rep
 
     const ctx: CheckCtx = .{ .allocator = allocator, .prefix = prefix, .io = io, .environ = .empty };
     try testing.expectEqual(CheckResult.ok, checkBrokenSymlinks(ctx, "Broken symlinks"));
+}
+
+test "checkCellarPackageDirs: real package dirs and a missing Cellar are clean" {
+    // Without this half the guard cannot fail — a check that always warns
+    // would satisfy the symlink case below on its own.
+    const allocator = testing.allocator;
+    const io = std.Options.debug_io;
+    var s = try Scratch.init("doctor_cellar_pkgdirs_ok");
+    defer s.deinit();
+
+    const ctx: CheckCtx = .{ .allocator = allocator, .prefix = s.base, .io = io, .environ = .empty };
+    defer resetVerboseHint();
+
+    try testing.expectEqual(CheckResult.ok, checkCellarPackageDirs(ctx, "Cellar package directories"));
+
+    try std.Io.Dir.cwd().createDirPath(io, s.p("/Cellar/real/1.0"));
+    try testing.expectEqual(CheckResult.ok, checkCellarPackageDirs(ctx, "Cellar package directories"));
+}
+
+test "checkCellarPackageDirs: a symlinked package dir warns and names the offender" {
+    const allocator = testing.allocator;
+    const io = std.Options.debug_io;
+    var s = try Scratch.init("doctor_cellar_pkgdirs_link");
+    defer s.deinit();
+
+    try std.Io.Dir.cwd().createDirPath(io, s.p("/Cellar/real/1.0"));
+    try std.Io.Dir.cwd().createDirPath(io, s.p("/victim"));
+    try std.Io.Dir.symLinkAbsolute(io, s.p("/victim"), s.p("/Cellar/planted"), .{});
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(allocator);
+    output.beginStderrCapture(allocator, &out);
+    defer output.endStderrCapture();
+
+    const ctx: CheckCtx = .{ .allocator = allocator, .prefix = s.base, .io = io, .environ = .empty };
+    defer resetVerboseHint();
+
+    try testing.expectEqual(CheckResult.warn_status, checkCellarPackageDirs(ctx, "Cellar package directories"));
+    try testing.expect(std.mem.indexOf(u8, out.items, "planted") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "refused") != null);
+}
+
+test "checkCellarPackageDirs: a dangling package-dir symlink is still reported" {
+    // The guard refuses on the link itself, not on what it resolves to, so a
+    // probe that followed the link would call this prefix healthy.
+    const allocator = testing.allocator;
+    const io = std.Options.debug_io;
+    var s = try Scratch.init("doctor_cellar_pkgdirs_dangling");
+    defer s.deinit();
+
+    try std.Io.Dir.cwd().createDirPath(io, s.p("/Cellar"));
+    try std.Io.Dir.symLinkAbsolute(io, s.p("/gone"), s.p("/Cellar/dangling"), .{});
+
+    output.setQuiet(true);
+    defer output.setQuiet(false);
+    const ctx: CheckCtx = .{ .allocator = allocator, .prefix = s.base, .io = io, .environ = .empty };
+    defer resetVerboseHint();
+
+    try testing.expectEqual(CheckResult.warn_status, checkCellarPackageDirs(ctx, "Cellar package directories"));
+}
+
+test "checkCellarPackageDirs: a live operation downgrades the finding, never hides it" {
+    // Mid-install the Cellar is in flux; blaming the user for a transient
+    // is the same mistake the other filesystem-vs-DB checks avoid.
+    const allocator = testing.allocator;
+    const io = std.Options.debug_io;
+    var s = try Scratch.init("doctor_cellar_pkgdirs_inflight");
+    defer s.deinit();
+
+    try std.Io.Dir.cwd().createDirPath(io, s.p("/Cellar"));
+    try std.Io.Dir.cwd().createDirPath(io, s.p("/victim"));
+    try std.Io.Dir.symLinkAbsolute(io, s.p("/victim"), s.p("/Cellar/planted"), .{});
+
+    output.setQuiet(true);
+    defer output.setQuiet(false);
+    const ctx: CheckCtx = .{
+        .allocator = allocator,
+        .prefix = s.base,
+        .io = io,
+        .environ = .empty,
+        .op_in_flight = true,
+    };
+    defer resetVerboseHint();
+
+    try testing.expectEqual(CheckResult.info_status, checkCellarPackageDirs(ctx, "Cellar package directories"));
 }
 
 test "checkOrphanedStore: counts only refcount<=0 rows across store entries" {

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -1075,9 +1075,9 @@ fn checkCellarPackageDirs(ctx: CheckCtx, name: []const u8) CheckResult {
     var msg_buf: [256]u8 = undefined;
     const msg = std.fmt.bufPrint(
         &msg_buf,
-        "{d} package dir(s) under Cellar are symlinks; installs into them are refused. First: {s}",
+        "{d} symlinked package dir(s) under Cellar; installs are refused. Replace with a real directory. First: {s}",
         .{ offenders.items.len, offenders.items[0] },
-    ) catch "Symlinked package dir(s) under Cellar; installs into them are refused";
+    ) catch "Symlinked package dir(s) under Cellar; installs are refused. Replace with a real directory";
     printCheck(name, .warn_status, msg);
     armVerboseHint();
     writeVerboseList(offenders.items);
@@ -1955,6 +1955,9 @@ test "checkCellarPackageDirs: a symlinked package dir warns and names the offend
     try testing.expectEqual(CheckResult.warn_status, checkCellarPackageDirs(ctx, "Cellar package directories"));
     try testing.expect(std.mem.indexOf(u8, out.items, "planted") != null);
     try testing.expect(std.mem.indexOf(u8, out.items, "refused") != null);
+    // Every sibling check names a remedy; a row that only says "broken"
+    // leaves the user with nowhere to go.
+    try testing.expect(std.mem.indexOf(u8, out.items, "Replace with a real directory") != null);
 }
 
 test "checkCellarPackageDirs: a dangling package-dir symlink is still reported" {

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -1663,7 +1663,7 @@ fn installCask(
 // (where describeError == @errorName) drop the parenthetical so the
 // message reads `Failed to materialize X: CloneFailed` instead of
 // `Failed to materialize X: CloneFailed (CloneFailed)`.
-fn formatMaterializeFailure(buf: []u8, name: []const u8, err: cellar_mod.CellarError) []const u8 {
+pub fn formatMaterializeFailure(buf: []u8, name: []const u8, err: cellar_mod.CellarError) []const u8 {
     const tag = @errorName(err);
     const desc = cellar_mod.describeError(err);
     const result = if (std.mem.eql(u8, tag, desc))
@@ -1850,6 +1850,21 @@ test "formatMaterializeFailure: action-hint tag keeps the parenthetical prose" {
     try std.testing.expect(std.mem.startsWith(u8, msg, "Failed to materialize pkg: InstallNameToolMissing ("));
     try std.testing.expect(std.mem.endsWith(u8, msg, ")"));
     try std.testing.expect(std.mem.indexOf(u8, msg, "install_name_tool not found on PATH") != null);
+}
+
+test "formatMaterializeFailure: a symlinked package dir names the cause and the remedy" {
+    // Both install and upgrade render their cellar refusal through here, so
+    // this is the line a user gets after the guard fires.
+    var buf: [256]u8 = undefined;
+    const msg = formatMaterializeFailure(&buf, "jq", cellar_mod.CellarError.UnsafeCellarLink);
+    try std.testing.expect(std.mem.startsWith(u8, msg, "Failed to materialize jq: UnsafeCellarLink ("));
+    try std.testing.expect(std.mem.indexOf(u8, msg, "is a symlink") != null);
+}
+
+test "formatMaterializeFailure: a name that overflows the buffer still reports a failure" {
+    var buf: [32]u8 = undefined;
+    const msg = formatMaterializeFailure(&buf, "n" ** 64, cellar_mod.CellarError.CloneFailed);
+    try std.testing.expectEqualStrings("Failed to materialize <truncated>", msg);
 }
 
 test "kegPresent returns true only when <prefix>/Cellar/<name> exists" {

--- a/src/cli/install/download.zig
+++ b/src/cli/install/download.zig
@@ -580,8 +580,8 @@ pub const InstallKegResult = struct {
 /// Materialise a keg from a formula's bottle URL.
 ///
 /// Composes the install pipeline's per-keg work — bottle resolve, GHCR
-/// download with bounded retry, store commit + refcount, cellar
-/// materialize — so the install pool worker and the upgrade per-keg
+/// download with bounded retry, store commit, cellar materialize +
+/// refcount — so the install pool worker and the upgrade per-keg
 /// loop share one implementation instead of drifting in two places.
 ///
 /// On a warm store the download branch is skipped entirely and the
@@ -601,13 +601,6 @@ pub fn installKegFromBottle(
     const bottle = formula_mod.resolveBottle(formula) catch return InstallError.NoBottle;
 
     const committed = try downloadBottleToStore(ctx, allocator, deps, formula, bottle);
-    if (committed) {
-        // Advisory refcount: commit succeeded so the bytes are ours; a
-        // bumped warning is not a failure of the materialize.
-        deps.store.incrementRef(bottle.sha256) catch |e| {
-            std.log.warn("refcount increment failed for {s}: {s}", .{ bottle.sha256, @errorName(e) });
-        };
-    }
 
     // Some bottles carry placeholder tokens whose value is a path inside a
     // *declared dependency's* keg rather than the prefix. Only here is the
@@ -634,6 +627,15 @@ pub fn installKegFromBottle(
         if (deps.cellar_diag) |out| out.* = err;
         return InstallError.CellarFailed;
     };
+
+    // Claim the bytes only once a keg exists: a bump taken before a refused
+    // materialize can never be undone, because no `kegs` row will ever
+    // reference it. Still advisory, still gated on `committed`.
+    if (committed) {
+        deps.store.incrementRef(bottle.sha256) catch |e| {
+            std.log.warn("refcount increment failed for {s}: {s}", .{ bottle.sha256, @errorName(e) });
+        };
+    }
 
     return .{ .sha256 = bottle.sha256, .keg = keg };
 }

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -670,17 +670,22 @@ fn upgradeFormula(
     // exit, instead of the old setup-free bar that stacked when over-width.
     var sp = progress_mod.SingleBar.init(name, 0);
     defer sp.finish();
+    // Without the sink the cellar cause is collapsed into `CellarFailed`
+    // at the call boundary and the user is told nothing actionable.
+    var cellar_diag: ?cellar_mod.CellarError = null;
     const fetch = install_download_mod.installKegFromBottle(
         ctx,
         allocator,
-        .{ .ghcr = &ghcr, .http = http, .store = &store, .bar = sp.bind() },
+        .{ .ghcr = &ghcr, .http = http, .store = &store, .bar = sp.bind(), .cellar_diag = &cellar_diag },
         &formula,
         prefix,
     ) catch |e| {
         if (e == InstallError.NoBottle) {
             output.err("No bottle available for {s} on this platform", .{name});
         } else if (e == InstallError.CellarFailed) {
-            output.err("Failed to materialize {s}", .{name});
+            var msg_buf: [256]u8 = undefined;
+            const cause = cellar_diag orelse cellar_mod.CellarError.CloneFailed;
+            output.err("{s}", .{install_mod.formatMaterializeFailure(&msg_buf, name, cause)});
             output.emitNdjsonEvent(.materialized, name, "failed");
         }
         return error.Aborted;

--- a/tests/install_keg_from_bottle_test.zig
+++ b/tests/install_keg_from_bottle_test.zig
@@ -241,3 +241,180 @@ test "installKegFromBottle stamps the specific CellarError variant into cellar_d
         cellar_diag,
     );
 }
+
+// ── cold-path store claim ──────────────────────────────────────────────────
+//
+// The refcount bump is the store's "these bytes are claimed" marker, and it
+// is only reachable on a cold commit — the warm path skips it by contract.
+// So this arm serves a real bottle over a loopback registry, the same
+// offline transport `bottle_download_test.zig` uses.
+
+const net = std.Io.net;
+
+const BottleStub = struct { io: std.Io, listener: *net.Server, body: []const u8 };
+
+fn serveBottle(s: *BottleStub) void {
+    const stream = s.listener.accept(s.io) catch return;
+    defer stream.close(s.io);
+    var rbuf: [16 * 1024]u8 = undefined;
+    var wbuf: [16 * 1024]u8 = undefined;
+    var reader = stream.reader(s.io, &rbuf);
+    var writer = stream.writer(s.io, &wbuf);
+    var srv = std.http.Server.init(&reader.interface, &writer.interface);
+    while (true) {
+        var req = srv.receiveHead() catch return;
+        if (std.mem.indexOf(u8, req.head.target, "/token") != null) {
+            req.respond("{\"token\":\"t1\"}", .{}) catch return;
+        } else if (std.mem.indexOf(u8, req.head.target, "/blobs/") != null) {
+            req.respond(s.body, .{}) catch return;
+        } else {
+            req.respond("not found\n", .{ .status = .not_found }) catch return;
+        }
+    }
+}
+
+// `std.Options.debug_io`'s failing allocator cannot back a child spawn.
+fn tarCzf(argv: []const []const u8) !void {
+    var threaded: std.Io.Threaded = .init(std.heap.c_allocator, .{ .environ = malt.app_ctx.processEnviron() });
+    defer threaded.deinit();
+    var child = try std.process.spawn(threaded.io(), .{ .argv = argv, .stdout = .ignore, .stderr = .ignore });
+    switch (try child.wait(threaded.io())) {
+        .exited => |code| if (code != 0) return error.TarFailed,
+        else => return error.TarFailed,
+    }
+}
+
+fn refRows(db: *sqlite.Database, sha: []const u8) !i64 {
+    var stmt = try db.prepare("SELECT count(*) FROM store_refs WHERE store_sha256 = ?1;");
+    defer stmt.finalize();
+    try stmt.bindText(1, sha);
+    _ = try stmt.step();
+    return stmt.columnInt(0);
+}
+
+fn claimedRefs(db: *sqlite.Database, sha: []const u8) !i64 {
+    var stmt = try db.prepare("SELECT count(*) FROM store_refs WHERE store_sha256 = ?1 AND refcount > 0;");
+    defer stmt.finalize();
+    try stmt.bindText(1, sha);
+    _ = try stmt.step();
+    return stmt.columnInt(0);
+}
+
+test "installKegFromBottle claims no store bytes when the materialise is refused" {
+    try test_io.skipIfNoSubprocess();
+
+    const prefix = try setupPrefix("coldrefused");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    // Mint a real bottle: `<name>/<version>/README`, the layout the store
+    // commit and the cellar clone both expect.
+    const payload = try std.fmt.allocPrint(testing.allocator, "{s}/work/coldpkg/1.0", .{prefix});
+    defer testing.allocator.free(payload);
+    try test_io.cwd().createDirPath(io, payload);
+    const readme = try std.fmt.allocPrint(testing.allocator, "{s}/README", .{payload});
+    defer testing.allocator.free(readme);
+    {
+        const f = try test_io.createFileAbsolute(io, readme, .{});
+        defer f.close(io);
+        try f.writeStreamingAll(io, "cold bottle fixture\n");
+    }
+    const work = try std.fmt.allocPrint(testing.allocator, "{s}/work", .{prefix});
+    defer testing.allocator.free(work);
+    const archive = try std.fmt.allocPrint(testing.allocator, "{s}/bottle.tar.gz", .{prefix});
+    defer testing.allocator.free(archive);
+    try tarCzf(&.{ "tar", "czf", archive, "-C", work, "coldpkg" });
+
+    const body = try test_io.readFileAbsoluteAlloc(io, testing.allocator, archive, 1 << 20);
+    defer testing.allocator.free(body);
+    var raw: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(body, &raw, .{});
+    const sha = std.fmt.bytesToHex(raw, .lower);
+
+    // A symlinked package dir is the cheapest deterministic refusal.
+    const victim = try std.fmt.allocPrint(testing.allocator, "{s}/victim", .{prefix});
+    defer testing.allocator.free(victim);
+    try test_io.cwd().createDirPath(io, victim);
+    const pkg_dir = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/coldpkg", .{prefix});
+    defer testing.allocator.free(pkg_dir);
+    try test_io.symLinkAbsolute(io, victim, pkg_dir, .{ .is_directory = true });
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+    var stub = BottleStub{ .io = io, .listener = &listener, .body = body };
+    const server_thread = try std.Thread.spawn(.{}, serveBottle, .{&stub});
+
+    var base_buf: [64]u8 = undefined;
+    const base_url = try std.fmt.bufPrint(&base_buf, "http://127.0.0.1:{d}", .{listener.socket.address.getPort()});
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const formula_json = try std.fmt.allocPrint(
+        arena.allocator(),
+        \\{{
+        \\  "name": "coldpkg",
+        \\  "full_name": "coldpkg",
+        \\  "tap": "homebrew/core",
+        \\  "desc": "",
+        \\  "homepage": "",
+        \\  "versions": {{"stable": "1.0"}},
+        \\  "revision": 0,
+        \\  "dependencies": [],
+        \\  "keg_only": false,
+        \\  "post_install_defined": false,
+        \\  "oldnames": [],
+        \\  "bottle": {{"stable": {{"files": {{"all": {{"cellar": ":any", "url": "https://ghcr.io/v2/homebrew/core/coldpkg/blobs/sha256:{s}", "sha256": "{s}"}}}}}}}}
+        \\}}
+    ,
+        .{ &sha, &sha },
+    );
+    var formula = try formula_mod.parseFormula(arena.allocator(), formula_json);
+    defer formula.deinit();
+
+    var inner: std.http.Client = .{ .allocator = testing.allocator, .io = io };
+    var http = malt.client.HttpClient.initWith(&inner, io, std.process.Environ.empty, testing.allocator);
+    var ghcr = malt.ghcr.GhcrClient.init(io, testing.allocator, &http);
+    defer ghcr.deinit();
+    ghcr.base_url = base_url;
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    var store = malt.store.Store.init(io, testing.allocator, &db, prefix);
+
+    const ctx: malt.app_ctx.AppCtx = .{ .io = io, .environ = .empty };
+    var cellar_diag: ?malt.cellar.CellarError = null;
+    const result = malt.install_download.installKegFromBottle(
+        &ctx,
+        testing.allocator,
+        .{ .ghcr = &ghcr, .http = &http, .store = &store, .cellar_diag = &cellar_diag },
+        &formula,
+        prefix,
+    );
+
+    http.deinit();
+    server_thread.join();
+
+    try testing.expectError(malt.install_record.InstallError.CellarFailed, result);
+    try testing.expectEqual(
+        @as(?malt.cellar.CellarError, malt.cellar.CellarError.UnsafeCellarLink),
+        cellar_diag,
+    );
+
+    // Without this the assertion below would also hold for a download that
+    // never happened, i.e. the cold path was really taken.
+    try testing.expect(store.exists(&sha));
+
+    // No keg row references these bytes, so nothing may claim them. Note
+    // this leaves NO row, which is not the same as reclaimable: purge
+    // defines an orphan as a row at refcount <= 0, and a rowless entry is
+    // deliberately invisible to it. What this pins is that the refcount
+    // never lies about a keg that does not exist.
+    try testing.expectEqual(@as(i64, 0), try claimedRefs(&db, &sha));
+    try testing.expectEqual(@as(i64, 0), try refRows(&db, &sha));
+}


### PR DESCRIPTION
## Description

A symlinked `<prefix>/Cellar/<name>` is refused by the cellar guard, but the machine gave the user nothing to act on: `upgrade` printed a bare "Failed to materialize <name>", `doctor` passed every check, and the store refcount was bumped for a keg that was never created.

Now `upgrade` renders the same variant-bearing line `install` already did, `doctor` names the symlinked package directory and says installs into it are refused, and the refcount is taken only once a keg actually exists.

## Related Issue

- None

## Notes for Reviewers

- None
