### PR TITLE
fix(store): stop reclaiming bottle bytes a live keg still holds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,9 @@ jobs:
       - name: Regression guard - versionless keg
         run: ./scripts/regressions/versionless-keg-empty-stable-version-installs-a-versionless-keg.sh
 
+      - name: Regression guard - store entries held by a live keg
+        run: ./scripts/regressions/store-refcount-moment-does-not-match-a-reference.sh
+
       - name: Build universal binary
         run: just build-universal
 

--- a/scripts/regressions/store-ref-tracks-keg-across-reinstall.sh
+++ b/scripts/regressions/store-ref-tracks-keg-across-reinstall.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Regression guard for the store refcount losing track of a live keg.
+#
+# The install path used to claim a store ref only when the bottle download
+# was cold, so materializing from a warm store wrote a `kegs` row without
+# taking one. After install -> uninstall -> install of the same version the
+# entry sat at refcount 0 while a live keg held the bytes, and the orphan
+# sweep reclaimed them.
+#
+# The offline sibling (store-refcount-moment-does-not-match-a-reference.sh)
+# pins the sweep half against seeded DB state. This one drives the real
+# install path end to end, so it is the guard that fails if the ref is ever
+# claimed on the download again instead of on the keg.
+#
+# Usage: scripts/regressions/store-ref-tracks-keg-across-reinstall.sh
+# Requirements: built `malt` binary, network access to formulae.brew.sh +
+# ghcr.io, sqlite3.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+PKG=tree
+
+PREFIX=$(mktemp -d /tmp/mt.XXX)
+export MALT_PREFIX="$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  ✓ %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+db() { sqlite3 "$PREFIX/db/malt.db" "$1"; }
+
+# refcount for the one store entry, or "none" when no row exists.
+refcount() {
+  local v
+  v=$(db "SELECT refcount FROM store_refs WHERE store_sha256 = '$1';")
+  printf '%s' "${v:-none}"
+}
+
+"$BIN" install "$PKG" </dev/null >/dev/null 2>&1 ||
+  fail "cold install of $PKG failed"
+
+SHA=$(db "SELECT store_sha256 FROM kegs WHERE name = '$PKG';")
+[[ -n "$SHA" ]] || fail 'cold install recorded no keg'
+[[ "$(refcount "$SHA")" == 1 ]] ||
+  fail "cold install left refcount $(refcount "$SHA"), want 1"
+pass "cold install claims the bytes"
+
+"$BIN" uninstall "$PKG" </dev/null >/dev/null 2>&1 ||
+  fail "uninstall of $PKG failed"
+[[ "$(refcount "$SHA")" == 0 ]] ||
+  fail "uninstall left refcount $(refcount "$SHA"), want 0"
+[[ -d "$PREFIX/store/$SHA" ]] ||
+  fail 'uninstall removed the store entry; the warm-reinstall path is gone'
+pass 'uninstall releases the bytes but keeps them warm'
+
+# The bug: this install materializes from the warm store, so the old
+# download-gated bump never fired and the entry stayed at 0.
+"$BIN" install "$PKG" </dev/null >/dev/null 2>&1 ||
+  fail "warm reinstall of $PKG failed"
+[[ "$(refcount "$SHA")" == 1 ]] ||
+  fail "warm reinstall left refcount $(refcount "$SHA"), want 1"
+pass 'warm reinstall re-claims the bytes for the new keg'
+
+"$BIN" purge --store-orphans </dev/null >/dev/null 2>&1 || true
+[[ -d "$PREFIX/store/$SHA" ]] ||
+  fail 'the orphan sweep reclaimed bytes a live keg holds'
+pass 'the orphan sweep leaves a referenced entry alone'
+
+# The opposite drift: --force replaces the keg row rather than adding one,
+# so a plain increment here would climb past the single keg that exists.
+"$BIN" install --force "$PKG" </dev/null >/dev/null 2>&1 ||
+  fail "forced reinstall of $PKG failed"
+[[ "$(refcount "$SHA")" == 1 ]] ||
+  fail "forced reinstall left refcount $(refcount "$SHA"), want 1"
+pass 'a forced reinstall does not inflate the count'
+
+printf 'PASS: the store ref tracks the keg across the reinstall lifecycle\n'

--- a/scripts/regressions/store-refcount-moment-does-not-match-a-reference.sh
+++ b/scripts/regressions/store-refcount-moment-does-not-match-a-reference.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Regression: a store entry a live `kegs` row references must never be
+# reclaimed, whatever `store_refs.refcount` says.
+#
+# The install path claimed a ref only when the bottle download was cold, so
+# a warm materialize (install → uninstall → install of the same version)
+# wrote a `kegs` row without taking one. The entry then sat at refcount 0
+# with a live keg holding its bytes, and both `mt purge --store-orphans` and
+# `mt doctor --fix` classified it as a purgeable orphan and deleted it — a
+# maintenance command reclaiming bytes a live keg owns.
+#
+# Property under test: the reclaim predicate consults `kegs`, not just the
+# counter. The second half guards the opposite over-correction — with no keg
+# row left, the same entry must still be reclaimable.
+#
+# Usage: scripts/regressions/store-refcount-moment-does-not-match-a-reference.sh
+# Requirements: built `malt` at $MALT_BIN or zig-out/bin/malt. Offline.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+MALT_BIN=${MALT_BIN:-$ROOT/zig-out/bin/malt}
+if [[ ! -x "$MALT_BIN" ]]; then
+  printf 'FAIL: malt binary not found at %s — run "zig build" first.\n' "$MALT_BIN" >&2
+  exit 1
+fi
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+PFX=$(mktemp -d -t mt_store_refcount_live_keg.XXXXXX)
+export MALT_PREFIX="$PFX"
+trap 'rm -rf "$PFX"' EXIT
+
+SHA=$(printf 'ab%.0s' {1..32})
+mkdir -p "$PFX/db" "$PFX/store/$SHA" "$PFX/Cellar/probe/1.0"
+
+# Let the real initializer create the schema, then seed the exact state a
+# warm reinstall after an uninstall leaves behind: refcount 0, live keg.
+"$MALT_BIN" purge --store-orphans </dev/null >/dev/null 2>&1 || true
+sqlite3 "$PFX/db/malt.db" \
+  "INSERT INTO store_refs (store_sha256, refcount) VALUES ('$SHA', 0);
+   INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path)
+     VALUES ('probe','probe','1.0',0,'$SHA','$PFX/Cellar/probe/1.0');"
+
+"$MALT_BIN" purge --store-orphans </dev/null >/dev/null 2>&1 || true
+[[ -d "$PFX/store/$SHA" ]] ||
+  fail 'purge --store-orphans reaped a store entry a live keg references'
+
+"$MALT_BIN" doctor --fix </dev/null >/dev/null 2>&1 || true
+[[ -d "$PFX/store/$SHA" ]] ||
+  fail 'doctor --fix reaped a store entry a live keg references'
+
+# With the keg row gone the same entry must still be reclaimable, or the
+# sweep has been disarmed rather than narrowed.
+sqlite3 "$PFX/db/malt.db" "DELETE FROM kegs WHERE store_sha256 = '$SHA';"
+"$MALT_BIN" purge --store-orphans </dev/null >/dev/null 2>&1 || true
+[[ ! -d "$PFX/store/$SHA" ]] ||
+  fail 'a genuinely unreferenced store entry is no longer reclaimable'
+
+printf 'PASS: store entries held by a live keg survive the orphan sweep\n'

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -2005,10 +2005,11 @@ test "checkCellarPackageDirs: a live operation downgrades the finding, never hid
     try testing.expectEqual(CheckResult.info_status, checkCellarPackageDirs(ctx, "Cellar package directories"));
 }
 
-test "checkOrphanedStore: counts only refcount<=0 rows across store entries" {
+test "checkOrphanedStore: counts only unreferenced refcount<=0 rows across store entries" {
     // Parity guard for the shared-probe swap: one orphan, one live ref, one
-    // no-row entry must warn with exactly one orphan — a miscount (probe reuse
-    // or the count-vs-remove policy leaking) flips the outcome or the number.
+    // no-row entry and one keg-held under-counted entry must warn with exactly
+    // one orphan — a miscount (probe reuse or the count-vs-remove policy
+    // leaking) flips the outcome or the number.
     const allocator = testing.allocator;
     const io = std.Options.debug_io;
     var s = try Scratch.init("doctor_orphan_store");
@@ -2023,12 +2024,15 @@ test "checkOrphanedStore: counts only refcount<=0 rows across store entries" {
     var db = try sqlite.Database.open(db_path);
     try db.exec(
         \\CREATE TABLE store_refs (store_sha256 TEXT PRIMARY KEY, refcount INTEGER NOT NULL DEFAULT 1);
+        \\CREATE TABLE kegs (id INTEGER PRIMARY KEY, store_sha256 TEXT);
         \\INSERT INTO store_refs VALUES ('orphan', 0);
         \\INSERT INTO store_refs VALUES ('live', 2);
+        \\INSERT INTO store_refs VALUES ('held', 0);
+        \\INSERT INTO kegs (store_sha256) VALUES ('held');
     );
     db.close();
 
-    for ([_][]const u8{ "orphan", "live", "norow" }) |sha| {
+    for ([_][]const u8{ "orphan", "live", "norow", "held" }) |sha| {
         var eb: [std.fs.max_path_bytes]u8 = undefined;
         const entry = try std.fmt.bufPrint(&eb, "{s}/store/{s}", .{ prefix, sha });
         try std.Io.Dir.cwd().createDirPath(io, entry);
@@ -2061,6 +2065,7 @@ test "checkOrphanedStore: a store with no refcount<=0 row is ok" {
     var db = try sqlite.Database.open(db_path);
     try db.exec(
         \\CREATE TABLE store_refs (store_sha256 TEXT PRIMARY KEY, refcount INTEGER NOT NULL DEFAULT 1);
+        \\CREATE TABLE kegs (id INTEGER PRIMARY KEY, store_sha256 TEXT);
         \\INSERT INTO store_refs VALUES ('live', 2);
     );
     db.close();

--- a/src/cli/doctor/fix.zig
+++ b/src/cli/doctor/fix.zig
@@ -281,14 +281,13 @@ fn removeEntry(io: std.Io, prefix: []const u8, db: *sqlite.Database, name: []con
     return true;
 }
 
-/// A store entry is a purgeable orphan iff its `store_refs` row exists and
-/// its refcount has dropped to <= 0 — the predicate `Store.orphans()` /
-/// `purge --store-orphans` use. A *missing* row is a warm / in-flight commit
-/// (`--download-only`, or an install interrupted before the ref is taken);
-/// purge cannot clear it, so it is not an orphan. Detection and remediation
-/// share this single definition.
-pub fn isPurgeableOrphan(has_row: bool, refcount: i64) bool {
-    return has_row and refcount <= 0;
+/// The one definition detection and remediation share with
+/// `Store.orphans()` / `purge --store-orphans`. `has_row` false is a warm /
+/// in-flight commit (`--download-only`, or an install interrupted before the
+/// ref is taken) that purge cannot clear; `referenced` outranks the counter,
+/// which can under-count a live keg.
+pub fn isPurgeableOrphan(has_row: bool, refcount: i64, referenced: bool) bool {
+    return has_row and refcount <= 0 and !referenced;
 }
 
 /// Owns the orphan-classification statement so a sweep prepares it once and
@@ -299,7 +298,10 @@ pub const OrphanProbe = struct {
     stmt: sqlite.Statement,
 
     pub fn init(db: *sqlite.Database) sqlite.SqliteError!OrphanProbe {
-        return .{ .stmt = try db.prepare("SELECT refcount FROM store_refs WHERE store_sha256 = ?1;") };
+        return .{ .stmt = try db.prepare(
+            "SELECT refcount, EXISTS (SELECT 1 FROM kegs WHERE kegs.store_sha256 = store_refs.store_sha256)" ++
+                " FROM store_refs WHERE store_sha256 = ?1;",
+        ) };
     }
 
     pub fn deinit(self: *OrphanProbe) void {
@@ -313,7 +315,8 @@ pub const OrphanProbe = struct {
         self.stmt.bindText(1, sha) catch return false;
         const has_row = self.stmt.step() catch return false;
         const refcount: i64 = if (has_row) self.stmt.columnInt(0) else 0;
-        return isPurgeableOrphan(has_row, refcount);
+        const referenced = has_row and self.stmt.columnInt(1) != 0;
+        return isPurgeableOrphan(has_row, refcount, referenced);
     }
 };
 
@@ -823,18 +826,23 @@ test "pidAlive: non-positive PIDs are dead, not process groups" {
     try std.testing.expect(!pidAlive(-1));
 }
 
-test "isPurgeableOrphan: only a refcount<=0 row is an orphan" {
-    // Matches `Store.orphans()` (WHERE refcount <= 0) so detection and
-    // remediation share one definition.
-    try std.testing.expect(isPurgeableOrphan(true, 0));
-    try std.testing.expect(isPurgeableOrphan(true, -1));
-    try std.testing.expect(!isPurgeableOrphan(true, 1));
+test "isPurgeableOrphan: only an unreferenced refcount<=0 row is an orphan" {
+    // Matches `Store.orphans()` so detection and remediation share one
+    // definition.
+    try std.testing.expect(isPurgeableOrphan(true, 0, false));
+    try std.testing.expect(isPurgeableOrphan(true, -1, false));
+    try std.testing.expect(!isPurgeableOrphan(true, 1, false));
     // No ref row: a warm / in-flight commit purge cannot clear — not an orphan.
-    try std.testing.expect(!isPurgeableOrphan(false, 0));
+    try std.testing.expect(!isPurgeableOrphan(false, 0, false));
+    // A live keg outranks the counter: an under-counted row is still owned.
+    try std.testing.expect(!isPurgeableOrphan(true, 0, true));
+    try std.testing.expect(!isPurgeableOrphan(true, -1, true));
+    try std.testing.expect(!isPurgeableOrphan(true, 1, true));
+    try std.testing.expect(!isPurgeableOrphan(false, 0, true));
 }
 
-test "OrphanProbe: one probe reset-drives orphan / live-ref / no-row shas in sequence" {
-    // Driving all three shas through a single probe is the point: it proves
+test "OrphanProbe: one probe reset-drives orphan / live-ref / no-row / held shas in sequence" {
+    // Driving every sha through a single probe is the point: it proves
     // reset-then-rebind works across rows — the lifecycle the old per-call
     // prepare/finalize never exercised.
     var s = try Scratch.init("fix_orphan_probe");
@@ -847,15 +855,19 @@ test "OrphanProbe: one probe reset-drives orphan / live-ref / no-row shas in seq
     defer db.close();
     try db.exec(
         \\CREATE TABLE store_refs (store_sha256 TEXT PRIMARY KEY, refcount INTEGER NOT NULL DEFAULT 1);
+        \\CREATE TABLE kegs (id INTEGER PRIMARY KEY, store_sha256 TEXT);
         \\INSERT INTO store_refs VALUES ('orphan', 0);
         \\INSERT INTO store_refs VALUES ('live', 2);
+        \\INSERT INTO store_refs VALUES ('held', 0);
+        \\INSERT INTO kegs (store_sha256) VALUES ('held');
     );
 
     var probe = try OrphanProbe.init(&db);
     defer probe.deinit();
-    try std.testing.expect(probe.isOrphan("orphan")); // row, refcount <= 0
+    try std.testing.expect(probe.isOrphan("orphan")); // row, refcount <= 0, no keg
     try std.testing.expect(!probe.isOrphan("live")); // row, refcount >= 1
     try std.testing.expect(!probe.isOrphan("missing")); // no row
+    try std.testing.expect(!probe.isOrphan("held")); // under-counted, keg still holds it
     // Reusable after a positive hit: same probe instance, sha reused.
     try std.testing.expect(probe.isOrphan("orphan"));
 }

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -1200,6 +1200,13 @@ fn runInstall(
             continue;
         };
 
+        // Claim the store bytes for the keg row just written. Reconciling
+        // against `kegs` (rather than bumping) keeps a warm materialize from
+        // under-counting and `--force` from over-counting.
+        store.syncRef(job.store_sha256) catch |e| {
+            sink.warn("refcount sync failed for {s}: {s}", .{ job.name, @errorName(e) });
+        };
+
         // `--force` post-link: now that `recordKeg` has inserted the
         // new row (and inherited any pin via COALESCE-MAX), it is
         // safe to drop the prior other-version rows + their dirs.

--- a/src/cli/install/download.zig
+++ b/src/cli/install/download.zig
@@ -600,7 +600,7 @@ pub fn installKegFromBottle(
 ) InstallError!InstallKegResult {
     const bottle = formula_mod.resolveBottle(formula) catch return InstallError.NoBottle;
 
-    const committed = try downloadBottleToStore(ctx, allocator, deps, formula, bottle);
+    _ = try downloadBottleToStore(ctx, allocator, deps, formula, bottle);
 
     // Some bottles carry placeholder tokens whose value is a path inside a
     // *declared dependency's* keg rather than the prefix. Only here is the
@@ -628,15 +628,8 @@ pub fn installKegFromBottle(
         return InstallError.CellarFailed;
     };
 
-    // Claim the bytes only once a keg exists: a bump taken before a refused
-    // materialize can never be undone, because no `kegs` row will ever
-    // reference it. Still advisory, still gated on `committed`.
-    if (committed) {
-        deps.store.incrementRef(bottle.sha256) catch |e| {
-            std.log.warn("refcount increment failed for {s}: {s}", .{ bottle.sha256, @errorName(e) });
-        };
-    }
-
+    // The store ref belongs to the keg row, not to this download: the caller
+    // claims it with `Store.syncRef` once `recordKeg` has run.
     return .{ .sha256 = bottle.sha256, .keg = keg };
 }
 
@@ -1142,9 +1135,8 @@ test "installKegFromBottle returns NoBottle before reaching ghcr/store when no p
 }
 
 // `downloadBottleToStore` returning `false` on the warm-store path is
-// the contract `installKegFromBottle` relies on to skip the refcount
-// bump, and that the `--download-only` pool worker relies on to keep
-// the warm fast path zero-I/O.
+// the contract the `--download-only` pool worker relies on to keep the
+// warm fast path zero-I/O.
 test "downloadBottleToStore returns false when the store already holds the bottle" {
     var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
     defer threaded.deinit();

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -768,10 +768,14 @@ fn upgradeFormula(
         }
     }
 
+    // Release the old bytes first, then reconcile the new: when both versions
+    // share a bottle sha, a decrement applied afterwards would zero an entry
+    // the fresh keg still holds. refcount is advisory; upgrade is already
+    // complete on disk.
     if (old.sha256.len > 0) {
-        // refcount is advisory; upgrade is already complete on disk.
         store.decrementRef(old.sha256) catch {};
     }
+    store.syncRef(fetch.sha256) catch {};
 
     // Same post-install contract as `mt install`: the fresh keg's hook
     // (declarative steps or Ruby body) runs against the new version, and

--- a/src/core/store.zig
+++ b/src/core/store.zig
@@ -99,6 +99,26 @@ pub const Store = struct {
         _ = stmt.step() catch return StoreError.RefCountError;
     }
 
+    /// Reconcile a store entry's refcount with the `kegs` rows that hold it.
+    /// Idempotent, so a forced reinstall (which replaces a `kegs` row rather
+    /// than adding one) cannot drift the counter the way an increment would.
+    /// Shares `incrementRef`'s key ingress check.
+    pub fn syncRef(self: *Store, sha256: []const u8) StoreError!void {
+        var buf: [store_path.entry_buf_len]u8 = undefined;
+        _ = try store_path.entry(&buf, self.prefix, sha256);
+
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+        var stmt = self.db.prepare(
+            "INSERT INTO store_refs (store_sha256, refcount)" ++
+                " VALUES (?1, (SELECT count(*) FROM kegs WHERE store_sha256 = ?1))" ++
+                " ON CONFLICT(store_sha256) DO UPDATE SET refcount = excluded.refcount;",
+        ) catch return StoreError.RefCountError;
+        defer stmt.finalize();
+        stmt.bindText(1, sha256) catch return StoreError.RefCountError;
+        _ = stmt.step() catch return StoreError.RefCountError;
+    }
+
     pub fn decrementRef(self: *Store, sha256: []const u8) StoreError!void {
         self.mutex.lockUncancelable(self.io);
         defer self.mutex.unlock(self.io);
@@ -110,7 +130,9 @@ pub const Store = struct {
         _ = stmt.step() catch return StoreError.RefCountError;
     }
 
-    /// Find store entries with refcount == 0.
+    /// Find reclaimable store entries. `kegs`, not the counter, is the
+    /// authority on whether the bytes are still owned: the counter can
+    /// under-count a live keg.
     pub fn orphans(self: *Store) StoreError!std.ArrayList([]const u8) {
         var list: std.ArrayList([]const u8) = .empty;
         errdefer {
@@ -118,7 +140,8 @@ pub const Store = struct {
             list.deinit(self.allocator);
         }
         var stmt = self.db.prepare(
-            "SELECT store_sha256 FROM store_refs WHERE refcount <= 0;",
+            "SELECT store_sha256 FROM store_refs WHERE refcount <= 0" ++
+                " AND NOT EXISTS (SELECT 1 FROM kegs WHERE kegs.store_sha256 = store_refs.store_sha256);",
         ) catch return StoreError.RefCountError;
         defer stmt.finalize();
 
@@ -207,4 +230,98 @@ test "orphans returns exactly the refcount-zero rows and skips referenced rows" 
         list.deinit(testing.allocator);
     }
     try testing.expectEqual(@as(usize, 2), list.items.len);
+}
+
+test "orphans excludes an entry a live keg still holds, whatever the counter says" {
+    var db = try openSchemaDb();
+    defer db.close();
+    try db.exec("INSERT INTO store_refs (store_sha256, refcount) VALUES ('loose', 0), ('held', 0);");
+    try db.exec(
+        "INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path)" ++
+            " VALUES ('probe', 'probe', '1.0', 'held', '/prefix/Cellar/probe/1.0');",
+    );
+
+    var store = Store.init(std.Options.debug_io, testing.allocator, &db, "");
+    var list = try store.orphans();
+    defer {
+        for (list.items) |item| testing.allocator.free(item);
+        list.deinit(testing.allocator);
+    }
+    try testing.expectEqual(@as(usize, 1), list.items.len);
+    try testing.expectEqualStrings("loose", list.items[0]);
+}
+
+fn refcountOf(db: *sqlite.Database, sha: []const u8) !?i64 {
+    var stmt = try db.prepare("SELECT refcount FROM store_refs WHERE store_sha256 = ?1;");
+    defer stmt.finalize();
+    try stmt.bindText(1, sha);
+    if (!try stmt.step()) return null;
+    return stmt.columnInt(0);
+}
+
+test "syncRef reconciles the counter with the kegs rows and stays idempotent" {
+    var db = try openSchemaDb();
+    defer db.close();
+    const sha = "a" ** 64;
+
+    var store = Store.init(std.Options.debug_io, testing.allocator, &db, "/prefix");
+
+    // Warm materialize after an uninstall: the row already sits at 0 while a
+    // keg holds the bytes, so the sync must lift it back to 1.
+    try db.exec("INSERT INTO store_refs (store_sha256, refcount) VALUES ('" ++ sha ++ "', 0);");
+    try db.exec(
+        "INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path)" ++
+            " VALUES ('probe', 'probe', '1.0', '" ++ sha ++ "', '/prefix/Cellar/probe/1.0');",
+    );
+    try store.syncRef(sha);
+    try testing.expectEqual(@as(?i64, 1), try refcountOf(&db, sha));
+
+    // `--force` replaces the keg row rather than adding one: an increment
+    // would drift up here, a reconcile must not.
+    try store.syncRef(sha);
+    try testing.expectEqual(@as(?i64, 1), try refcountOf(&db, sha));
+}
+
+test "syncRef on a bottle no keg holds leaves the entry reclaimable" {
+    var db = try openSchemaDb();
+    defer db.close();
+    const sha = "b" ** 64;
+
+    var store = Store.init(std.Options.debug_io, testing.allocator, &db, "/prefix");
+    try store.syncRef(sha);
+    try testing.expectEqual(@as(?i64, 0), try refcountOf(&db, sha));
+}
+
+test "syncRef refuses a key a store path could never name" {
+    var db = try openSchemaDb();
+    defer db.close();
+
+    var store = Store.init(std.Options.debug_io, testing.allocator, &db, "/prefix");
+    try testing.expectError(StoreError.InvalidSha256, store.syncRef("not-hex"));
+    try testing.expectError(StoreError.InvalidSha256, store.syncRef(""));
+    try testing.expectError(StoreError.InvalidSha256, store.syncRef("A" ** 64));
+    // Refused at birth means no row was created either.
+    try testing.expectEqual(@as(?i64, null), try refcountOf(&db, "not-hex"));
+}
+
+test "syncRef restores the true count after a decrement against the same key" {
+    // Upgrade releases the old bottle then reconciles the new one. When both
+    // versions carry the same sha those are the same key, so the reconcile has
+    // to be able to undo the decrement — otherwise the fresh keg's entry is
+    // left at 0.
+    var db = try openSchemaDb();
+    defer db.close();
+    const sha = "c" ** 64;
+
+    var store = Store.init(std.Options.debug_io, testing.allocator, &db, "/prefix");
+    try db.exec(
+        "INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path)" ++
+            " VALUES ('probe', 'probe', '2.0', '" ++ sha ++ "', '/prefix/Cellar/probe/2.0');",
+    );
+    try store.syncRef(sha);
+    try store.decrementRef(sha);
+    try testing.expectEqual(@as(?i64, 0), try refcountOf(&db, sha));
+
+    try store.syncRef(sha);
+    try testing.expectEqual(@as(?i64, 1), try refcountOf(&db, sha));
 }

--- a/tests/doctor_fix_test.zig
+++ b/tests/doctor_fix_test.zig
@@ -714,6 +714,62 @@ test "fixOrphanedStore: a stranded reap dir does not block reaping a fresh same-
     try testing.expectEqual(@as(u32, 0), fix.probeOrphanedStoreCount(io, prefix));
 }
 
+test "orphan parity: an entry a live keg holds is invisible to both doctor and purge" {
+    // The shape a warm materialize after an uninstall leaves behind: the
+    // counter is back at 0 but a `kegs` row still holds the bytes. Reaping it
+    // costs the user a re-download of a package they have installed, so both
+    // the sweep and the probe must consult `kegs`, not just the counter.
+    var prefix_buf: [128]u8 = undefined;
+    const prefix = try makePrefix(&prefix_buf, "heldkeg");
+    defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    var db_dir_buf: [256]u8 = undefined;
+    const db_dir = try std.fmt.bufPrint(&db_dir_buf, "{s}/db", .{prefix});
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, db_dir);
+
+    var store_dir_buf: [256]u8 = undefined;
+    const store_dir = try std.fmt.bufPrint(&store_dir_buf, "{s}/store", .{prefix});
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, store_dir);
+
+    var db_path_buf: [256]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    try schema.initSchema(&db);
+
+    const sha = "cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe";
+    var entry_dir_buf: [320]u8 = undefined;
+    const entry_dir = try std.fmt.bufPrint(&entry_dir_buf, "{s}/store/{s}", .{ prefix, sha });
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, entry_dir);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var store = store_mod.Store.init(io, testing.allocator, &db, prefix);
+    try store.incrementRef(sha); // cold install
+    try store.decrementRef(sha); // uninstall drops the counter, keeps the bytes
+    try db.exec(
+        "INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path)" ++
+            " VALUES ('probe', 'probe', '1.0', '" ++ sha ++ "', '/probe/Cellar/probe/1.0');",
+    );
+
+    // Remediation side: purge enumerates nothing.
+    var orphans = try store.orphans();
+    defer {
+        for (orphans.items) |item| testing.allocator.free(item);
+        orphans.deinit(testing.allocator);
+    }
+    try testing.expectEqual(@as(usize, 0), orphans.items.len);
+
+    // Detection side (shared by `--fix` and the inline doctor check) agrees,
+    // and the sweep leaves the bytes alone.
+    try testing.expectEqual(@as(u32, 0), fix.probeOrphanedStoreCount(io, prefix));
+    const sweep = fix.fixOrphanedStore(io, prefix);
+    try testing.expectEqual(@as(u32, 0), sweep.count);
+    try testing.expect(pathExists(entry_dir));
+}
+
 test "orphan parity: a no-row store entry is invisible to both doctor and purge" {
     // A store dir with no `store_refs` row is a warm / in-flight commit
     // (`--download-only`, or an install interrupted before `incrementRef`).


### PR DESCRIPTION
## Description

Reinstalling a package you had previously uninstalled left its bottle bytes marked unreferenced, so the next `mt purge --store-orphans` or `mt doctor --fix` deleted them out from under the live keg. Nothing was lost - the keg is a copy, not a link - but a maintenance command reclaimed bytes a working install owned, and the next install of that version had to re-download.

The store now treats an installed keg, not the counter, as proof the bytes are owned, and the counter itself is claimed when the keg is recorded rather than when a download happens. Unreferenced entries are still reclaimed and prefetched bytes are still left alone.

## Related Issue

- None

## Notes for Reviewers

- None