### PR TITLE
fix(migrate): stop a blocked migrate from claiming store bytes on every retry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,9 @@ jobs:
       - name: Regression guard - store entries held by a live keg
         run: ./scripts/regressions/store-refcount-moment-does-not-match-a-reference.sh
 
+      - name: Regression guard - blocked migrate claims no store bytes
+        run: ./scripts/regressions/migrate-bump-precedes-materialize-961-follow-up.sh
+
       - name: Regression guard - doctor survives a relative keg path
         run: ./scripts/regressions/doctor-survives-a-relative-keg-path.sh
 

--- a/build.zig
+++ b/build.zig
@@ -278,6 +278,7 @@ pub fn build(b: *std.Build) void {
         "tests/bottle_test.zig",
         "tests/cleanup_cli_test.zig",
         "tests/install_keg_from_bottle_test.zig",
+        "tests/migrate_keg_refcount_test.zig",
         "tests/install_pool_test.zig",
         "tests/tap_head_etag_integration_test.zig",
         "tests/tap_raw_rb_auth_test.zig",

--- a/scripts/regressions/migrate-bump-precedes-materialize-961-follow-up.sh
+++ b/scripts/regressions/migrate-bump-precedes-materialize-961-follow-up.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Regression: a blocked `migrate` must not claim store bytes.
+#
+# `migrateKeg` bumped the store refcount before materialising the keg,
+# and nothing decremented it when materialise refused. Retrying a
+# blocked migrate therefore left `store_refs.refcount = N` with no
+# `kegs` row to match — and since every reclaim path (`Store.orphans`,
+# `doctor --fix`) treats `refcount <= 0` as the only reclaimable state,
+# those bytes were pinned for the life of the prefix.
+#
+# Fully offline: a warm store and a seeded API cache keep the run off
+# the network, and a symlinked package dir forces a repeatable refusal.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+if [[ ! -x "$BIN" ]] && ! zig build >/dev/null 2>&1; then
+  echo "FAIL: could not build zig-out/bin/malt" >&2
+  exit 1
+fi
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+# `pwd -P` normalizes the trailing slash TMPDIR may carry: MALT_PREFIX
+# refuses a path with an empty component.
+tmp="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$tmp"' EXIT
+
+prefix="$tmp/prefix"
+brew="$tmp/brew"
+sha="feed$(printf '0%.0s' $(seq 1 60))"
+
+mkdir -p "$prefix"/{store,Cellar,Caskroom,opt,bin,lib,tmp,cache,db} \
+  "$prefix/store/$sha/planted/1.0" "$prefix/cache/api" \
+  "$brew/Cellar/planted/1.0" "$tmp/victim"
+echo warm >"$prefix/store/$sha/planted/1.0/README"
+
+cat >"$prefix/cache/api/formula_planted.json" <<EOF
+{"name":"planted","full_name":"planted","tap":"homebrew/core","desc":"","homepage":"",
+ "versions":{"stable":"1.0"},"revision":0,"dependencies":[],"keg_only":false,
+ "post_install_defined":false,"oldnames":[],
+ "bottle":{"stable":{"files":{"all":{"cellar":":any",
+   "url":"https://ghcr.io/v2/homebrew/core/planted/blobs/sha256:$sha","sha256":"$sha"}}}}}
+EOF
+
+# Planting the package dir as a symlink out of the prefix is the
+# cheapest way to make materialise refuse the same way every run.
+ln -s "$tmp/victim" "$prefix/Cellar/planted"
+
+export MALT_PREFIX="$prefix" HOMEBREW_PREFIX="$brew" NO_COLOR=1 MALT_NO_EMOJI=1 MALT_OFFLINE=1
+
+for _ in 1 2 3; do
+  "$BIN" migrate >"$tmp/run.txt" 2>&1 || true
+done
+
+grep -q 'failed to materialize' "$tmp/run.txt" ||
+  fail "migrate did not reach the cellar refusal — the fixture no longer exercises the bug"
+
+n=$(sqlite3 "$prefix/db/malt.db" \
+  "SELECT COALESCE(SUM(refcount),0) FROM store_refs WHERE store_sha256='$sha';")
+[[ "$n" == "0" ]] ||
+  fail "three blocked migrate runs claimed refcount=$n for a keg that was never created"
+
+echo "PASS: a blocked migrate claims no store bytes, however often it is retried"

--- a/src/cli/migrate/keg.zig
+++ b/src/cli/migrate/keg.zig
@@ -150,10 +150,6 @@ pub fn migrateKeg(
         output.emitNdjsonEvent(.stored, keg_name, "ok");
     }
 
-    // Serialise the refcount bump on the shared connection's write lock
-    // before materialise (the expensive step stays parallel, lock-free).
-    incrementRefLocked(ctx.io, deps.store, deps.db_mu, bottle.sha256, keg_name);
-
     // Same bottle path as a fresh install, so it needs the same
     // dependency-scoped placeholder resolution.
     var placeholder_buf: [512]u8 = undefined;
@@ -226,6 +222,13 @@ pub fn migrateKeg(
         };
         recordDeps(deps.db, keg_id, &formula);
     }
+
+    // Claim only once a keg row references the bytes: bumping before
+    // materialise strands one claim per failed retry, and nothing can
+    // reclaim it. `db_mu` is already held here and is not recursive.
+    deps.store.incrementRef(bottle.sha256) catch |e| {
+        std.log.warn("refcount increment failed for {s}: {s}", .{ keg_name, @errorName(e) });
+    };
 
     if (formula.hasPostInstallHook()) {
         if (deps.post_install_queue) |q| {
@@ -638,7 +641,8 @@ fn releaseDbMuForOomFallback(io: std.Io, db_mu: ?*std.Io.Mutex) bool {
 /// worker's connection-global `last_insert_rowid()` read, handing the
 /// peer a foreign rowid. Taking `db_mu` makes it the single
 /// connection-wide write lock so no insert escapes it. Serial callers
-/// pass `db_mu == null` and pay no lock cost.
+/// pass `db_mu == null` and pay no lock cost. Not recursive: callers
+/// already holding `db_mu` must call `store.incrementRef` directly.
 fn incrementRefLocked(
     io: std.Io,
     store: *store_mod.Store,
@@ -966,9 +970,10 @@ test "releaseDbMuForOomFallback is a no-op on the serial path (db_mu null)" {
 // hammer `incrementRef` while one worker records kegs. Because
 // `last_insert_rowid()` is connection-global, an unguarded refcount
 // insert landing between a worker's `INSERT INTO kegs` and its rowid read
-// hands the worker a foreign keg_id. The fix routes the bump through
-// `incrementRefLocked` so it serialises on `db_mu`; with that lock no
-// connection write escapes and every keg_id resolves to its own row.
+// hands the worker a foreign keg_id. Holding `db_mu` over the bump is what
+// closes it — `migrateKeg` now bumps inside the region it already holds,
+// and `incrementRefLocked` gives callers outside that region the same
+// guarantee.
 test "incrementRef under db_mu keeps each worker's keg_id bound to its own kegs row" {
     const schema = @import("../../db/schema.zig");
 

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -23,6 +23,7 @@ pub const install_sink = @import("cli/install/sink.zig");
 pub const cli_link = @import("cli/link.zig");
 pub const cli_list = @import("cli/list.zig");
 pub const cli_migrate = @import("cli/migrate.zig");
+pub const cli_migrate_keg = @import("cli/migrate/keg.zig");
 pub const cli_migrate_manifest = @import("cli/migrate/manifest.zig");
 pub const cli_migrate_outcomes = @import("cli/migrate/outcomes.zig");
 pub const cli_migrate_parallel = @import("cli/migrate/parallel.zig");

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -75,6 +75,7 @@ comptime {
     _ = @import("install_idempotent_test.zig");
     _ = @import("install_isolation_test.zig");
     _ = @import("install_keg_from_bottle_test.zig");
+    _ = @import("migrate_keg_refcount_test.zig");
     _ = @import("install_local_test.zig");
     _ = @import("install_parse_cache_test.zig");
     _ = @import("install_pool_test.zig");

--- a/tests/migrate_keg_refcount_test.zig
+++ b/tests/migrate_keg_refcount_test.zig
@@ -1,0 +1,293 @@
+//! Integration tests for the store claim `cli/migrate/keg.zig::migrateKeg`
+//! takes. The refcount is what keeps a bottle's bytes out of every reclaim
+//! path, so it may only be bumped once a `kegs` row actually references
+//! them — otherwise a retried, blocked migrate pins those bytes forever.
+
+const std = @import("std");
+const malt = @import("malt");
+const test_io = @import("test_io");
+const testing = std.testing;
+const sqlite = malt.sqlite;
+const schema = malt.schema;
+const migrate_keg = malt.cli_migrate_keg;
+
+/// 64 lowercase hex, or the bottle entry is dropped by the parser.
+const sha = "feed" ** 16;
+
+const Fixture = struct {
+    prefix: []const u8,
+    cache_dir: []const u8,
+    brew_prefix: []const u8,
+
+    /// Per-test unique paths: on a shared fixture dir, concurrent runs
+    /// wipe each other's seeded cache and fall through to the network.
+    fn init(tag: []const u8) !Fixture {
+        const prefix = try test_io.uniqueTempPath(testing.allocator, "migratekegref", tag);
+        errdefer testing.allocator.free(prefix);
+        test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+        inline for (.{ "store", "Cellar", "opt", "bin", "lib", "cache/api" }) |sub| {
+            const dir = try std.fmt.allocPrint(testing.allocator, "{s}/{s}", .{ prefix, sub });
+            defer testing.allocator.free(dir);
+            try test_io.cwd().createDirPath(std.Options.debug_io, dir);
+        }
+
+        const cache_dir = try std.fmt.allocPrint(testing.allocator, "{s}/cache", .{prefix});
+        errdefer testing.allocator.free(cache_dir);
+        const brew_prefix = try std.fmt.allocPrint(testing.allocator, "{s}/brew", .{prefix});
+        errdefer testing.allocator.free(brew_prefix);
+
+        return .{ .prefix = prefix, .cache_dir = cache_dir, .brew_prefix = brew_prefix };
+    }
+
+    fn deinit(self: *Fixture) void {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, self.prefix) catch {};
+        testing.allocator.free(self.brew_prefix);
+        testing.allocator.free(self.cache_dir);
+        testing.allocator.free(self.prefix);
+    }
+
+    /// Warm store + cached formula: `migrateKeg` then reaches materialise
+    /// without touching the network.
+    fn seed(self: *const Fixture, name: []const u8, keg_only: bool) !void {
+        const inner = try std.fmt.allocPrint(
+            testing.allocator,
+            "{s}/store/{s}/{s}/1.0",
+            .{ self.prefix, sha, name },
+        );
+        defer testing.allocator.free(inner);
+        try test_io.cwd().createDirPath(std.Options.debug_io, inner);
+        try self.writeFile(inner, "README", "warm store probe\n");
+
+        const json = try std.fmt.allocPrint(testing.allocator,
+            \\{{"name":"{s}","full_name":"{s}","tap":"homebrew/core","desc":"","homepage":"",
+            \\ "versions":{{"stable":"1.0"}},"revision":0,"dependencies":[],"keg_only":{},
+            \\ "post_install_defined":false,"oldnames":[],
+            \\ "bottle":{{"stable":{{"files":{{"all":{{"cellar":":any",
+            \\   "url":"https://ghcr.io/v2/homebrew/core/{s}/blobs/sha256:{s}","sha256":"{s}"}}}}}}}}}}
+        , .{ name, name, keg_only, name, sha, sha });
+        defer testing.allocator.free(json);
+
+        const api_dir = try std.fmt.allocPrint(testing.allocator, "{s}/api", .{self.cache_dir});
+        defer testing.allocator.free(api_dir);
+        const filename = try std.fmt.allocPrint(testing.allocator, "formula_{s}.json", .{name});
+        defer testing.allocator.free(filename);
+        try self.writeFile(api_dir, filename, json);
+    }
+
+    fn writeFile(_: *const Fixture, dir: []const u8, name: []const u8, body: []const u8) !void {
+        const path = try std.fmt.allocPrint(testing.allocator, "{s}/{s}", .{ dir, name });
+        defer testing.allocator.free(path);
+        const f = try test_io.cwd().createFile(std.Options.debug_io, path, .{});
+        defer f.close(std.Options.debug_io);
+        try f.writeStreamingAll(std.Options.debug_io, body);
+    }
+};
+
+/// A symlinked package dir is the cheapest deterministic materialise refusal.
+fn plantSymlinkedPackageDir(io: std.Io, prefix: []const u8, name: []const u8) !void {
+    const victim = try std.fmt.allocPrint(testing.allocator, "{s}/victim", .{prefix});
+    defer testing.allocator.free(victim);
+    try test_io.cwd().createDirPath(io, victim);
+    const pkg_dir = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/{s}", .{ prefix, name });
+    defer testing.allocator.free(pkg_dir);
+    try test_io.symLinkAbsolute(io, victim, pkg_dir, .{ .is_directory = true });
+}
+
+fn claimedRefs(db: *sqlite.Database) !i64 {
+    var stmt = try db.prepare(
+        "SELECT COALESCE(SUM(refcount), 0) FROM store_refs WHERE store_sha256 = ?1;",
+    );
+    defer stmt.finalize();
+    try stmt.bindText(1, sha);
+    _ = try stmt.step();
+    return stmt.columnInt(0);
+}
+
+fn kegRows(db: *sqlite.Database) !i64 {
+    var stmt = try db.prepare("SELECT count(*) FROM kegs;");
+    defer stmt.finalize();
+    _ = try stmt.step();
+    return stmt.columnInt(0);
+}
+
+const Harness = struct {
+    /// `migrateKeg` frees the formula JSON its `BrewApi` allocated and
+    /// leaves the returned keg path to the caller's allocator, so both
+    /// share one arena here — as they share one allocator in production.
+    arena: std.heap.ArenaAllocator,
+    threaded: std.Io.Threaded,
+    http: malt.client.HttpClient,
+    ghcr: malt.ghcr.GhcrClient,
+    api: malt.api.BrewApi,
+    db: sqlite.Database,
+    store: malt.store.Store,
+    linker: malt.linker.Linker,
+
+    fn ctx(self: *Harness) malt.app_ctx.AppCtx {
+        return .{ .io = self.threaded.io(), .environ = .empty };
+    }
+
+    /// `db_mu` non-null is the `--parallel` shape: the worker lock is
+    /// taken around the record + claim region.
+    fn parallelDeps(self: *Harness, fx: *const Fixture, mu: *std.Io.Mutex) migrate_keg.MigrateDeps {
+        var d = self.deps(fx);
+        d.db_mu = mu;
+        return d;
+    }
+
+    fn deps(self: *Harness, fx: *const Fixture) migrate_keg.MigrateDeps {
+        return .{
+            .api = &self.api,
+            .ghcr = &self.ghcr,
+            .http = &self.http,
+            .store = &self.store,
+            .linker = &self.linker,
+            .db = &self.db,
+            .prefix = fx.prefix,
+            .homebrew_prefix = fx.brew_prefix,
+            .use_system_ruby_scope = &.{},
+        };
+    }
+
+    fn deinit(self: *Harness) void {
+        self.ghcr.deinit();
+        self.http.deinit();
+        self.db.close();
+        self.threaded.deinit();
+        self.arena.deinit();
+    }
+};
+
+/// `Harness` self-references through pointers, so it has to be filled in
+/// place rather than returned by value.
+fn initHarness(h: *Harness, fx: *const Fixture) !void {
+    h.arena = std.heap.ArenaAllocator.init(testing.allocator);
+    h.threaded = .init(testing.allocator, .{});
+    const io = h.threaded.io();
+    h.http = malt.client.HttpClient.init(io, .empty, testing.allocator);
+    h.ghcr = malt.ghcr.GhcrClient.init(io, testing.allocator, &h.http);
+    h.api = malt.api.BrewApi.init(io, h.arena.allocator(), &h.http, fx.cache_dir);
+    h.db = try sqlite.Database.open(":memory:");
+    try schema.initSchema(&h.db);
+    h.store = malt.store.Store.init(io, testing.allocator, &h.db, fx.prefix);
+    h.linker = malt.linker.Linker.init(io, testing.allocator, &h.db, fx.prefix);
+}
+
+test "a refused migrate claims no store bytes, however often it is retried" {
+    var fx = try Fixture.init("refused");
+    defer fx.deinit();
+    try fx.seed("planted", false);
+
+    var h: Harness = undefined;
+    try initHarness(&h, &fx);
+    defer h.deinit();
+
+    try plantSymlinkedPackageDir(h.threaded.io(), fx.prefix, "planted");
+
+    const ctx = h.ctx();
+    const deps = h.deps(&fx);
+    // Three attempts: one stranded bump is a bug, three is the inflation
+    // that no reclaim path can ever drain.
+    for (0..3) |_| {
+        try testing.expectEqual(
+            migrate_keg.KegResult.failed_install,
+            migrate_keg.migrateKeg(&ctx, h.arena.allocator(), "planted", deps),
+        );
+    }
+
+    try testing.expectEqual(@as(i64, 0), try kegRows(&h.db));
+    try testing.expectEqual(@as(i64, 0), try claimedRefs(&h.db));
+}
+
+test "a successful migrate claims the bottle exactly once" {
+    var fx = try Fixture.init("ok");
+    defer fx.deinit();
+    try fx.seed("planted", false);
+
+    var h: Harness = undefined;
+    try initHarness(&h, &fx);
+    defer h.deinit();
+
+    const ctx = h.ctx();
+    const deps = h.deps(&fx);
+    try testing.expectEqual(
+        migrate_keg.KegResult.migrated,
+        migrate_keg.migrateKeg(&ctx, h.arena.allocator(), "planted", deps),
+    );
+
+    try testing.expectEqual(@as(i64, 1), try kegRows(&h.db));
+    try testing.expectEqual(@as(i64, 1), try claimedRefs(&h.db));
+}
+
+test "re-migrating an installed keg does not claim the bottle a second time" {
+    var fx = try Fixture.init("again");
+    defer fx.deinit();
+    try fx.seed("planted", false);
+
+    var h: Harness = undefined;
+    try initHarness(&h, &fx);
+    defer h.deinit();
+
+    const ctx = h.ctx();
+    const deps = h.deps(&fx);
+    try testing.expectEqual(
+        migrate_keg.KegResult.migrated,
+        migrate_keg.migrateKeg(&ctx, h.arena.allocator(), "planted", deps),
+    );
+    try testing.expectEqual(
+        migrate_keg.KegResult.skipped_installed,
+        migrate_keg.migrateKeg(&ctx, h.arena.allocator(), "planted", deps),
+    );
+
+    try testing.expectEqual(@as(i64, 1), try claimedRefs(&h.db));
+}
+
+// The claim sits after both record branches; moving it inside the linked
+// one would leave keg-only bottles unclaimed and reclaimable while live.
+test "a keg-only migrate claims the bottle exactly once" {
+    var fx = try Fixture.init("kegonly");
+    defer fx.deinit();
+    try fx.seed("planted", true);
+
+    var h: Harness = undefined;
+    try initHarness(&h, &fx);
+    defer h.deinit();
+
+    const ctx = h.ctx();
+    const deps = h.deps(&fx);
+    try testing.expectEqual(
+        migrate_keg.KegResult.migrated,
+        migrate_keg.migrateKeg(&ctx, h.arena.allocator(), "planted", deps),
+    );
+
+    try testing.expectEqual(@as(i64, 1), try kegRows(&h.db));
+    try testing.expectEqual(@as(i64, 1), try claimedRefs(&h.db));
+}
+
+// `std.Io.Mutex` is not recursive, so routing the claim back through
+// `incrementRefLocked` here would hang every worker rather than fail a
+// check. This drives the locked shape end to end so that never ships.
+test "a parallel-shaped migrate claims once without re-taking the worker lock" {
+    var fx = try Fixture.init("parallel");
+    defer fx.deinit();
+    try fx.seed("planted", false);
+
+    var h: Harness = undefined;
+    try initHarness(&h, &fx);
+    defer h.deinit();
+
+    var db_mu: std.Io.Mutex = .init;
+    const ctx = h.ctx();
+    const deps = h.parallelDeps(&fx, &db_mu);
+    try testing.expectEqual(
+        migrate_keg.KegResult.migrated,
+        migrate_keg.migrateKeg(&ctx, h.arena.allocator(), "planted", deps),
+    );
+
+    // Released, not still held by the run that just finished.
+    try testing.expect(db_mu.tryLock());
+    db_mu.unlock(h.threaded.io());
+
+    try testing.expectEqual(@as(i64, 1), try claimedRefs(&h.db));
+}


### PR DESCRIPTION
## Description

`migrate` claimed a bottle's store bytes before it had a keg to give them to,
so a migration blocked at materialise left the claim behind - once per retry.
malt only reclaims store entries whose refcount has drained to zero, so those
bytes stayed pinned for the life of the prefix, invisible to both
`purge --store-orphans` and `doctor --fix`. The claim now happens once the keg
row exists, so it always pairs with a real holder.

## Related Issue

Closes #961

## Notes for Reviewers

- `incrementRefLocked` is left without a production caller: the new site
  already holds `db_mu`, which is not recursive. It and its tests stay as the
  contract for any caller outside that region.