### PR TITLE
fix(migrate): stop the Cellar scan instead of retrying a wedged disk forever

### DIFF
--- a/scripts/regressions/cellar-scan-error-cap-cellar-scan-spins-on-failing-directory-iterator.sh
+++ b/scripts/regressions/cellar-scan-error-cap-cellar-scan-spins-on-failing-directory-iterator.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Regression: a Cellar scan that hits a wedged directory read must stop.
+#
+# `std.Io.Dir.Iterator` gives no forward-progress guarantee when `next`
+# fails, so an errno that reproduces on every call used to turn the scan
+# into an unbounded retry loop. No `malt` subcommand can present that
+# fault, so the guard judges the colocated integration tests instead.
+#
+# A reintroduced spin does not fail the suite, it stops returning — so
+# the timeout arm (rc 124) is itself a regression signal.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+SRC="$ROOT/tests/migrate_smoke_test.zig"
+
+FILTERS=(
+  "scanCellarKegs aborts instead of spinning on a non-advancing iterator error"
+  "scanCellarKegs tolerates consecutive errors below the cap"
+  "scanCellarKegs resets its error budget after a successful read"
+  "scanCellarKegs keeps the names gathered before the abort"
+)
+
+for F in "${FILTERS[@]}"; do
+  grep -qs -- "$F" "$SRC" || {
+    echo "FAIL: guard test missing: $F" >&2
+    exit 1
+  }
+done
+
+# Build fresh: a stale binary from an earlier run cannot carry the guard.
+(cd "$ROOT" && zig build test-bin >/dev/null 2>&1) ||
+  {
+    echo "FAIL: could not build test binaries (zig build test-bin)" >&2
+    exit 1
+  }
+
+set +e
+OUT=$(timeout 120 "$ROOT/zig-out/test-bin/migrate_smoke_test" 2>&1)
+RC=$?
+set -e
+[[ $RC -eq 124 ]] && {
+  echo "FAIL: migrate_smoke_test did not finish - the Cellar scan spins on iterator error again" >&2
+  exit 1
+}
+# Any other failure in this binary is a regression too - the per-test
+# checks below only see the guards, not a break elsewhere in the suite.
+[[ $RC -ne 0 ]] && {
+  echo "FAIL: migrate_smoke_test exited $RC" >&2
+  printf '%s\n' "$OUT" | grep -E "FAIL|error:" | head -5 >&2
+  exit 1
+}
+
+for F in "${FILTERS[@]}"; do
+  LINE=$(printf '%s\n' "$OUT" | grep -F -- "$F" || true)
+  [[ -z "$LINE" ]] && {
+    echo "FAIL: guard test did not run: $F" >&2
+    exit 1
+  }
+  [[ "$LINE" != *OK ]] && {
+    echo "FAIL: Cellar scan error handling regressed: $F" >&2
+    exit 1
+  }
+done
+
+echo "PASS: Cellar scan aborts on a non-advancing iterator error"
+exit 0

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -56,6 +56,10 @@ fn lockTimeoutMs(ctx: *const AppCtx) u32 {
     return 30_000;
 }
 
+/// `std.Io` promises no forward progress when `Dir.Iterator.next` fails,
+/// so a persistent errno would be retried forever. Bound the retries.
+pub const max_consecutive_scan_errors: usize = 16;
+
 /// Arena-own Cellar names and log + skip iterator errors instead of
 /// truncating the scan — `iter.next() catch null` used to hide every
 /// later keg behind the first bad entry. `anytype` for mock iterators
@@ -68,11 +72,20 @@ pub fn scanCellarKegs(
     dir: anytype,
     names: *std.ArrayList([]const u8),
 ) !void {
+    var consecutive_errors: usize = 0;
     while (true) {
         const entry = iter.next(io) catch |err| {
+            consecutive_errors += 1;
+            if (consecutive_errors >= max_consecutive_scan_errors) {
+                output.err("Cellar scan aborted after {d} consecutive read errors: {s}", .{ consecutive_errors, @errorName(err) });
+                return error.Aborted;
+            }
             output.warn("Cellar scan error: {s}; skipping entry, kept {d} so far", .{ @errorName(err), names.items.len });
             continue;
         } orelse break;
+        // Consecutive, not cumulative: scattered bad entries must not
+        // abort a Cellar the scan can still walk to the end.
+        consecutive_errors = 0;
         const accept = switch (entry.kind) {
             .directory => true,
             // Resolve the symlink target; dangling or non-dir links

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -684,3 +684,11 @@ fn ensureDirs(ctx: *const AppCtx, prefix: []const u8) !void {
         };
     }
 }
+
+const testing = std.testing;
+
+test "the scan error budget leaves room for transient failures" {
+    // A cap of 1 would abort on the first bad entry — exactly the
+    // truncating behaviour the log-and-skip arm exists to prevent.
+    try testing.expect(max_consecutive_scan_errors > 1);
+}

--- a/tests/migrate_smoke_test.zig
+++ b/tests/migrate_smoke_test.zig
@@ -1355,15 +1355,32 @@ const MockIter = struct {
     entries: []const MockDirEntry,
     idx: usize = 0,
     fail_after: ?usize = null,
+    /// Per-entry count of consecutive failures to emit before that entry
+    /// is yielded — a transient fault the iterator recovers from.
+    bursts: []const usize = &.{},
+    burst_done: usize = 0,
+    /// Fail at this index forever without advancing. Separate from
+    /// `fail_after`, whose advancing is load-bearing for the tests above.
+    stuck_at: ?usize = null,
+    calls: usize = 0,
 
     pub fn next(self: *MockIter, io: std.Io) !?MockDirEntry {
         _ = io;
+        self.calls += 1;
+        if (self.idx < self.bursts.len and self.burst_done < self.bursts[self.idx]) {
+            self.burst_done += 1;
+            return error.AccessDenied;
+        }
+        if (self.stuck_at) |n| if (self.idx == n) return error.Unexpected;
         if (self.fail_after) |n| if (self.idx == n) {
             self.idx += 1;
             return error.AccessDenied;
         };
         if (self.idx >= self.entries.len) return null;
-        defer self.idx += 1;
+        defer {
+            self.idx += 1;
+            self.burst_done = 0;
+        }
         return self.entries[self.idx];
     }
 };
@@ -1459,6 +1476,135 @@ test "scanCellarKegs continues past a mid-scan iterator error" {
     try testing.expectEqualStrings("tree", names.items[0]);
     try testing.expectEqualStrings("ffmpeg", names.items[1]);
     try testing.expect(containsLine(buf.items, "Cellar scan error"));
+}
+
+// ── Iterator-error surface: the skip arm is bounded ───────────────────
+//
+// Log-and-skip only terminates if the iterator advances, and `std.Io`
+// makes no such promise: a read that fails the same way every time
+// leaves the cursor untouched, so the scan would retry it forever.
+
+test "scanCellarKegs aborts instead of spinning on a non-advancing iterator error" {
+    resetOutput();
+    color.setForTest(false, false);
+    defer color.setForTest(null, null);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    var names: std.ArrayList([]const u8) = .empty;
+    var mock = MockIter{
+        .entries = &.{.{ .name = "tree", .kind = .directory }},
+        .stuck_at = 0, // wedged before the first entry is ever read
+    };
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    io_mod.beginStderrCapture(testing.allocator, &buf);
+    defer io_mod.endStderrCapture();
+
+    try testing.expectError(
+        error.Aborted,
+        migrate.scanCellarKegs(std.Options.debug_io, arena.allocator(), &mock, MockDir{}, &names),
+    );
+    // Returning at all is the termination proof; the call count pins the
+    // bound so a wedged device is detected in a handful of syscalls.
+    try testing.expectEqual(migrate.max_consecutive_scan_errors, mock.calls);
+    try testing.expect(containsLine(buf.items, "Cellar scan aborted"));
+}
+
+test "scanCellarKegs tolerates consecutive errors below the cap" {
+    resetOutput();
+    color.setForTest(false, false);
+    defer color.setForTest(null, null);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    var names: std.ArrayList([]const u8) = .empty;
+    // One short of the cap, then a good entry: the counter is consecutive,
+    // not cumulative, so a Cellar with scattered bad reads still scans out.
+    var mock = MockIter{
+        .entries = &.{.{ .name = "tree", .kind = .directory }},
+        .bursts = &.{migrate.max_consecutive_scan_errors - 1},
+    };
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    io_mod.beginStderrCapture(testing.allocator, &buf);
+    defer io_mod.endStderrCapture();
+
+    try migrate.scanCellarKegs(std.Options.debug_io, arena.allocator(), &mock, MockDir{}, &names);
+
+    try testing.expectEqual(@as(usize, 1), names.items.len);
+    try testing.expectEqualStrings("tree", names.items[0]);
+    try testing.expect(!containsLine(buf.items, "Cellar scan aborted"));
+}
+
+test "scanCellarKegs resets its error budget after a successful read" {
+    resetOutput();
+    color.setForTest(false, false);
+    defer color.setForTest(null, null);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    var names: std.ArrayList([]const u8) = .empty;
+    // Two near-cap bursts split by a good read. Cumulative counting would
+    // abort here; a Cellar with scattered bad reads must still scan out.
+    const burst = migrate.max_consecutive_scan_errors - 1;
+    var mock = MockIter{
+        .entries = &.{
+            .{ .name = "tree", .kind = .directory },
+            .{ .name = "wget", .kind = .directory },
+        },
+        .bursts = &.{ burst, burst },
+    };
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    io_mod.beginStderrCapture(testing.allocator, &buf);
+    defer io_mod.endStderrCapture();
+
+    try migrate.scanCellarKegs(std.Options.debug_io, arena.allocator(), &mock, MockDir{}, &names);
+
+    try testing.expectEqual(@as(usize, 2), names.items.len);
+    try testing.expectEqualStrings("tree", names.items[0]);
+    try testing.expectEqualStrings("wget", names.items[1]);
+    try testing.expect(!containsLine(buf.items, "Cellar scan aborted"));
+}
+
+test "scanCellarKegs keeps the names gathered before the abort" {
+    resetOutput();
+    color.setForTest(false, false);
+    defer color.setForTest(null, null);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    var names: std.ArrayList([]const u8) = .empty;
+    var mock = MockIter{
+        .entries = &.{
+            .{ .name = "tree", .kind = .directory },
+            .{ .name = "wget", .kind = .directory },
+        },
+        .stuck_at = 2, // wedges only after both kegs are collected
+    };
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    io_mod.beginStderrCapture(testing.allocator, &buf);
+    defer io_mod.endStderrCapture();
+
+    try testing.expectError(
+        error.Aborted,
+        migrate.scanCellarKegs(std.Options.debug_io, arena.allocator(), &mock, MockDir{}, &names),
+    );
+    // The arena-owned slice is not clobbered on the error path. No caller
+    // reads it today; this keeps partial-progress reporting available.
+    try testing.expectEqual(@as(usize, 2), names.items.len);
+    try testing.expectEqualStrings("tree", names.items[0]);
+    try testing.expectEqualStrings("wget", names.items[1]);
 }
 
 // ── Resume manifest ────────────────────────────────────────────────


### PR DESCRIPTION
## Description

`malt migrate` could hang forever before migrating anything. If reading the Homebrew Cellar failed the same way on every attempt - a dying disk, an ejected volume, a wedged network mount - the scan retried without limit, printing a warning each time and growing stderr until the terminal was unusable. Ctrl-C could not break it.

The scan now gives up after a bounded run of consecutive failures and exits non-zero. Scattered bad entries behave as before: the budget resets on every good read. Aborting loudly beats the alternative; a partial keg list migrated as if it were complete is a silent half-migration the user believes is whole.

## Related Issue

- None

## Notes for Reviewers

- None