### PR TITLE
fix(tui): reap a pipe-less background audit exactly once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,12 @@ jobs:
       - name: Tap-resolution contract guard
         run: ./scripts/regressions/tap-resolution-contract.sh
 
+      # Static structural guard: the TUI interpreter reaps each background
+      # audit exactly once. `kill` already reaps, so a following `wait` would
+      # abort on the cleared pid. Source scan only — no build, no network.
+      - name: TUI single-reap guard
+        run: ./scripts/regressions/tui-background-fetch-no-double-reap-start-background-waits-after-kill.sh
+
       - name: Install shell-lint tools
         run: brew install shellcheck shfmt
 

--- a/justfile
+++ b/justfile
@@ -40,6 +40,7 @@ regressions-static:
     @./scripts/regressions/clean-misses-tmpdir-test-scratch.sh
     @./scripts/regressions/post-install-native-spawns-inherit-full-environment.sh
     @./scripts/regressions/tar-prescan-followups-925-926-follow-up.sh
+    @./scripts/regressions/tui-background-fetch-no-double-reap-start-background-waits-after-kill.sh
     @MALT_STATIC_ONLY=1 ./scripts/regressions/post-install-steps-live-artefacts.sh
     @./scripts/test/bench_release_resolution_test.sh
 

--- a/scripts/regressions/tui-background-fetch-no-double-reap-start-background-waits-after-kill.sh
+++ b/scripts/regressions/tui-background-fetch-no-double-reap-start-background-waits-after-kill.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Regression: the TUI interpreter must reap a background audit exactly once.
+#
+# `std.process.Child.kill` blocks to termination, reaps, and clears the pid;
+# `wait` opens with `assert(child.id != null)`. A `wait` after a `kill` is
+# therefore a panic, not a belt-and-braces reap — and `catch {}` cannot
+# absorb an assert.
+#
+# No `malt` subcommand can reach the pipe-less spawn arm this protects, so the
+# guard judges the source shape and the colocated inline guard test instead of
+# driving the CLI. It stays a static check on purpose: the inline test it pins
+# is executed by `just test`, and rebuilding the suite here would cost minutes
+# for no extra signal.
+#
+# The `.wait(` ban is file-scoped by design. A `wait` after a *drain* is the
+# correct idiom and is used legitimately elsewhere in the tree.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+SRC="$ROOT/src/tui/perform.zig"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+HIT=$(grep -n '\.wait(' "$SRC" || true)
+[[ -n "$HIT" ]] && fail "perform.zig waits on a child; kill already reaps it: ${HIT%%:*}"
+
+# Catch a reintroduction under a different receiver name.
+grep -n -A3 'kill(' "$SRC" | grep -q 'wait(' &&
+  fail "perform.zig waits within three lines of a kill - double reap"
+
+grep -q 'test "startBackground never waits after a kill"' "$SRC" ||
+  fail "the inline no-wait guard test was removed from src/tui/perform.zig"
+
+echo "PASS: the TUI interpreter reaps each background audit exactly once"
+exit 0

--- a/src/tui/perform.zig
+++ b/src/tui/perform.zig
@@ -170,8 +170,7 @@ pub fn startBackground(io: std.Io, fetches: *Fetches, shared: *SharedModel, r: c
     if (fetches.getPtr(r.tag).* != null) return; // already auditing this tab
     var child = std.process.spawn(io, .{ .argv = r.argv, .stdout = .pipe, .stderr = .ignore }) catch return;
     const out = child.stdout orelse {
-        child.kill(io);
-        _ = child.wait(io) catch {}; // best-effort reap of a pipe-less child; there is nothing to drain
+        child.kill(io); // `kill` reaps and closes stdio; a second reap would abort on the cleared pid
         return;
     };
     shared.tab_loading.insert(r.tag);

--- a/src/tui/perform.zig
+++ b/src/tui/perform.zig
@@ -305,6 +305,15 @@ test "the interpreter imports no tab module and no json parser" {
     try testing.expect(std.mem.indexOf(u8, src, "_tab.zig" ++ "\")") == null);
 }
 
+test "startBackground never waits after a kill" {
+    // Regression guard, not coverage: the pipe-less arm is unreachable today, so
+    // nothing at runtime can exercise it. `kill` already reaps and clears the pid,
+    // and a following `wait` would trip std's assert. The needle is split so this
+    // test's own bytes never contain the marker it searches for.
+    const src = @embedFile("perform.zig");
+    try testing.expect(std.mem.indexOf(u8, src, "." ++ "wait(") == null);
+}
+
 test "classify splits recoverable backend faults from fatal terminal/OOM faults" {
     // Child-process + parse faults: survivable — show a banner, keep the session.
     try testing.expectEqual(ErrorClass.recoverable, classify(error.SpawnFailed));


### PR DESCRIPTION
## Description

The TUI's background-audit spawn had a defensive arm that killed the child and then waited on it. In Zig 0.16 `kill` *is* the reap - it clears the pid, and `wait` asserts the pid is set - so that arm would have aborted the TUI and left the terminal in raw mode rather than failing quietly. It reaps once now.

The arm is unreachable today, so this changes no behaviour a user can observe. The value is that the one path meant to keep a spawn fault quiet can no longer become the loudest failure in the app. A source-scan guard runs in CI lint so the idiom cannot come back.

## Related Issue

- None

## Notes for Reviewers

- None