### PR TITLE
fix(tap): stop a slugless tap name from ever panicking the cold path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,12 @@ jobs:
       - name: Tap-resolution contract guard
         run: ./scripts/regressions/tap-resolution-contract.sh
 
+      # Static structural guard: the tap cold path derives its pair from the
+      # canonical slug buffer, never by splitting the caller's raw slug on a
+      # `/` it may not contain. Source scan only — no build, no network.
+      - name: Tap slugless cold-path guard
+        run: ./scripts/regressions/tap-slugless-effective-owner-repo-unreachable-on-slugless-input.sh
+
       # Static structural guard: the TUI interpreter reaps each background
       # audit exactly once. `kill` already reaps, so a following `wait` would
       # abort on the cleared pid. Source scan only — no build, no network.

--- a/justfile
+++ b/justfile
@@ -36,6 +36,7 @@ install:
 [group('test')]
 regressions-static:
     @./scripts/regressions/tap-resolution-contract.sh
+    @./scripts/regressions/tap-slugless-effective-owner-repo-unreachable-on-slugless-input.sh
     @./scripts/regressions/relocated-store-logic-version-pin.sh
     @./scripts/regressions/clean-misses-tmpdir-test-scratch.sh
     @./scripts/regressions/post-install-native-spawns-inherit-full-environment.sh

--- a/scripts/regressions/tap-slugless-effective-owner-repo-unreachable-on-slugless-input.sh
+++ b/scripts/regressions/tap-slugless-effective-owner-repo-unreachable-on-slugless-input.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Lock the tap cold path against a slugless tap name.
+#
+# `effectiveOwnerRepo` used to split the caller's raw slug with
+# `orelse unreachable`, so a name with no `/` was UB in ReleaseFast and a
+# panic in ReleaseSafe. The split now runs on the buffer
+# `canonicalTapSlug` builds, which rejects a slugless input one frame
+# earlier and surfaces it as a typed error.
+#
+# Pinned properties:
+#   1. Structural — the cold path never splits the raw slug again. This
+#      is the leg that guards the finding: reintroducing the direct
+#      `orelse unreachable` fails here even when no CLI surface can
+#      reach it today.
+#   2. Behavioural — a slugless name fails typed and never panics.
+#
+# Usage: scripts/regressions/tap-slugless-effective-owner-repo-unreachable-on-slugless-input.sh
+# Requirements: a built malt binary; POSIX grep/awk — no network.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+# (1) structural
+body=$(awk '/^pub fn effectiveOwnerRepo\(/,/^}/' src/core/tap.zig)
+[[ -n "$body" ]] || fail "could not locate effectiveOwnerRepo in src/core/tap.zig"
+
+if grep -q 'orelse unreachable' <<<"$body"; then
+  printf "FAIL: effectiveOwnerRepo regained an 'orelse unreachable':\n\n" >&2
+  grep -n 'orelse unreachable' <<<"$body" >&2
+  printf "\nDerive the pair from canonicalTapSlug's buffer instead — the\n" >&2
+  printf "raw slug is caller-supplied and need not contain a '/'.\n" >&2
+  exit 1
+fi
+
+grep -q 'canonicalTapSlug(&canon_buf, slug) orelse return' <<<"$body" ||
+  fail "cold path no longer routes its split through canonicalTapSlug"
+
+# (2) behavioural
+MALT_BIN=${MALT_BIN:-$ROOT/zig-out/bin/malt}
+[[ -x "$MALT_BIN" ]] ||
+  fail "malt binary not found at $MALT_BIN — run \"zig build\" first."
+
+PREFIX=$(mktemp -d)
+trap 'rm -rf "$PREFIX"' EXIT
+
+out=$(MALT_PREFIX="$PREFIX" "$MALT_BIN" tap noslash 2>&1) && rc=0 || rc=$?
+[[ $rc -eq 1 ]] || fail "expected exit 1 for a slugless tap, got $rc: $out"
+grep -qi 'panic' <<<"$out" && fail "panic on a slugless tap: $out"
+grep -q "Invalid tap 'noslash'" <<<"$out" ||
+  fail "slugless tap did not produce the validation message: $out"
+
+printf 'OK: the tap cold path rejects a slugless name without panicking.\n'

--- a/scripts/regressions/tap-slugless-effective-owner-repo-unreachable-on-slugless-input.sh
+++ b/scripts/regressions/tap-slugless-effective-owner-repo-unreachable-on-slugless-input.sh
@@ -15,7 +15,8 @@
 #   2. Behavioural — a slugless name fails typed and never panics.
 #
 # Usage: scripts/regressions/tap-slugless-effective-owner-repo-unreachable-on-slugless-input.sh
-# Requirements: a built malt binary; POSIX grep/awk — no network.
+# Requirements: POSIX grep/awk — no network. Leg 2 needs a built binary and
+# skips without one, so leg 1 can gate the no-build lint job.
 
 set -euo pipefail
 
@@ -44,8 +45,10 @@ grep -q 'canonicalTapSlug(&canon_buf, slug) orelse return' <<<"$body" ||
 
 # (2) behavioural
 MALT_BIN=${MALT_BIN:-$ROOT/zig-out/bin/malt}
-[[ -x "$MALT_BIN" ]] ||
-  fail "malt binary not found at $MALT_BIN — run \"zig build\" first."
+if [[ ! -x "$MALT_BIN" ]]; then
+  printf 'OK (leg 1 only): no binary at %s — skipping the CLI leg.\n' "$MALT_BIN"
+  exit 0
+fi
 
 PREFIX=$(mktemp -d)
 trap 'rm -rf "$PREFIX"' EXIT

--- a/src/cli/tap.zig
+++ b/src/cli/tap.zig
@@ -874,7 +874,7 @@ fn run(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u
                 };
                 break :pair tap_mod.effectiveOwnerRepo(allocator, &db, name, chosen_host) catch |e| switch (e) {
                     error.ExplicitRepoRequired => {
-                        output.err("Registering a {s} tap needs an explicit repo — add --repo <owner>/<repo> or use --url <repo-url>. The homebrew-<repo> default only applies to github.com.", .{chosen_host});
+                        output.err("Registering a {s} tap needs an explicit repo — add --repo <owner>/<repo> or use --url <repo-url>. The homebrew-<repo> default only applies to a well-formed github.com tap name.", .{chosen_host});
                         return error.Aborted;
                     },
                     else => return e,

--- a/src/core/tap.zig
+++ b/src/core/tap.zig
@@ -1087,7 +1087,10 @@ test "effectiveOwnerRepo rejects a slugless name instead of panicking" {
     const schema = @import("../db/schema.zig");
     try schema.initSchema(&db);
 
-    for ([_][]const u8{ "noslash", "" }) |slug| {
+    // `canon_buf` is deliberately smaller than `tap_slug.max_slug_len`, so an
+    // over-long slug must degrade to the same typed error, never truncate.
+    const long = "a" ** 100 ++ "/" ++ "b" ** 100;
+    for ([_][]const u8{ "noslash", "", long }) |slug| {
         try std.testing.expectError(
             error.ExplicitRepoRequired,
             effectiveOwnerRepo(std.testing.allocator, &db, slug, "github.com"),

--- a/src/core/tap.zig
+++ b/src/core/tap.zig
@@ -1078,6 +1078,23 @@ test "effectiveOwnerRepo refuses to synthesize a repo for non-github hosts" {
     );
 }
 
+test "effectiveOwnerRepo rejects a slugless name instead of panicking" {
+    // The cold path splits `canonicalTapSlug`'s buffer, not the caller's
+    // slug, so a name with no `/` fails typed rather than tripping an
+    // `unreachable` on the split.
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    const schema = @import("../db/schema.zig");
+    try schema.initSchema(&db);
+
+    for ([_][]const u8{ "noslash", "" }) |slug| {
+        try std.testing.expectError(
+            error.ExplicitRepoRequired,
+            effectiveOwnerRepo(std.testing.allocator, &db, slug, "github.com"),
+        );
+    }
+}
+
 test "effectiveOwnerRepo reads the stored row regardless of the host hint" {
     // Once a row exists its persisted host wins; the hint only governs
     // the cold-path synthesis decision.

--- a/tests/cli_tap_test.zig
+++ b/tests/cli_tap_test.zig
@@ -512,6 +512,10 @@ test "execute --host without an explicit repo fails with a hint, not a homebrew-
         tap_cli.execute(&ctx, testing.allocator, &.{ "grp/tap", "--host", "gitlab.com" }),
     );
     try testing.expect(std.mem.indexOf(u8, captured.items, "needs an explicit repo") != null);
+    // The same error also fires on github.com for a name that cannot be
+    // canonicalised, so the hint must qualify the default rather than
+    // claim it is a github.com-only rule.
+    try testing.expect(std.mem.indexOf(u8, captured.items, "well-formed github.com tap name") != null);
 }
 
 test "execute rejects a --host that carries a scheme or path" {


### PR DESCRIPTION
## Description

A tap name with no `/` used to reach a raw `orelse unreachable` in the tap cold path - a panic in ReleaseSafe, UB in ReleaseFast. Earlier slug canonicalisation work already retired it, but nothing pinned the property, so it could come back unnoticed. This adds that guard and runs it on every pull request rather than only in the manual regression pool.

Also corrects the hint the same error prints. It claimed the `homebrew-<repo>` default "only applies to github.com", which contradicts itself in the one case the error can fire *on* a github.com host - a name that cannot be canonicalised.

## Related Issue

- None

## Notes for Reviewers

- The cold path itself is unchanged: this is a guard plus a message fix.
