### PR TITLE
ci: gate every static regression guard, not a hand-picked three

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,23 +123,16 @@ jobs:
       - name: Check Zig formatting
         run: zig fmt --check src/ tests/
 
-      # Static structural guard: every tap fetch URL, writeback URL,
-      # and MALT_GITHUB_TOKEN reach stays inside src/core/tap.zig.
-      # No build, no network — fast enough to live in lint.
-      - name: Tap-resolution contract guard
-        run: ./scripts/regressions/tap-resolution-contract.sh
+      - name: Install just
+        uses: taiki-e/install-action@v2.87.1
+        with:
+          tool: just
 
-      # Static structural guard: the tap cold path derives its pair from the
-      # canonical slug buffer, never by splitting the caller's raw slug on a
-      # `/` it may not contain. Source scan only — no build, no network.
-      - name: Tap slugless cold-path guard
-        run: ./scripts/regressions/tap-slugless-effective-owner-repo-unreachable-on-slugless-input.sh
-
-      # Static structural guard: the TUI interpreter reaps each background
-      # audit exactly once. `kill` already reaps, so a following `wait` would
-      # abort on the cleared pid. Source scan only — no build, no network.
-      - name: TUI single-reap guard
-        run: ./scripts/regressions/tui-background-fetch-no-double-reap-start-background-waits-after-kill.sh
+      # Source scans and fixture checks — no build, no network, fast enough
+      # to live in lint. The justfile recipe is the only list: a guard added
+      # there is gated here, so local `just test` and CI cannot drift apart.
+      - name: Static regression guards
+        run: just regressions-static
 
       - name: Install shell-lint tools
         run: brew install shellcheck shfmt

--- a/scripts/regressions/post-install-steps-live-artefacts.sh
+++ b/scripts/regressions/post-install-steps-live-artefacts.sh
@@ -24,16 +24,14 @@
 #
 # Usage: scripts/regressions/post-install-steps-live-artefacts.sh
 #        MALT_REGRESSION_SLOW=1 scripts/regressions/post-install-steps-live-artefacts.sh
-# Requirements: built `mt` binary, network access to formulae.brew.sh + ghcr.io.
+# Requirements: built `mt` binary and network access to formulae.brew.sh +
+#               ghcr.io — both only for the install cases. MALT_STATIC_ONLY=1
+#               runs the ordering guards alone and needs neither.
 
 set -euo pipefail
 
 ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 BIN="${MALT_BIN:-$ROOT/zig-out/bin/mt}"
-[[ -x "$BIN" ]] || {
-  echo "build malt first: zig build" >&2
-  exit 2
-}
 
 if [[ -z "${MALT_GITHUB_TOKEN:-}" ]] && command -v gh >/dev/null 2>&1; then
   MALT_GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
@@ -121,6 +119,13 @@ if [[ -n "${MALT_STATIC_ONLY:-}" ]]; then
   echo "OK: post_install ordering guards hold (static-only)"
   exit 0
 fi
+
+# Only the install cases below need a binary, so the check sits after the
+# static-only exit rather than before it.
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
 
 # ── set_permissions, applied through the prefix's link farm ──────────
 install_clean redis

--- a/scripts/regressions/tar-prescan-followups-925-926-follow-up.sh
+++ b/scripts/regressions/tar-prescan-followups-925-926-follow-up.sh
@@ -83,7 +83,11 @@ ${fixed//$'\n'/$'\n'        }"
 # and the corpus logs only survive CI if the artifact glob matches the root.
 # clean.sh holds one pattern list and sweeps it under every scratch root, so
 # re-attach the /tmp prefix the templates below are written with.
-mapfile -t swept < <(sed -nE "s/^patterns='(.*)'\$/\1/p" "$ROOT/scripts/clean.sh" |
+# Read line-by-line instead of `mapfile` because macOS still ships bash 3.2.
+swept=()
+while IFS= read -r pat; do
+  [[ -n "$pat" ]] && swept+=("$pat")
+done < <(sed -nE "s/^patterns='(.*)'\$/\1/p" "$ROOT/scripts/clean.sh" |
   tr ' ' '\n' | sed 's|^|/tmp/|')
 ((${#swept[@]} > 0)) || fail "no scratch patterns found in clean.sh; this check is inert"
 while IFS= read -r tmpl; do


### PR DESCRIPTION
## Description

The lint job ran three hand-picked static guards while the justfile recipe had nine, so six ran nowhere in CI. CI now calls `just regressions-static`: the recipe is the only list, and the two can no longer drift.

One guard needed fixing first - `post-install-steps-live-artefacts.sh` demanded a built binary before its own static-only exit, so its no-build path could never run in a no-build job.

## Related Issue

- None

## Notes for Reviewers

- None