### PR TITLE
fix(purge): stop routine cleanup from deleting an installed cask's cached artifact

### DIFF
--- a/scripts/regressions/stale-casks-deletes-installed-cask-cache.sh
+++ b/scripts/regressions/stale-casks-deletes-installed-cask-cache.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Regression: `purge --stale-casks` — reached by every `mt cleanup` run via
+# `--housekeeping` — must keep every cached artefact belonging to a token that
+# is still in `casks`, and remove only artefacts of tokens that are not.
+#
+# The bug: the scope rebuilt a token from a cache filename by stripping one of
+# `.dmg`/`.zip`/`.pkg` and nothing else. Artefacts are cached per version as
+# `<token>-<version><ext>`, so the lookup asked for `flux-2.0`, matched no row,
+# and deleted the installed cask's artefact — the one `rollback` depends on and
+# that latest-only vendor URLs cannot re-fetch. `.tar.gz`, `.tar.xz` and
+# `.fonts` were not even extension-stripped, so they could never match.
+#
+# Exits 0 when the bug is absent, non-zero naming the offending file when
+# present. No network; well under 30s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+# The harness runs the built binary, which `zig build test` does not refresh —
+# build it here so a stale binary never masks the fix.
+zig build >/dev/null
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+export MALT_PREFIX="$tmp/p"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+
+# Must survive: installed token, every cached name shape, current and historical.
+keep=(flux-2.0.dmg flux-2.0.tar.gz flux-2.0.tar.xz flux-2.0.fonts flux-1.0.zip flux.dmg)
+# Must go: no such token in `casks`. `fluxbox` shares a prefix with `flux` but not
+# a token boundary, so the `flux` row must not rescue it.
+drop=(ghost-1.0.dmg fluxbox-1.0.dmg)
+
+fail=0
+
+seed() {
+  rm -rf "$MALT_PREFIX"
+  mkdir -p "$MALT_PREFIX/db" "$MALT_PREFIX/cache/Cask" "$MALT_PREFIX/Caskroom/flux/2.0"
+  sqlite3 "$MALT_PREFIX/db/malt.db" <<'SQL'
+CREATE TABLE IF NOT EXISTS casks (token TEXT PRIMARY KEY, name TEXT, version TEXT,
+  url TEXT, sha256 TEXT, app_path TEXT, auto_updates INTEGER);
+INSERT INTO casks VALUES ('flux','flux','2.0','https://example.invalid/x',NULL,NULL,0);
+SQL
+  for f in "${keep[@]}" "${drop[@]}"; do echo x >"$MALT_PREFIX/cache/Cask/$f"; done
+}
+
+check() {
+  local via="$1" f
+  for f in "${keep[@]}"; do
+    [ -e "$MALT_PREFIX/cache/Cask/$f" ] || {
+      echo "FAIL: $via deleted the installed cask's artefact $f" >&2
+      fail=1
+    }
+  done
+  for f in "${drop[@]}"; do
+    [ -e "$MALT_PREFIX/cache/Cask/$f" ] && {
+      echo "FAIL: $via kept the orphaned artefact $f" >&2
+      fail=1
+    }
+  done
+  # The Caskroom half classifies correctly and was left alone; pin that.
+  [ -d "$MALT_PREFIX/Caskroom/flux/2.0" ] || {
+    echo "FAIL: $via deleted the installed cask's Caskroom entry" >&2
+    fail=1
+  }
+  return 0
+}
+
+seed
+"$BIN" purge --stale-casks --yes >/dev/null
+check "purge --stale-casks"
+
+# `cleanup` prepends --housekeeping, which folds in --stale-casks: this is the
+# verb the bug actually reached users through, so guard it directly.
+seed
+"$BIN" cleanup --yes >/dev/null
+check "cleanup"
+
+[ "$fail" -eq 0 ] || exit 1
+
+echo "ok: stale-casks keeps installed cask artefacts and removes orphans"

--- a/src/cli/purge/scopes.zig
+++ b/src/cli/purge/scopes.zig
@@ -432,9 +432,9 @@ pub fn runStaleCasks(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix: [
         return result;
     };
 
-    // Single reusable lookup for both passes — they ask the same
-    // question. A persistent prepare failure (schema drift, lock held)
-    // would otherwise empty the candidate set silently.
+    // Caskroom directories are bare tokens, so they match exactly. A
+    // persistent prepare failure (schema drift, lock held) would otherwise
+    // empty the candidate set silently.
     var lookup = db.prepare("SELECT token FROM casks WHERE token = ?1 LIMIT 1;") catch |e| {
         output.err("stale-casks: cannot prepare cask lookup ({s})", .{@errorName(e)});
         result.status = .err;
@@ -442,6 +442,19 @@ pub fn runStaleCasks(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix: [
         return result;
     };
     defer lookup.finalize();
+
+    // Cache files are named `<token>-<version><ext>`, so a stem belongs to a
+    // cask when it is the token or the token followed by a literal `-`.
+    // Matching from the token side is what keeps dashed tokens honest.
+    var cache_lookup = db.prepare(
+        "SELECT 1 FROM casks WHERE ?1 = token OR substr(?1, 1, length(token) + 1) = token || '-' LIMIT 1;",
+    ) catch |e| {
+        output.err("stale-casks: cannot prepare cask lookup ({s})", .{@errorName(e)});
+        result.status = .err;
+        result.error_kind = "db_prepare";
+        return result;
+    };
+    defer cache_lookup.finalize();
 
     // Collect candidates first so we can emit a single header line with
     // an accurate count before printing the per-item bullets.
@@ -467,8 +480,10 @@ pub fn runStaleCasks(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix: [
         while (iter.next(io) catch null) |entry| {
             if (entry.kind == .directory) continue;
             const name = entry.name;
-            const token = blk: {
-                for ([_][]const u8{ ".dmg", ".zip", ".pkg" }) |ext| {
+            // `.fonts` stays local: it is a manifest, not an artefact, so it
+            // has no place in the deletion-driving `cache_extensions`.
+            const stem = blk: {
+                for (cask_mod.cache_extensions ++ [_][]const u8{".fonts"}) |ext| {
                     if (std.mem.endsWith(u8, name, ext)) {
                         break :blk name[0 .. name.len - ext.len];
                     }
@@ -476,15 +491,15 @@ pub fn runStaleCasks(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix: [
                 break :blk name;
             };
 
-            const token_z = allocator.dupeZ(u8, token) catch continue;
-            defer allocator.free(token_z);
+            const stem_z = allocator.dupeZ(u8, stem) catch continue;
+            defer allocator.free(stem_z);
 
-            lookup.reset() catch {};
-            lookup.bindText(1, token_z) catch |e| {
-                output.warn("stale-casks: skipping {s}: bind failed ({s})", .{ token, @errorName(e) });
+            cache_lookup.reset() catch {};
+            cache_lookup.bindText(1, stem_z) catch |e| {
+                output.warn("stale-casks: skipping {s}: bind failed ({s})", .{ stem, @errorName(e) });
                 continue;
             };
-            if (lookup.step() catch false) continue; // still installed
+            if (cache_lookup.step() catch false) continue; // still installed
 
             const stat = dir.statFile(io, entry.name, .{}) catch continue;
             const dup = allocator.dupe(u8, entry.name) catch continue;
@@ -1020,6 +1035,108 @@ test "runStaleCasks self-heals a schema-less db rather than reporting it as a fa
     try testing.expectEqual(util.ScopeStatus.ok, result.status);
     try testing.expect(result.error_kind == null);
     try testing.expectEqual(@as(u32, 0), result.removed);
+}
+
+test "runStaleCasks keeps every cached artefact shape of an installed cask" {
+    // Artefacts are cached as `<token>-<version><ext>`, so a scope that only
+    // strips the extension asks the DB for `flux-2.0` and deletes the running
+    // version's download. Legacy bare `<token><ext>` files must keep working.
+    const allocator = testing.allocator;
+
+    var s = try Scratch.init("runStaleCasks_keep_installed");
+    defer s.deinit();
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, s.p("/db"));
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, s.p("/cache/Cask"));
+
+    {
+        var db = try sqlite.Database.open(s.p("/db/malt.db"));
+        defer db.close();
+        try schema.initSchema(&db);
+        try seedCurrentCask(&db, "flux", "2.0");
+    }
+
+    const kept = [_][]const u8{
+        "/cache/Cask/flux-2.0.dmg",
+        "/cache/Cask/flux-2.0.tar.gz",
+        "/cache/Cask/flux-2.0.tar.xz",
+        "/cache/Cask/flux-2.0.fonts",
+        "/cache/Cask/flux-1.0.zip", // history: --old-versions' job, not this scope's
+        "/cache/Cask/flux.dmg",
+    };
+    for (kept) |rel| try touchFile(fs_test_io, s.p(rel));
+
+    const ctx = AppCtx{ .io = fs_test_io, .environ = .empty };
+    const result = try runStaleCasks(&ctx, allocator, s.base, false);
+
+    try testing.expectEqual(util.ScopeStatus.ok, result.status);
+    try testing.expectEqual(@as(u32, 0), result.removed);
+    for (kept) |rel| try std.Io.Dir.accessAbsolute(fs_test_io, s.p(rel), .{});
+}
+
+test "runStaleCasks removes a per-version artefact whose token is no longer installed" {
+    const allocator = testing.allocator;
+
+    var s = try Scratch.init("runStaleCasks_drop_orphan");
+    defer s.deinit();
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, s.p("/db"));
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, s.p("/cache/Cask"));
+
+    {
+        var db = try sqlite.Database.open(s.p("/db/malt.db"));
+        defer db.close();
+        try schema.initSchema(&db);
+    }
+
+    try touchFile(fs_test_io, s.p("/cache/Cask/ghost-1.0.dmg"));
+    try touchFile(fs_test_io, s.p("/cache/Cask/ghost.tar.gz"));
+
+    const ctx = AppCtx{ .io = fs_test_io, .environ = .empty };
+    const result = try runStaleCasks(&ctx, allocator, s.base, false);
+
+    try testing.expectEqual(util.ScopeStatus.ok, result.status);
+    try testing.expectEqual(@as(u32, 2), result.removed);
+    try testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.accessAbsolute(fs_test_io, s.p("/cache/Cask/ghost-1.0.dmg"), .{}),
+    );
+    try testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.accessAbsolute(fs_test_io, s.p("/cache/Cask/ghost.tar.gz"), .{}),
+    );
+}
+
+test "runStaleCasks matches a cache stem on the token boundary, not a bare prefix" {
+    // Tokens and versions both carry dashes, so the only sound rule is
+    // "token, then a literal `-`". `fluxbox` shares a prefix with `flux` but
+    // not a boundary and must go; `flux-2-1.0` is indistinguishable from
+    // `flux` at version `2-1.0`, so it is kept rather than risk the artefact.
+    const allocator = testing.allocator;
+
+    var s = try Scratch.init("runStaleCasks_boundary");
+    defer s.deinit();
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, s.p("/db"));
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, s.p("/cache/Cask"));
+
+    {
+        var db = try sqlite.Database.open(s.p("/db/malt.db"));
+        defer db.close();
+        try schema.initSchema(&db);
+        try seedCurrentCask(&db, "flux", "2.0");
+    }
+
+    const kept = [_][]const u8{ "/cache/Cask/flux-2.0.dmg", "/cache/Cask/flux-2-1.0.dmg" };
+    const gone = [_][]const u8{ "/cache/Cask/fluxbox-1.0.dmg", "/cache/Cask/flux2-1.0.dmg" };
+    for (kept ++ gone) |rel| try touchFile(fs_test_io, s.p(rel));
+
+    const ctx = AppCtx{ .io = fs_test_io, .environ = .empty };
+    const result = try runStaleCasks(&ctx, allocator, s.base, false);
+
+    try testing.expectEqual(@as(u32, gone.len), result.removed);
+    for (kept) |rel| try std.Io.Dir.accessAbsolute(fs_test_io, s.p(rel), .{});
+    for (gone) |rel| try testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.accessAbsolute(fs_test_io, s.p(rel), .{}),
+    );
 }
 
 test "runCache reclaims relocated kegs orphaned by a past logic-version bump" {

--- a/src/cli/purge/scopes.zig
+++ b/src/cli/purge/scopes.zig
@@ -1106,10 +1106,8 @@ test "runStaleCasks removes a per-version artefact whose token is no longer inst
 }
 
 test "runStaleCasks matches a cache stem on the token boundary, not a bare prefix" {
-    // Tokens and versions both carry dashes, so the only sound rule is
-    // "token, then a literal `-`". `fluxbox` shares a prefix with `flux` but
-    // not a boundary and must go; `flux-2-1.0` is indistinguishable from
-    // `flux` at version `2-1.0`, so it is kept rather than risk the artefact.
+    // Tokens and versions both carry dashes, so the rule is "token, then a
+    // literal `-`" — and where that is still ambiguous, the file is kept.
     const allocator = testing.allocator;
 
     var s = try Scratch.init("runStaleCasks_boundary");
@@ -1136,6 +1134,37 @@ test "runStaleCasks matches a cache stem on the token boundary, not a bare prefi
     for (gone) |rel| try testing.expectError(
         error.FileNotFound,
         std.Io.Dir.accessAbsolute(fs_test_io, s.p(rel), .{}),
+    );
+}
+
+test "runStaleCasks keeps a dash-prefixed sibling's artefact on its own token" {
+    // `git-lfs` is installed, `git` is not. The sibling must be kept by its
+    // own row, and `git`'s leftover artefact must not ride along on it.
+    const allocator = testing.allocator;
+
+    var s = try Scratch.init("runStaleCasks_sibling");
+    defer s.deinit();
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, s.p("/db"));
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, s.p("/cache/Cask"));
+
+    {
+        var db = try sqlite.Database.open(s.p("/db/malt.db"));
+        defer db.close();
+        try schema.initSchema(&db);
+        try seedCurrentCask(&db, "git-lfs", "2.0");
+    }
+
+    try touchFile(fs_test_io, s.p("/cache/Cask/git-lfs-2.0.dmg"));
+    try touchFile(fs_test_io, s.p("/cache/Cask/git-2.39.0.dmg"));
+
+    const ctx = AppCtx{ .io = fs_test_io, .environ = .empty };
+    const result = try runStaleCasks(&ctx, allocator, s.base, false);
+
+    try testing.expectEqual(@as(u32, 1), result.removed);
+    try std.Io.Dir.accessAbsolute(fs_test_io, s.p("/cache/Cask/git-lfs-2.0.dmg"), .{});
+    try testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.accessAbsolute(fs_test_io, s.p("/cache/Cask/git-2.39.0.dmg"), .{}),
     );
 }
 

--- a/tests/purge_scopes_test.zig
+++ b/tests/purge_scopes_test.zig
@@ -203,6 +203,60 @@ test "--stale-casks --dry-run iterates orphaned cache/Cask files and Caskroom di
     try purge.execute(&ctx, allocator, &.{"--stale-casks"});
 }
 
+test "--stale-casks --yes keeps an installed cask's artefacts and removes only orphans" {
+    // End-to-end through `purge.execute` — the path `mt cleanup` takes via
+    // `--housekeeping`. Vendor URLs are often latest-only, so deleting the
+    // installed version's artefact here is unrecoverable data loss.
+    const allocator = testing.allocator;
+    var prefix = try ScratchPrefix.init(allocator, "stale_casks_keep");
+    defer prefix.deinit(allocator);
+
+    {
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix.path}, 0);
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        try schema.initSchema(&db);
+
+        var cask_stmt = try db.prepare(
+            \\INSERT INTO casks (token, name, version, url, sha256, app_path, auto_updates)
+            \\VALUES ('flux', 'flux', '2.0', 'https://example.invalid/dummy', NULL, NULL, 0);
+        );
+        defer cask_stmt.finalize();
+        _ = try cask_stmt.step();
+    }
+
+    const kept = [_][]const u8{ "flux-2.0.dmg", "flux-2.0.tar.gz", "flux-2.0.fonts", "flux.dmg" };
+    const gone = [_][]const u8{ "ghost-1.0.dmg", "fluxbox-1.0.dmg" };
+    for (kept ++ gone) |name| {
+        try writeFileAt(allocator, &.{ prefix.path, "cache", "Cask", name }, "x");
+    }
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setMode(.human);
+    output.setDryRun(false);
+    output.setNdjson(false);
+    output.setQuiet(true);
+
+    const ctx = malt.app_ctx.debug_ctx;
+    try purge.execute(&ctx, allocator, &.{ "--stale-casks", "--yes" });
+
+    for (kept) |name| {
+        const path = try std.fmt.allocPrint(allocator, "{s}/cache/Cask/{s}", .{ prefix.path, name });
+        defer allocator.free(path);
+        try test_io.accessAbsolute(std.Options.debug_io, path, .{});
+    }
+    for (gone) |name| {
+        const path = try std.fmt.allocPrint(allocator, "{s}/cache/Cask/{s}", .{ prefix.path, name });
+        defer allocator.free(path);
+        try testing.expectError(
+            error.FileNotFound,
+            test_io.accessAbsolute(std.Options.debug_io, path, .{}),
+        );
+    }
+}
+
 // --- --old-versions ------------------------------------------------------
 
 test "--old-versions --yes sweeps cask per-version cache + caskroom + history row" {


### PR DESCRIPTION
## Description

Running `mt cleanup` no longer deletes the cached artifact of a cask you have
installed.

`--stale-casks` is documented - in help, completions and the README - as clearing cache and Caskroom entries for *uninstalled* casks. It was clearing them for installed ones too: artifacts are cached per version, so the scope asked the database for `flux-2.0` rather than `flux`, found no cask, and sweptthe file. Vendor URLs are frequently latest-only, so the artifact `mt rollback` depends on was often gone for good.

The scope now matches on the token boundary. Where a token and a version are genuinely ambiguous - both may contain dashes - the file is kept: reclaiming old versions of installed casks belongs to `--old-versions`, which cleanup deliberately does not run.

## Related Issue

- None

## Notes for Reviewers

- None