### PR TITLE
fix(purge): refuse to wipe when the backup manifest cannot be trusted

### DIFF
--- a/scripts/regressions/wipe-backup-empty-manifest-wipe-backup-writes-empty-manifest-on-unreadable-db.sh
+++ b/scripts/regressions/wipe-backup-empty-manifest-wipe-backup-writes-empty-manifest-on-unreadable-db.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Regression: a database that cannot be read must never be reported as "no
+# packages installed". `purge --wipe --backup` used to write a header-only
+# manifest, announce success, and then delete the prefix — destroying the only
+# record of what was installed. `mt backup` did the same over unreadable
+# tables. A prefix with no database at all is still an honest empty backup.
+#
+# Exits 0 when the bug is absent, non-zero (with a clear message) when present.
+# No network; all state lives under a throwaway prefix removed on EXIT.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+
+# The shell harness runs the built binary; `zig build test` does not refresh
+# it, so a stale binary would mask the fix.
+zig build >/dev/null
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+export NO_COLOR=1 MALT_NO_EMOJI=1
+
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+# 1. unreadable DB must abort before deleting anything
+P="$tmp/corrupt"
+mkdir -p "$P/db" "$P/Cellar"
+printf 'not a sqlite file\n' >"$P/db/malt.db"
+: >"$P/Cellar/marker"
+man="$tmp/m1.txt"
+if MALT_PREFIX="$P" "$BIN" purge --wipe --backup="$man" --yes >"$tmp/out" 2>&1; then
+  fail "wipe succeeded with an unreadable database"
+fi
+[ -e "$man" ] && fail "manifest written despite unreadable DB"
+[ -e "$P/Cellar/marker" ] || fail "prefix destroyed after failed backup"
+[ -e "$P/db/malt.db" ] || fail "database removed after failed backup"
+grep -qi 'database' "$tmp/out" || fail "abort message does not name the database"
+grep -qi 'refusing to wipe' "$tmp/out" || fail "abort did not explain why the wipe stopped"
+
+# 2. absent DB is an honest empty manifest, not a failure
+P2="$tmp/fresh"
+mkdir -p "$P2/db" "$P2/Cellar"
+: >"$P2/Cellar/marker"
+man2="$tmp/m2.txt"
+MALT_PREFIX="$P2" "$BIN" purge --wipe --backup="$man2" --yes >/dev/null 2>&1 ||
+  fail "wipe on a DB-less prefix should still succeed"
+[ -s "$man2" ] || fail "manifest missing for the absent-DB case"
+
+# 3. mt backup must not report success over an unreadable table
+P3="$tmp/badtable"
+mkdir -p "$P3/db"
+sqlite3 "$P3/db/malt.db" "CREATE TABLE kegs(x);"
+if MALT_PREFIX="$P3" "$BIN" backup -o "$tmp/b.txt" >"$tmp/bout" 2>&1; then
+  fail "backup reported success over an unreadable kegs table"
+fi
+grep -q 'packages)' "$tmp/bout" && fail "backup printed a success summary over an unreadable table"
+
+printf '  ✓ unreadable database aborts the wipe with the prefix intact\n'

--- a/src/cli/backup.zig
+++ b/src/cli/backup.zig
@@ -85,8 +85,12 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         return Error.DatabaseError;
     };
     defer db.close();
-    // Schema is idempotent; backup's SELECTs surface a real DB error if one exists.
-    schema.initSchema(&db) catch {};
+    // Guarantees the tables exist, so a failing `prepare` below can only mean
+    // a genuinely broken database — never a fresh one.
+    schema.initSchema(&db) catch |e| {
+        output.err("Failed to prepare database at {s} ({s})", .{ db_path, @errorName(e) });
+        return Error.DatabaseError;
+    };
 
     // ── Serialize into an in-memory buffer ───────────────────────────────
     var aw: std.Io.Writer.Allocating = .init(allocator);
@@ -104,12 +108,12 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         "SELECT name, version FROM kegs " ++
         "WHERE install_reason = 'direct' " ++
         "ORDER BY name;";
-    var fstmt = db.prepare(formulae_sql) catch null;
-    if (fstmt) |*s| {
-        defer s.finalize();
-        while (s.step() catch false) {
-            const name_ptr = s.columnText(0) orelse continue;
-            const ver_ptr = s.columnText(1);
+    {
+        var fstmt = try prepareOrFail(&db, formulae_sql);
+        defer fstmt.finalize();
+        while (try stepOrFail(&fstmt)) {
+            const name_ptr = fstmt.columnText(0) orelse continue;
+            const ver_ptr = fstmt.columnText(1);
             const name = std.mem.sliceTo(name_ptr, 0);
             const version = if (ver_ptr) |p| std.mem.sliceTo(p, 0) else "";
             try writeEntry(w, .formula, name, version, include_versions);
@@ -122,10 +126,10 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     // `<user>/<repo>/<token>`. Bare tokens 404 against the core API
     // on restore; the qualified form routes through
     // `installTapFormula` and re-installs from the owning tap.
-    var cstmt = db.prepare("SELECT token, version, tap FROM casks ORDER BY token;") catch null;
-    if (cstmt) |*s| {
+    {
+        var s = try prepareOrFail(&db, "SELECT token, version, tap FROM casks ORDER BY token;");
         defer s.finalize();
-        while (s.step() catch false) {
+        while (try stepOrFail(&s)) {
             const name_ptr = s.columnText(0) orelse continue;
             const ver_ptr = s.columnText(1);
             const tap_ptr = s.columnText(2);
@@ -157,10 +161,10 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     // the same re-bootstrap invariant — presence of the line implies
     // auto_start, no extra token needed.
     if (include_services) {
-        var sstmt = db.prepare("SELECT name FROM services WHERE auto_start = 1 ORDER BY name;") catch null;
-        if (sstmt) |*st| {
+        {
+            var st = try prepareOrFail(&db, "SELECT name FROM services WHERE auto_start = 1 ORDER BY name;");
             defer st.finalize();
-            while (st.step() catch false) {
+            while (try stepOrFail(&st)) {
                 const name_ptr = st.columnText(0) orelse continue;
                 const name = std.mem.sliceTo(name_ptr, 0);
                 try writeEntry(w, .service, name, "", false);
@@ -188,6 +192,22 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     output.success("Backup written to {s} ({d} packages)", .{ default_path, count });
 }
 
+/// A backup that silently drops rows is worse than no backup — restore would
+/// quietly rebuild a smaller machine. Both faults abort instead.
+fn prepareOrFail(db: *sqlite.Database, sql: []const u8) Error!sqlite.Statement {
+    return db.prepare(sql) catch |e| {
+        output.err("Failed to read installed packages ({s})", .{@errorName(e)});
+        return Error.DatabaseError;
+    };
+}
+
+fn stepOrFail(stmt: *sqlite.Statement) Error!bool {
+    return stmt.step() catch |e| {
+        output.err("Database read failed mid-scan ({s})", .{@errorName(e)});
+        return Error.DatabaseError;
+    };
+}
+
 /// `--json` path: gather direct formulas + casks (with their `tap`
 /// field) and emit `{formulas:[...],casks:[...]}` to stdout, or to
 /// `--output <path>`. Plain-text contract is untouched so `mt restore`
@@ -209,14 +229,12 @@ fn executeJson(
     var casks: std.ArrayList(JsonCask) = .empty;
     var services: std.ArrayList(JsonService) = .empty;
 
-    var fstmt = db.prepare(
-        "SELECT name, version FROM kegs " ++
+    {
+        var s = try prepareOrFail(db, "SELECT name, version FROM kegs " ++
             "WHERE install_reason = 'direct' " ++
-            "ORDER BY name;",
-    ) catch null;
-    if (fstmt) |*s| {
+            "ORDER BY name;");
         defer s.finalize();
-        while (s.step() catch false) {
+        while (try stepOrFail(&s)) {
             const name_ptr = s.columnText(0) orelse continue;
             const ver_ptr = s.columnText(1);
             const name = a.dupe(u8, std.mem.sliceTo(name_ptr, 0)) catch return Error.WriteFailed;
@@ -227,10 +245,10 @@ fn executeJson(
         }
     }
 
-    var cstmt = db.prepare("SELECT token, version, tap FROM casks ORDER BY token;") catch null;
-    if (cstmt) |*s| {
+    {
+        var s = try prepareOrFail(db, "SELECT token, version, tap FROM casks ORDER BY token;");
         defer s.finalize();
-        while (s.step() catch false) {
+        while (try stepOrFail(&s)) {
             const name_ptr = s.columnText(0) orelse continue;
             const ver_ptr = s.columnText(1);
             const tap_ptr = s.columnText(2);
@@ -245,10 +263,10 @@ fn executeJson(
     }
 
     if (include_services) {
-        var sstmt = db.prepare("SELECT name FROM services WHERE auto_start = 1 ORDER BY name;") catch null;
-        if (sstmt) |*st| {
+        {
+            var st = try prepareOrFail(db, "SELECT name FROM services WHERE auto_start = 1 ORDER BY name;");
             defer st.finalize();
-            while (st.step() catch false) {
+            while (try stepOrFail(&st)) {
                 const name_ptr = st.columnText(0) orelse continue;
                 const name = a.dupe(u8, std.mem.sliceTo(name_ptr, 0)) catch return Error.WriteFailed;
                 services.append(a, .{ .name = name, .auto_start = true }) catch

--- a/src/cli/purge.zig
+++ b/src/cli/purge.zig
@@ -137,7 +137,13 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
             wipe_result.status,
             wipe_result.error_kind,
         );
-        wipe_result = try wipe_mod.runWipe(ctx, allocator, opts, prefix, cache_dir, dry_run);
+        wipe_result = wipe_mod.runWipe(ctx, allocator, opts, prefix, cache_dir, dry_run) catch |e| {
+            wipe_result.status = .err;
+            // The only `Aborted` runWipe raises is the refused manifest;
+            // everything else (user abort, OOM) keeps a null kind.
+            if (e == error.Aborted) wipe_result.error_kind = "db_unreadable";
+            return e;
+        };
         return;
     }
 
@@ -153,7 +159,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         if (dry_run) {
             output.info("would write backup manifest to {s}", .{bp});
         } else {
-            try wipe_mod.writeManifest(ctx, allocator, bp);
+            wipe_mod.writeManifest(ctx, allocator, bp) catch |e| return if (e == Error.DatabaseError) error.Aborted else e;
             output.success("backup manifest written to {s}", .{bp});
         }
     }

--- a/src/cli/purge/wipe.zig
+++ b/src/cli/purge/wipe.zig
@@ -4,6 +4,7 @@
 const std = @import("std");
 const AppCtx = @import("../../app_ctx.zig").AppCtx;
 const sqlite = @import("../../db/sqlite.zig");
+const schema = @import("../../db/schema.zig");
 const atomic = @import("../../fs/atomic.zig");
 const path_write = @import("../../fs/path_write.zig");
 const output = @import("../../ui/output.zig");
@@ -94,48 +95,64 @@ fn warnBanner() void {
     output.warnPlain("{s}", .{rule});
 }
 
+/// The caller deletes the prefix on the strength of this manifest, so a DB
+/// fault must be louder than an empty file. Only a prefix that never had a
+/// database is honestly empty.
 pub fn writeManifest(ctx: *const AppCtx, allocator: std.mem.Allocator, path: []const u8) Error!void {
     const prefix = atomic.maltPrefixOrAbort();
-    var db_path_buf: [512]u8 = undefined;
-    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return Error.DatabaseError;
 
     var aw: std.Io.Writer.Allocating = .init(allocator);
     defer aw.deinit();
     const w = &aw.writer;
     backup_mod.writeHeader(w) catch return Error.WriteFailed;
 
-    if (sqlite.Database.open(db_path)) |*db_val| {
-        var db = db_val.*;
-        defer db.close();
-
-        var fstmt = db.prepare(
-            "SELECT name, version FROM kegs WHERE install_reason = 'direct' ORDER BY name;",
-        ) catch null;
-        if (fstmt) |*s| {
-            defer s.finalize();
-            while (s.step() catch false) {
-                const name_ptr = s.columnText(0) orelse continue;
-                const ver_ptr = s.columnText(1);
-                const name = std.mem.sliceTo(name_ptr, 0);
-                const version = if (ver_ptr) |p| std.mem.sliceTo(p, 0) else "";
-                backup_mod.writeEntry(w, .formula, name, version, true) catch return Error.WriteFailed;
-            }
-        }
-
-        var cstmt = db.prepare("SELECT token, version FROM casks ORDER BY token;") catch null;
-        if (cstmt) |*s| {
-            defer s.finalize();
-            while (s.step() catch false) {
-                const name_ptr = s.columnText(0) orelse continue;
-                const ver_ptr = s.columnText(1);
-                const name = std.mem.sliceTo(name_ptr, 0);
-                const version = if (ver_ptr) |p| std.mem.sliceTo(p, 0) else "";
-                backup_mod.writeEntry(w, .cask, name, version, true) catch return Error.WriteFailed;
-            }
-        }
-    } else |_| {}
+    switch (util.openDbTri(ctx.io, prefix)) {
+        .absent => {},
+        .unreadable => |e| return refuseUnusableDb(prefix, e),
+        .opened => |db_val| {
+            var db = db_val;
+            defer db.close();
+            // Guarantees the tables exist, so a failing `prepare` below can
+            // only mean a genuinely broken database, never a fresh one.
+            schema.initSchema(&db) catch |e| return refuseUnusableDb(prefix, e);
+            try writeRows(
+                w,
+                &db,
+                .formula,
+                "SELECT name, version FROM kegs WHERE install_reason = 'direct' ORDER BY name;",
+            );
+            try writeRows(w, &db, .cask, "SELECT token, version FROM casks ORDER BY token;");
+        },
+    }
 
     try writeBytesToPath(ctx, path, aw.written());
+}
+
+/// Open and schema faults are the same story to the caller: no row source it
+/// can trust.
+fn refuseUnusableDb(prefix: []const u8, e: anyerror) Error {
+    output.err("cannot read database at {s}/db/malt.db ({s}) — refusing to wipe without a usable backup", .{ prefix, @errorName(e) });
+    return Error.DatabaseError;
+}
+
+/// Query failures abort rather than truncate — a short manifest reads as
+/// "fewer packages installed", which is exactly the lie to avoid here.
+fn writeRows(w: *std.Io.Writer, db: *sqlite.Database, kind: backup_mod.Kind, sql: []const u8) Error!void {
+    var stmt = db.prepare(sql) catch |e| {
+        output.err("cannot read installed packages ({s}) — refusing to wipe without a usable backup", .{@errorName(e)});
+        return Error.DatabaseError;
+    };
+    defer stmt.finalize();
+    while (stmt.step() catch |e| {
+        output.err("database read failed mid-scan ({s}) — refusing to wipe with a partial backup", .{@errorName(e)});
+        return Error.DatabaseError;
+    }) {
+        const name_ptr = stmt.columnText(0) orelse continue;
+        const ver_ptr = stmt.columnText(1);
+        const name = std.mem.sliceTo(name_ptr, 0);
+        const version = if (ver_ptr) |p| std.mem.sliceTo(p, 0) else "";
+        backup_mod.writeEntry(w, kind, name, version, true) catch return Error.WriteFailed;
+    }
 }
 
 fn writeBytesToPath(ctx: *const AppCtx, path: []const u8, bytes: []const u8) Error!void {
@@ -236,7 +253,7 @@ pub fn runWipe(ctx: *const AppCtx, allocator: std.mem.Allocator, opts: Options, 
         if (dry_run) {
             output.info("would write backup manifest to {s}", .{bp});
         } else {
-            try writeManifest(ctx, allocator, bp);
+            writeManifest(ctx, allocator, bp) catch |e| return if (e == Error.DatabaseError) error.Aborted else e;
             output.success("backup manifest written to {s}", .{bp});
         }
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -734,7 +734,8 @@ fn dispatch(allocator: std.mem.Allocator, ctx: *const AppCtx, cmd: Command, cmd_
         .run => try run_cmd.execute(ctx, allocator, cmd_args),
         .completions => try completions.execute(ctx, cmd_args),
         .shellenv => try shellenv.execute(ctx, allocator, cmd_args),
-        .backup => try backup.execute(ctx, allocator, cmd_args),
+        // Message already printed; `Aborted` exits 1 without a stack trace.
+        .backup => backup.execute(ctx, allocator, cmd_args) catch |e| return if (e == backup.Error.DatabaseError) error.Aborted else e,
         .restore => try restore.execute(ctx, allocator, cmd_args),
         .purge => try purge.execute(ctx, allocator, cmd_args),
         .cleanup => try purge.executeCleanup(ctx, allocator, cmd_args),

--- a/tests/backup_cli_test.zig
+++ b/tests/backup_cli_test.zig
@@ -759,3 +759,74 @@ test "execute writes tap casks as <user>/<repo>/<token> so restore re-routes cor
     // attempt would 404 against the core API.
     try testing.expect(std.mem.indexOf(u8, body, "cask flux-markdown\n") == null);
 }
+
+test "execute fails when the kegs table cannot be read" {
+    // A DB that opens but whose tables are unusable must not be reported as
+    // an empty install — the backup would silently lose every package.
+    var s = try Scratch.init(testing.allocator, "bad_kegs");
+    defer s.deinit(testing.allocator);
+    try seedBrokenKegs(s.path);
+
+    quiet();
+    defer unquiet();
+
+    try testing.expectError(
+        backup.Error.DatabaseError,
+        backup.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "--output", "/tmp/discard.txt" }),
+    );
+}
+
+test "execute --json fails when the kegs table cannot be read" {
+    var s = try Scratch.init(testing.allocator, "bad_kegs_json");
+    defer s.deinit(testing.allocator);
+    try seedBrokenKegs(s.path);
+
+    const prior = withJson();
+    defer restoreJson(prior);
+    quiet();
+    defer unquiet();
+
+    try testing.expectError(
+        backup.Error.DatabaseError,
+        backup.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "--output", "/tmp/discard.json" }),
+    );
+}
+
+/// A `kegs` table with the wrong shape: `initSchema`'s CREATE IF NOT EXISTS
+/// is a no-op over it, so the column-selecting prepare is what fails.
+fn seedBrokenKegs(prefix: []const u8) !void {
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    var st = try db.prepare("CREATE TABLE kegs(x);");
+    defer st.finalize();
+    _ = try st.step();
+}
+
+test "execute --services fails when the services table cannot be read" {
+    // `--services` adds its own query, so it needs its own guard.
+    var s = try Scratch.init(testing.allocator, "bad_services");
+    defer s.deinit(testing.allocator);
+    try seedRows(s.path);
+    {
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{s.path}, 0);
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        var st = try db.prepare("DROP TABLE services;");
+        defer st.finalize();
+        _ = try st.step();
+        var st2 = try db.prepare("CREATE TABLE services(x);");
+        defer st2.finalize();
+        _ = try st2.step();
+    }
+
+    quiet();
+    defer unquiet();
+
+    try testing.expectError(
+        backup.Error.DatabaseError,
+        backup.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "--services", "--output", "/tmp/discard.txt" }),
+    );
+}

--- a/tests/purge_scopes_test.zig
+++ b/tests/purge_scopes_test.zig
@@ -697,3 +697,151 @@ test "multi-scope dry-run renders the summary table when more than one scope ran
     const ctx = malt.app_ctx.debug_ctx;
     try purge.execute(&ctx, allocator, &.{"--housekeeping"});
 }
+
+test "--wipe --backup refuses an unreadable database and leaves the prefix intact" {
+    // The manifest is the wipe's only safety net: if it cannot be built from
+    // a real DB, deleting the prefix destroys the install record for good.
+    const allocator = testing.allocator;
+    var prefix = try ScratchPrefix.init(allocator, "wipe_backup_corrupt");
+    defer prefix.deinit(allocator);
+
+    try writeFileAt(allocator, &.{ prefix.path, "Cellar", "marker" }, "x");
+    try writeFileAt(allocator, &.{ prefix.path, "db", "malt.db" }, "not a sqlite file\n");
+
+    const backup_base = try test_io.uniqueTempPath(allocator, "wipe", "corrupt");
+    defer allocator.free(backup_base);
+    const backup_path = try std.fmt.allocPrint(allocator, "{s}.txt", .{backup_base});
+    defer allocator.free(backup_path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, backup_path) catch {};
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setMode(.human);
+    output.setDryRun(false);
+    output.setNdjson(false);
+    output.setQuiet(true);
+
+    const ctx = malt.app_ctx.debug_ctx;
+    try testing.expectError(
+        error.Aborted,
+        purge.execute(&ctx, allocator, &.{ "--wipe", "--yes", "--backup", backup_path }),
+    );
+
+    // A zero-entry manifest on disk is worse than none — it reads as proof
+    // that nothing was installed.
+    try testing.expectError(
+        error.FileNotFound,
+        test_io.accessAbsolute(std.Options.debug_io, backup_path, .{}),
+    );
+
+    const marker = try std.fmt.allocPrint(allocator, "{s}/Cellar/marker", .{prefix.path});
+    defer allocator.free(marker);
+    try test_io.accessAbsolute(std.Options.debug_io, marker, .{});
+}
+
+test "--cache --backup refuses an unreadable database before any scope runs" {
+    // Same guard on the non-wipe backup call site.
+    const allocator = testing.allocator;
+    var prefix = try ScratchPrefix.init(allocator, "cache_backup_corrupt");
+    defer prefix.deinit(allocator);
+
+    try writeFileAt(allocator, &.{ prefix.path, "db", "malt.db" }, "not a sqlite file\n");
+
+    const backup_base = try test_io.uniqueTempPath(allocator, "cache", "corrupt");
+    defer allocator.free(backup_base);
+    const backup_path = try std.fmt.allocPrint(allocator, "{s}.txt", .{backup_base});
+    defer allocator.free(backup_path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, backup_path) catch {};
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setMode(.human);
+    output.setDryRun(false);
+    output.setNdjson(false);
+    output.setQuiet(true);
+
+    const ctx = malt.app_ctx.debug_ctx;
+    try testing.expectError(
+        error.Aborted,
+        purge.execute(&ctx, allocator, &.{ "--cache", "--yes", "--backup", backup_path }),
+    );
+    try testing.expectError(
+        error.FileNotFound,
+        test_io.accessAbsolute(std.Options.debug_io, backup_path, .{}),
+    );
+}
+
+test "--wipe --backup refuses a database whose kegs table is unreadable" {
+    // Opens fine, schema is unusable: the manifest would silently claim the
+    // prefix held nothing.
+    const allocator = testing.allocator;
+    var prefix = try ScratchPrefix.init(allocator, "wipe_backup_badtable");
+    defer prefix.deinit(allocator);
+
+    try writeFileAt(allocator, &.{ prefix.path, "Cellar", "marker" }, "x");
+    {
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix.path}, 0);
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        var st = try db.prepare("CREATE TABLE kegs(x);");
+        defer st.finalize();
+        _ = try st.step();
+    }
+
+    const backup_base = try test_io.uniqueTempPath(allocator, "wipe", "badtable");
+    defer allocator.free(backup_base);
+    const backup_path = try std.fmt.allocPrint(allocator, "{s}.txt", .{backup_base});
+    defer allocator.free(backup_path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, backup_path) catch {};
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setMode(.human);
+    output.setDryRun(false);
+    output.setNdjson(false);
+    output.setQuiet(true);
+
+    const ctx = malt.app_ctx.debug_ctx;
+    try testing.expectError(
+        error.Aborted,
+        purge.execute(&ctx, allocator, &.{ "--wipe", "--yes", "--backup", backup_path }),
+    );
+
+    const marker = try std.fmt.allocPrint(allocator, "{s}/Cellar/marker", .{prefix.path});
+    defer allocator.free(marker);
+    try test_io.accessAbsolute(std.Options.debug_io, marker, .{});
+}
+
+test "--wipe --backup writes an empty manifest when the prefix never had a database" {
+    // The `.absent` arm: no `db/` at all, so SQLite cannot even create a file.
+    // This is the one empty manifest that is honest, and the refusal above
+    // must not swallow it.
+    const allocator = testing.allocator;
+    var prefix = try ScratchPrefix.init(allocator, "wipe_backup_nodb");
+    defer prefix.deinit(allocator);
+
+    const db_dir = try std.fmt.allocPrint(allocator, "{s}/db", .{prefix.path});
+    defer allocator.free(db_dir);
+    try test_io.deleteTreeAbsolute(std.Options.debug_io, db_dir);
+
+    try writeFileAt(allocator, &.{ prefix.path, "Cellar", "marker" }, "x");
+
+    const backup_base = try test_io.uniqueTempPath(allocator, "wipe", "nodb");
+    defer allocator.free(backup_base);
+    const backup_path = try std.fmt.allocPrint(allocator, "{s}.txt", .{backup_base});
+    defer allocator.free(backup_path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, backup_path) catch {};
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setMode(.human);
+    output.setDryRun(false);
+    output.setNdjson(false);
+    output.setQuiet(true);
+
+    const ctx = malt.app_ctx.debug_ctx;
+    try purge.execute(&ctx, allocator, &.{ "--wipe", "--yes", "--backup", backup_path });
+
+    try test_io.accessAbsolute(std.Options.debug_io, backup_path, .{});
+}


### PR DESCRIPTION
## Description

`purge --wipe --backup` treated an unreadable database as "nothing is
installed": it wrote a header-only manifest, reported success, then deleted the prefix - losing the only record of what had been installed. `backup` had the same blind spot, reporting `(0 packages)` with exit 0.

A backup that cannot be trusted now stops the wipe before any delete, leaves the prefix intact, and writes no manifest - an empty file reads as proof that nothing was installed. A prefix that genuinely has no database still gets an empty manifest and completes as before.

## Related Issue

- None

## Notes for Reviewers

- None