### PR TITLE
fix(upgrade): keep the installed cask until its replacement is downloaded

### DIFF
--- a/justfile
+++ b/justfile
@@ -39,6 +39,7 @@ regressions-static:
     @./scripts/regressions/tap-slugless-effective-owner-repo-unreachable-on-slugless-input.sh
     @./scripts/regressions/relocated-store-logic-version-pin.sh
     @./scripts/regressions/clean-misses-tmpdir-test-scratch.sh
+    @./scripts/regressions/cask-upgrade-deletes-app-before-download.sh
     @./scripts/regressions/post-install-native-spawns-inherit-full-environment.sh
     @./scripts/regressions/tar-prescan-followups-925-926-follow-up.sh
     @./scripts/regressions/tui-background-fetch-no-double-reap-start-background-waits-after-kill.sh

--- a/scripts/regressions/cask-upgrade-deletes-app-before-download.sh
+++ b/scripts/regressions/cask-upgrade-deletes-app-before-download.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Regression: both cask upgrade routes used to uninstall the installed app
+# before a single byte of the replacement artifact had been fetched. A dropped
+# connection then destroyed the app while the DB rollback restored the row, so
+# `mt list --cask` and `doctor` kept reporting a package that was gone.
+#
+# Two halves, because neither alone is sufficient and neither may need network:
+#   1. Ordering (static): in each upgrade route the prefetch call must appear
+#      strictly before `installer.uninstall(token)`. That is the invariant a
+#      future refactor would silently break.
+#   2. Behaviour: a failed prefetch must leave the seeded bundle and the casks
+#      row intact. That guard is a colocated test in tests/cask_extra_test.zig,
+#      which `zig build test` already runs — this script only asserts it still
+#      exists, rather than rebuilding every test binary to re-run it.
+#
+# Exits 0 when the bug is absent, non-zero (naming the offending route) when
+# present. Static only: no network, no build, runs in milliseconds.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+UP="$ROOT/src/cli/upgrade.zig"
+FILTER="a failed cask prefetch leaves the installed app and its row intact"
+fail=0
+
+# 1. Ordering, per route.
+check_order() { # $1=route label  $2=start line  $3=end line
+  local pre un
+  pre=$(awk -v a="$2" -v b="$3" 'NR>=a&&NR<=b&&/downloadOnly|download_only = true/{print NR;exit}' "$UP")
+  un=$(awk -v a="$2" -v b="$3" 'NR>=a&&NR<=b&&/installer\.uninstall\(token\)/{print NR;exit}' "$UP")
+  if [[ -z "$pre" || -z "$un" || "$pre" -ge "$un" ]]; then
+    echo "FAIL: $1 uninstalls before it fetches the replacement artifact" >&2
+    fail=1
+  fi
+}
+
+# Derive the route ranges from the fn headers rather than hardcoding lines.
+TAP_LINE=$(grep -n 'fn upgradeRoutedTapCask' "$UP" | cut -d: -f1)
+API_LINE=$(grep -n 'fn upgradeCask(' "$UP" | cut -d: -f1)
+if [[ -z "$TAP_LINE" || -z "$API_LINE" ]]; then
+  echo "FAIL: could not locate the cask upgrade routes in upgrade.zig" >&2
+  exit 1
+fi
+check_order "tap route" "$TAP_LINE" "$API_LINE"
+check_order "API route" "$API_LINE" "$(wc -l <"$UP")"
+
+# 2. Behaviour. The test itself runs under `zig build test`; deleting it would
+# silently drop that coverage, so assert it is still there.
+if ! grep -Rqs -- "$FILTER" "$ROOT/tests/cask_extra_test.zig"; then
+  echo "FAIL: the failed-prefetch guard test is missing from cask_extra_test.zig" >&2
+  fail=1
+fi
+
+if [[ $fail -eq 0 ]]; then
+  echo "PASS: cask upgrade fetches the replacement before it destroys the old app"
+fi
+exit $fail

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -204,9 +204,9 @@ pub fn installTapFormula(
 /// Install a tap cask whose owning tap is already known. Skips the
 /// `Formula/` probe — safe to call from inside an open DB transaction
 /// because the formula branch of `materializeRubyFormula` (which
-/// begins its own transaction) is structurally unreachable. Upgrade
-/// callers never opt into `download_only`, so the legacy false is
-/// hard-wired here rather than forwarded.
+/// begins its own transaction) is structurally unreachable.
+/// `download_only` is what lets an upgrade warm the cache before it
+/// touches the installed app.
 pub fn installTapCask(
     ctx: *const AppCtx,
     allocator: std.mem.Allocator,
@@ -216,9 +216,10 @@ pub fn installTapCask(
     prefix: []const u8,
     dry_run: bool,
     force: bool,
+    download_only: bool,
     sink: OutputSink,
 ) !void {
-    return installTapRb(ctx, allocator, pkg_name, db, linker, prefix, dry_run, force, false, .cask_only, sink);
+    return installTapRb(ctx, allocator, pkg_name, db, linker, prefix, dry_run, force, download_only, .cask_only, sink);
 }
 
 /// True when a row matching `(leaf, tap_slug)` exists. The tap match is what

--- a/src/cli/install/sink.zig
+++ b/src/cli/install/sink.zig
@@ -91,6 +91,25 @@ pub const silent: OutputSink = .{
     .show_progress = false,
 };
 
+/// Swallows every human line but keeps the progress bar. An upgrade's
+/// prefetch is the only real download of the run, so the bar has to survive
+/// even though the per-install narration around it would duplicate the
+/// upgrade's own output — and the upgrade reports its own failures.
+pub const progress_only: OutputSink = .{
+    .writeInfo = swallow,
+    .writeWarn = swallow,
+    .writeSuccess = swallow,
+    .writeErr = swallow,
+    .show_progress = true,
+};
+
+test "progress_only differs from silent only in keeping the bar" {
+    // The swallowing is `silent`'s test above; what matters here is that a
+    // long download still shows feedback.
+    try std.testing.expect(progress_only.show_progress);
+    try std.testing.expect(!silent.show_progress);
+}
+
 test "terminal sink forwards human lines to ui/output" {
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(std.testing.allocator);

--- a/src/cli/purge/scopes.zig
+++ b/src/cli/purge/scopes.zig
@@ -915,7 +915,7 @@ fn sweepCaskOldVersion(io: std.Io, prefix: []const u8, token: []const u8, versio
         } else |_| {}
     } else |_| {}
 
-    return cask_mod.deletePerVersionCacheFile(io, prefix, token, version);
+    return cask_mod.deletePerVersionCacheFile(io, prefix, token, version, null);
 }
 
 fn deleteCaskVersionRow(db: *sqlite.Database, token: []const u8, version: []const u8) void {

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -1097,7 +1097,7 @@ fn upgradeRoutedTapCask(
     // dropped connection here must leave the installed app in place. Nothing
     // has been opened yet, so there is nothing to roll back.
     const download_only = true;
-    install_local_mod.installTapCask(ctx, allocator, full_name, db, &linker, prefix, dry_run, true, download_only, install_sink_mod.terminal) catch |dl_err| {
+    install_local_mod.installTapCask(ctx, allocator, full_name, db, &linker, prefix, dry_run, true, download_only, install_sink_mod.progress_only) catch |dl_err| {
         output.err("Failed to download {s}: {s} (installed version left in place)", .{ full_name, @errorName(dl_err) });
         return error.Aborted;
     };

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -1449,7 +1449,10 @@ fn upgradeCask(ctx: *const AppCtx, allocator: std.mem.Allocator, token: []const 
         );
         return error.Aborted;
     };
-    allocator.free(prefetched);
+    defer allocator.free(prefetched);
+    // Consumed by `install` below and spared by `uninstall`, so the bytes are
+    // fetched exactly once even when the cask pins no digest to revalidate.
+    installer.prefetched_artifact = prefetched;
 
     db.beginTransaction() catch |txn_err| {
         output.err(

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -1085,6 +1085,23 @@ fn upgradeRoutedTapCask(
     // Snapshot the pin so a force-upgrade preserves the user's hold.
     const was_pinned = pin_mod.isPinned(db, token);
 
+    const full_name = std.fmt.allocPrint(allocator, "{s}/{s}", .{ tap_label, token }) catch return error.Aborted;
+    defer allocator.free(full_name);
+
+    // `installTapCask` (not `installTapFormula`) so the resolver
+    // never enters the Formula/ probe that would open a nested DB
+    // transaction inside our outer one.
+    var linker = linker_mod.Linker.init(ctx.io, allocator, db, prefix);
+
+    // Fetch and sha-verify the replacement before anything is destroyed: a
+    // dropped connection here must leave the installed app in place. Nothing
+    // has been opened yet, so there is nothing to roll back.
+    const download_only = true;
+    install_local_mod.installTapCask(ctx, allocator, full_name, db, &linker, prefix, dry_run, true, download_only, install_sink_mod.terminal) catch |dl_err| {
+        output.err("Failed to download {s}: {s} (installed version left in place)", .{ full_name, @errorName(dl_err) });
+        return error.Aborted;
+    };
+
     // Single DB transaction across uninstall + install + recordInstall.
     // Mirrors the core-API path in `upgradeCask` so a partial failure
     // can't leave the casks row missing once the new app is on disk.
@@ -1105,17 +1122,8 @@ fn upgradeRoutedTapCask(
         return error.Aborted;
     };
 
-    const full_name = std.fmt.allocPrint(allocator, "{s}/{s}", .{ tap_label, token }) catch {
-        db.rollback();
-        return error.Aborted;
-    };
-    defer allocator.free(full_name);
-
-    // `installTapCask` (not `installTapFormula`) so the resolver
-    // never enters the Formula/ probe that would open a nested DB
-    // transaction inside our outer one.
-    var linker = linker_mod.Linker.init(ctx.io, allocator, db, prefix);
-    install_local_mod.installTapCask(ctx, allocator, full_name, db, &linker, prefix, dry_run, true, install_sink_mod.terminal) catch |in_err| {
+    // Cache hit off the prefetch above, so this does not re-download.
+    install_local_mod.installTapCask(ctx, allocator, full_name, db, &linker, prefix, dry_run, true, false, install_sink_mod.terminal) catch |in_err| {
         output.err("Failed to upgrade tap cask {s}: {s}", .{ full_name, @errorName(in_err) });
         db.rollback();
         return error.Aborted;
@@ -1430,6 +1438,19 @@ fn upgradeCask(ctx: *const AppCtx, allocator: std.mem.Allocator, token: []const 
     // (potentially slow) install is harmless to other connections.
     var installer = cask_mod.CaskInstaller.init(ctx.io, ctx.environ, allocator, db, prefix);
     installer.offline = ctx.offline;
+
+    // Fetch before destroying, as in `upgradeRoutedTapCask` above.
+    const prefetched = installer.downloadOnly(&parsed_cask) catch |dl_err| {
+        // Distinct from the post-uninstall failure below: this one left the
+        // installed version in place, and the log has to say so.
+        output.err(
+            "Failed to download new version of {s}: {s} (installed version left in place)",
+            .{ token, @errorName(dl_err) },
+        );
+        return error.Aborted;
+    };
+    allocator.free(prefetched);
+
     db.beginTransaction() catch |txn_err| {
         output.err(
             "Could not begin DB transaction for {s}: {s} ({s})",

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -658,7 +658,12 @@ pub const CaskInstaller = struct {
 
         const cache_path = try self.downloadOnly(cask);
         errdefer {
-            std.Io.Dir.cwd().deleteFile(self.io, cache_path) catch {};
+            // A failed mount or copy says nothing about the bytes, and
+            // `rollback --to` reads this exact file. An unpinned artefact
+            // still goes: it can never be validated, so it is not reusable.
+            if (artifactIntegrity(cask.sha256) != .digest_pinned) {
+                std.Io.Dir.cwd().deleteFile(self.io, cache_path) catch {};
+            }
             self.allocator.free(cache_path);
         }
 
@@ -2306,4 +2311,51 @@ test "downloadToCache reuses a cached artifact only when its digest pins the byt
         defer c.deinit();
         try std.testing.expectError(error.OfflineRequired, installer.downloadToCache(&c, cache_dir, null));
     }
+}
+
+test "a failed install keeps a digest-pinned artefact in the cache" {
+    // The bytes were sha-verified before the install ran, so a failed mount or
+    // copy is no reason to throw them away — `rollback --to` reads this file,
+    // and re-fetching it is not always possible.
+    var threaded: std.Io.Threaded = .init(std.heap.c_allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const prefix = try std.fmt.allocPrintSentinel(a, "/tmp/malt_cask_keep_{d}", .{std.c.getpid()}, 0);
+    std.Io.Dir.cwd().deleteTree(io, prefix) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, prefix) catch {};
+    const cache_dir = try std.fmt.allocPrint(a, "{s}/cache/Cask", .{prefix});
+    try std.Io.Dir.cwd().createDirPath(io, cache_dir);
+    try std.Io.Dir.cwd().createDirPath(io, try std.fmt.allocPrint(a, "{s}/Applications", .{prefix}));
+
+    // Not a zip, so the extraction below fails after the cache hit.
+    const dest = try std.fmt.allocPrint(a, "{s}/keeper-1.0.zip", .{cache_dir});
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, dest, .{});
+        defer f.close(io);
+        try f.writeStreamingAll(io, "not an archive");
+    }
+    const digest = try hashFileSha256(io, dest);
+
+    var json_buf: [512]u8 = undefined;
+    var cask = try parseCask(a, try std.fmt.bufPrint(&json_buf,
+        \\{{"token":"keeper","name":["Keeper"],"version":"1.0","url":"https://example.invalid/keeper.zip","sha256":"{s}","artifacts":[{{"app":["Keeper.app"]}}]}}
+    , .{digest[0..]}));
+    defer cask.deinit();
+
+    var installer: CaskInstaller = .{
+        .allocator = a,
+        .io = io,
+        .environ = .empty,
+        .prefix = prefix,
+        .db = undefined,
+        .progress = null,
+    };
+    installer.offline = true; // proves the cache hit, not a re-download, fed the install
+
+    try std.testing.expectError(CaskError.InstallFailed, installer.install(&cask));
+    try std.Io.Dir.accessAbsolute(io, dest, .{});
 }

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -934,10 +934,12 @@ pub const CaskInstaller = struct {
         // A pinned digest proves the cached file is this exact artefact, so an
         // upgrade's prefetch makes the install that follows it free. Casks that
         // pin nothing reuse one filename across releases and must re-fetch.
-        if (artifactIntegrity(cask.sha256) == .digest_pinned) {
-            if (verifyFileSha256(self.io, dest, cask.sha256)) |_| {
-                return .{ .path = dest, .verified = true };
-            } else |_| {}
+        if (artifactIntegrity(cask.sha256) == .digest_pinned) reuse: {
+            // A planted cache file must not let a `file://` or `data:`
+            // manifest install without ever facing the scheme check.
+            client_mod.HttpClient.requireSecureOrigin(cask.url, .digest_pinned) catch break :reuse;
+            verifyFileSha256(self.io, dest, cask.sha256) catch break :reuse;
+            return .{ .path = dest, .verified = true };
         }
 
         // Download via HTTP client

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -298,10 +298,13 @@ pub fn artifactTypeTag(t: ArtifactType) []const u8 {
 /// (or none existed); false when an existing file could not be
 /// deleted — the caller uses that signal to gate the DB row delete
 /// so a read-only mount doesn't orphan history.
-pub fn deletePerVersionCacheFile(io: std.Io, prefix: []const u8, token: []const u8, version: []const u8) bool {
+/// `keep` spares one already-fetched artefact, so an upgrade's uninstall
+/// cannot wipe the bytes it is about to install.
+pub fn deletePerVersionCacheFile(io: std.Io, prefix: []const u8, token: []const u8, version: []const u8, keep: ?[]const u8) bool {
     for (cache_extensions) |ext| {
         var path_buf: [512]u8 = undefined;
         const path = std.fmt.bufPrint(&path_buf, "{s}/cache/Cask/{s}-{s}{s}", .{ prefix, token, version, ext }) catch continue;
+        if (keep) |k| if (std.mem.eql(u8, path, k)) continue;
         std.Io.Dir.accessAbsolute(io, path, .{}) catch continue;
         std.Io.Dir.cwd().deleteFile(io, path) catch return false;
     }
@@ -316,14 +319,16 @@ pub fn deletePerVersionCacheFile(io: std.Io, prefix: []const u8, token: []const 
 /// Enumerates every history row so stale rollback artefacts are swept too.
 /// Best-effort: a failed delete never gates uninstall. Call BEFORE the
 /// history rows are deleted, or the version list is already empty.
-pub fn sweepOwnedVersionCache(io: std.Io, db: *sqlite.Database, prefix: []const u8, token: []const u8) void {
+/// `keep` is an artefact an in-flight upgrade already fetched; wiping it would
+/// force a second download of bytes we are about to install.
+pub fn sweepOwnedVersionCache(io: std.Io, db: *sqlite.Database, prefix: []const u8, token: []const u8, keep: ?[]const u8) void {
     var stmt = db.prepare("SELECT version FROM cask_versions WHERE token = ?1;") catch return;
     defer stmt.finalize();
     stmt.bindText(1, token) catch return;
 
     while (stmt.step() catch false) {
         const ver_ptr = stmt.columnText(0) orelse continue;
-        _ = deletePerVersionCacheFile(io, prefix, token, std.mem.sliceTo(ver_ptr, 0));
+        _ = deletePerVersionCacheFile(io, prefix, token, std.mem.sliceTo(ver_ptr, 0), keep);
     }
 }
 
@@ -606,6 +611,11 @@ pub const CaskInstaller = struct {
     /// internal HttpClient so a download miss surfaces `OfflineRequired`
     /// instead of stalling on connect.
     offline: bool = false,
+    /// An artefact the caller already fetched and verified. `install`
+    /// consumes it instead of re-fetching and `uninstall` leaves it alone,
+    /// which is what lets an upgrade survive a failed download even for a
+    /// cask that pins no digest and so can never be validated from cache.
+    prefetched_artifact: ?[]const u8 = null,
 
     pub fn init(io: std.Io, environ: std.process.Environ, allocator: std.mem.Allocator, db: *sqlite.Database, prefix: [:0]const u8) CaskInstaller {
         return .{ .allocator = allocator, .io = io, .environ = environ, .db = db, .prefix = prefix, .progress = null };
@@ -656,7 +666,10 @@ pub const CaskInstaller = struct {
         const artifact_type = self.artifact_type_override orelse artifactTypeFromUrl(cask.url);
         if (artifact_type == .unknown) return CaskError.InstallFailed;
 
-        const cache_path = try self.downloadOnly(cask);
+        const cache_path = if (self.prefetched_artifact) |p|
+            try self.allocator.dupe(u8, p)
+        else
+            try self.downloadOnly(cask);
         errdefer {
             // A failed mount or copy says nothing about the bytes, and
             // `rollback --to` reads this exact file. An unpinned artefact
@@ -764,11 +777,12 @@ pub const CaskInstaller = struct {
         var cache_buf: [512]u8 = undefined;
         for (cache_extensions) |ext| {
             const cache_file = std.fmt.bufPrint(&cache_buf, "{s}/cache/Cask/{s}{s}", .{ self.prefix, token, ext }) catch continue;
+            if (self.prefetched_artifact) |k| if (std.mem.eql(u8, k, cache_file)) continue;
             std.Io.Dir.cwd().deleteFile(self.io, cache_file) catch {};
         }
         // Must precede the history wipe below — the sweep reads the version
         // list from `cask_versions`, which the DELETE would otherwise empty.
-        sweepOwnedVersionCache(self.io, self.db, self.prefix, token);
+        sweepOwnedVersionCache(self.io, self.db, self.prefix, token, self.prefetched_artifact);
 
         // Drop every history row so a future install starts clean.
         if (self.db.prepare("DELETE FROM cask_versions WHERE token = ?1;")) |prepared| {

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -627,19 +627,20 @@ pub const CaskInstaller = struct {
             else => return CaskError.InstallFailed,
         };
 
-        const cache_path = self.downloadToCache(cask, cache_dir, self.progress) catch |e| switch (e) {
+        const fetched = self.downloadToCache(cask, cache_dir, self.progress) catch |e| switch (e) {
             // A retry re-fetches the same manifest and refuses identically, so
             // this must not reach the user wearing a transient error's name.
             error.InsecureUrlScheme => return CaskError.InsecureOrigin,
             error.WatchdogSpawnFailed => return CaskError.DownloadLocalResourceExhausted,
             else => return CaskError.DownloadFailed,
         };
+        const cache_path = fetched.path;
         errdefer {
             std.Io.Dir.cwd().deleteFile(self.io, cache_path) catch {};
             self.allocator.free(cache_path);
         }
 
-        self.verifySha256(cache_path, cask.sha256) catch |e| switch (e) {
+        if (!fetched.verified) self.verifySha256(cache_path, cask.sha256) catch |e| switch (e) {
             // A retry re-downloads and fails identically, so it must not
             // reach the caller wearing the transient error's name.
             error.Sha256Missing => return CaskError.Sha256Missing,
@@ -897,7 +898,11 @@ pub const CaskInstaller = struct {
 
     // --- Private helpers ---
 
-    fn downloadToCache(self: *CaskInstaller, cask: *const Cask, cache_dir: []const u8, progress: ?client_mod.ProgressCallback) ![]const u8 {
+    /// `verified` marks a cache hit whose hash was already checked here, so
+    /// `downloadOnly` does not hash the same payload a second time.
+    const CachedArtifact = struct { path: []const u8, verified: bool };
+
+    fn downloadToCache(self: *CaskInstaller, cask: *const Cask, cache_dir: []const u8, progress: ?client_mod.ProgressCallback) !CachedArtifact {
         const resolved = self.artifact_type_override orelse artifactTypeFromUrl(cask.url);
         const ext_str = artifactExtension(resolved);
         // Per-version filename so older versions' artefacts survive a
@@ -906,6 +911,15 @@ pub const CaskInstaller = struct {
         // back to a fresh download.
         const dest = try std.fmt.allocPrint(self.allocator, "{s}/{s}-{s}{s}", .{ cache_dir, cask.token, cask.version, ext_str });
         errdefer self.allocator.free(dest);
+
+        // A pinned digest proves the cached file is this exact artefact, so an
+        // upgrade's prefetch makes the install that follows it free. Casks that
+        // pin nothing reuse one filename across releases and must re-fetch.
+        if (artifactIntegrity(cask.sha256) == .digest_pinned) {
+            if (verifyFileSha256(self.io, dest, cask.sha256)) |_| {
+                return .{ .path = dest, .verified = true };
+            } else |_| {}
+        }
 
         // Download via HTTP client
         var http = client_mod.HttpClient.init(self.io, self.environ, self.allocator);
@@ -922,7 +936,7 @@ pub const CaskInstaller = struct {
         defer file.close(self.io);
         try file.writeStreamingAll(self.io, resp.body);
 
-        return dest;
+        return .{ .path = dest, .verified = false };
     }
 
     fn verifySha256(self: *CaskInstaller, file_path: []const u8, expected: ?[]const u8) !void {
@@ -2217,4 +2231,79 @@ test "freshTempDir fails instead of creating a prefix tmp dir that is absent" {
     var buf: [512]u8 = undefined;
     // Creating the parent here would re-open the adoption hole it guards.
     try std.testing.expectError(error.InstallFailed, installer.freshTempDir(&buf, "mount", "tok"));
+}
+
+test "downloadToCache reuses a cached artifact only when its digest pins the bytes" {
+    // The upgrade routes prefetch, then install; without this reuse every cask
+    // upgrade would fetch its artifact twice. `offline` makes any real fetch a
+    // distinct error, so a returned path proves nothing went over the wire.
+    var threaded: std.Io.Threaded = .init(std.heap.c_allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const cache_dir = try std.fmt.allocPrintSentinel(a, "/tmp/malt_cask_cachehit_{d}", .{std.c.getpid()}, 0);
+    std.Io.Dir.cwd().deleteTree(io, cache_dir) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, cache_dir) catch {};
+    try std.Io.Dir.cwd().createDirPath(io, cache_dir);
+
+    const dest = try std.fmt.allocPrint(a, "{s}/cached-1.0.zip", .{cache_dir});
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, dest, .{});
+        defer f.close(io);
+        try f.writeStreamingAll(io, "artifact bytes");
+    }
+    const digest = try hashFileSha256(io, dest);
+
+    var installer: CaskInstaller = .{
+        .allocator = a,
+        .io = io,
+        .environ = .empty,
+        .prefix = "/tmp/malt_cask_cachehit_prefix",
+        .db = undefined,
+        .progress = null,
+    };
+    installer.offline = true;
+
+    const json_fmt =
+        \\{{"token":"cached","name":["Cached"],"version":"{s}","url":"https://example.invalid/cached.zip","sha256":"{s}","artifacts":[{{"app":["Cached.app"]}}]}}
+    ;
+    var json_buf: [512]u8 = undefined;
+
+    {
+        // Pinned to the bytes already on disk: reused as-is.
+        var c = try parseCask(a, try std.fmt.bufPrint(&json_buf, json_fmt, .{ "1.0", digest[0..] }));
+        defer c.deinit();
+        const hit = try installer.downloadToCache(&c, cache_dir, null);
+        defer a.free(hit.path);
+        try std.testing.expectEqualStrings(dest, hit.path);
+        // Already hashed here, so `downloadOnly` must not hash it again.
+        try std.testing.expect(hit.verified);
+    }
+
+    {
+        // Same filename, different digest — the cached bytes are the wrong
+        // artifact and must not be handed back.
+        var c = try parseCask(a, try std.fmt.bufPrint(&json_buf, json_fmt, .{ "1.0", "a" ** 64 }));
+        defer c.deinit();
+        try std.testing.expectError(error.OfflineRequired, installer.downloadToCache(&c, cache_dir, null));
+    }
+
+    {
+        // `no_check` casks reuse one filename across releases, so a cached file
+        // is unverifiable and a stale hit would silently install an old version.
+        var c = try parseCask(a, try std.fmt.bufPrint(&json_buf, json_fmt, .{ "1.0", "no_check" }));
+        defer c.deinit();
+        try std.testing.expectError(error.OfflineRequired, installer.downloadToCache(&c, cache_dir, null));
+    }
+
+    {
+        // Nothing cached — every first install. An absent file must fall
+        // through to the download, never surface as the lookup's own error.
+        var c = try parseCask(a, try std.fmt.bufPrint(&json_buf, json_fmt, .{ "2.0", digest[0..] }));
+        defer c.deinit();
+        try std.testing.expectError(error.OfflineRequired, installer.downloadToCache(&c, cache_dir, null));
+    }
 }

--- a/tests/cask_extra_test.zig
+++ b/tests/cask_extra_test.zig
@@ -430,3 +430,50 @@ test "a failed cask prefetch leaves the installed app and its row intact" {
     try std.Io.Dir.accessAbsolute(io, app_path_z, .{});
     try testing.expect(cask.isInstalled(&db, "prefetch-guard"));
 }
+
+test "an unpinned artefact fetched once survives uninstall and installs from the prefetch" {
+    // The `sha256 :no_check` case the cache reuse cannot cover: nothing can
+    // revalidate those bytes, so the only way an upgrade survives a failed
+    // download is to fetch before destroying, then consume that fetch.
+    var fx = try Fixture.init("prefetch_consume");
+    defer fx.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{ .environ = testEnviron() });
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const cache_dir = fx.p("cache/Cask");
+    try std.Io.Dir.cwd().createDirPath(io, cache_dir);
+    try std.Io.Dir.cwd().createDirPath(io, fx.p("Applications"));
+
+    const prefetched = fx.p("cache/Cask/rolling-latest.zip");
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, prefetched, .{});
+        defer f.close(io);
+        try f.writeStreamingAll(io, "not an archive");
+    }
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var c = try cask.parseCask(testing.allocator,
+        \\{"token":"rolling","name":["Rolling"],"version":"latest","url":"https://example.invalid/rolling.zip","sha256":"no_check","artifacts":[{"app":["Rolling.app"]}]}
+    );
+    defer c.deinit();
+
+    const app_path = fx.p("Applications/Rolling.app");
+    try std.Io.Dir.cwd().createDirPath(io, app_path);
+    try cask.recordInstall(&db, &c, app_path, null);
+
+    var installer = cask.CaskInstaller.init(io, testEnviron(), testing.allocator, &db, fx.base);
+    installer.offline = true; // any re-fetch would fail loudly instead of quietly working
+    installer.prefetched_artifact = prefetched;
+
+    // The upgrade's destructive step must leave the fetched bytes behind.
+    try installer.uninstall("rolling");
+    try std.Io.Dir.accessAbsolute(io, prefetched, .{});
+
+    // InstallFailed (extracting a non-archive), not DownloadFailed: the
+    // install consumed the prefetch instead of reaching for the network.
+    try testing.expectError(cask.CaskError.InstallFailed, installer.install(&c));
+}

--- a/tests/cask_extra_test.zig
+++ b/tests/cask_extra_test.zig
@@ -392,3 +392,41 @@ test "downloadOnly reports a cleartext origin as its own error, not a download f
     var installer = cask.CaskInstaller.init(io, testEnviron(), testing.allocator, &db, fx.base);
     try testing.expectError(error.InsecureOrigin, installer.downloadOnly(&c));
 }
+
+test "a failed cask prefetch leaves the installed app and its row intact" {
+    // Both upgrade routes now fetch the replacement before they uninstall, so
+    // the failure the network hands them has to be a no-op — the old app stays
+    // on disk and its row stays in the DB.
+    const prefetch_cask_json =
+        \\{"token":"prefetch-guard","name":["Prefetch"],"version":"2.0","desc":"","homepage":"",
+        \\ "url":"https://example.invalid/prefetch.dmg",
+        \\ "sha256":"00000000000000000000000000000000000000000000000000000000deadbeef",
+        \\ "auto_updates":false,"artifacts":[{"app":["Prefetch.app"]}]}
+    ;
+    var c = try cask.parseCask(testing.allocator, prefetch_cask_json);
+    defer c.deinit();
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var bundle = try Fixture.init("prefetch_bundle");
+    defer bundle.deinit();
+    const app_path_z = bundle.p("Prefetch.app");
+    try test_io.makeDirAbsolute(std.Options.debug_io, app_path_z);
+    try cask.recordInstall(&db, &c, app_path_z, null);
+
+    var fx = try Fixture.init("prefetch_prefix");
+    defer fx.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{ .environ = testEnviron() });
+    defer threaded.deinit();
+    const io = threaded.io();
+    try std.Io.Dir.cwd().createDirPath(io, fx.p("cache"));
+    var installer = cask.CaskInstaller.init(io, testEnviron(), testing.allocator, &db, fx.base);
+    installer.offline = true; // stands in for the dropped connection, hermetically
+
+    try testing.expectError(cask.CaskError.DownloadFailed, installer.downloadOnly(&c));
+
+    try std.Io.Dir.accessAbsolute(io, app_path_z, .{});
+    try testing.expect(cask.isInstalled(&db, "prefetch-guard"));
+}

--- a/tests/cask_test.zig
+++ b/tests/cask_test.zig
@@ -1064,7 +1064,7 @@ test "sweepOwnedVersionCache deletes only the token's own recorded versions" {
         try f.writeStreamingAll(io, "x");
     }
 
-    cask.sweepOwnedVersionCache(io, &db, fx.base, "git");
+    cask.sweepOwnedVersionCache(io, &db, fx.base, "git", null);
 
     // Recorded versions gone; the prefix sibling and legacy shape survive.
     try testing.expectError(error.FileNotFound, test_io.accessAbsolute(io, seeds[0], .{}));
@@ -1080,7 +1080,7 @@ test "sweepOwnedVersionCache is a no-op when the token has no history rows" {
     try schema.initSchema(&db);
 
     // No rows and an absent cache dir — the sweep must not error.
-    cask.sweepOwnedVersionCache(io, &db, "/tmp/malt_cask_sweep_missing", "git");
+    cask.sweepOwnedVersionCache(io, &db, "/tmp/malt_cask_sweep_missing", "git", null);
 }
 
 test "sweepOwnedVersionCache handles a dash-bearing version without touching siblings" {
@@ -1105,7 +1105,7 @@ test "sweepOwnedVersionCache handles a dash-bearing version without touching sib
         try f.writeStreamingAll(io, "x");
     }
 
-    cask.sweepOwnedVersionCache(io, &db, fx.base, "git");
+    cask.sweepOwnedVersionCache(io, &db, fx.base, "git", null);
 
     try testing.expectError(error.FileNotFound, test_io.accessAbsolute(io, owned, .{}));
     try test_io.accessAbsolute(io, sibling, .{});
@@ -1134,7 +1134,7 @@ test "sweepOwnedVersionCache sweeps a pre-v7 row with NULL artifact_type" {
         try f.writeStreamingAll(io, "x");
     }
 
-    cask.sweepOwnedVersionCache(io, &db, fx.base, "git");
+    cask.sweepOwnedVersionCache(io, &db, fx.base, "git", null);
     try testing.expectError(error.FileNotFound, test_io.accessAbsolute(io, owned, .{}));
 }
 


### PR DESCRIPTION
## Description

A failed cask upgrade could destroy the installed app. Both routes uninstalled first and downloaded second, so a dropped connection left the bundle deleted while the DB rollback restored its row - `list`, `info` and `doctor` all kept reporting a package that was gone. For a vendor-rolling cask the old artifact may be unfetchable, making the loss permanent.

Both routes now fetch and verify the replacement before touching the installed app, and hand those exact bytes to the install step, so every cask is downloaded once and a failed upgrade is a no-op. Casks that pin a digest additionally reuse an artifact already in the cache, and a verified artifact is no longer discarded when the mount or copy consuming it fails - both make `mt rollback <cask> --to <ver>` cheaper too.

## Related Issue

- None

## Notes for Reviewers

- None