### PR TITLE
fix(upgrade): install a tap cask from the bytes its prefetch fetched

### DIFF
--- a/scripts/regressions/cask-upgrade-deletes-app-before-download.sh
+++ b/scripts/regressions/cask-upgrade-deletes-app-before-download.sh
@@ -44,6 +44,15 @@ fi
 check_order "tap route" "$TAP_LINE" "$API_LINE"
 check_order "API route" "$API_LINE" "$(wc -l <"$UP")"
 
+# 1b. The tap route must hand the artefact it fetched to its install pass.
+# Without that, the uninstall's cache sweep can drop those bytes and the
+# install goes back to the network with the old app already deleted.
+slots=$(awk -v a="$TAP_LINE" -v b="$API_LINE" 'NR>=a&&NR<=b&&/installTapCask\(/&&/&prefetched/{n++} END{print n+0}' "$UP")
+if [[ "$slots" -ne 2 ]]; then
+  echo "FAIL: tap route does not carry its prefetched artefact into the install pass" >&2
+  fail=1
+fi
+
 # 2. Behaviour. The test itself runs under `zig build test`; deleting it would
 # silently drop that coverage, so assert it is still there.
 if ! grep -Rqs -- "$FILTER" "$ROOT/tests/cask_extra_test.zig"; then

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -198,7 +198,7 @@ pub fn installTapFormula(
     download_only: bool,
     sink: OutputSink,
 ) !void {
-    return installTapRb(ctx, allocator, pkg_name, db, linker, prefix, dry_run, force, download_only, .formula_or_cask, sink);
+    return installTapRb(ctx, allocator, pkg_name, db, linker, prefix, dry_run, force, download_only, .formula_or_cask, null, sink);
 }
 
 /// Install a tap cask whose owning tap is already known. Skips the
@@ -207,6 +207,11 @@ pub fn installTapFormula(
 /// begins its own transaction) is structurally unreachable.
 /// `download_only` is what lets an upgrade warm the cache before it
 /// touches the installed app.
+///
+/// `prefetch_slot` carries that artefact between an upgrade's two passes:
+/// the download-only pass fills it and hands over ownership, the install
+/// pass consumes it instead of fetching again. Callers with a single pass
+/// pass null and keep today's behaviour.
 pub fn installTapCask(
     ctx: *const AppCtx,
     allocator: std.mem.Allocator,
@@ -217,9 +222,10 @@ pub fn installTapCask(
     dry_run: bool,
     force: bool,
     download_only: bool,
+    prefetch_slot: ?*?[]const u8,
     sink: OutputSink,
 ) !void {
-    return installTapRb(ctx, allocator, pkg_name, db, linker, prefix, dry_run, force, download_only, .cask_only, sink);
+    return installTapRb(ctx, allocator, pkg_name, db, linker, prefix, dry_run, force, download_only, .cask_only, prefetch_slot, sink);
 }
 
 /// True when a row matching `(leaf, tap_slug)` exists. The tap match is what
@@ -253,6 +259,7 @@ fn installTapRb(
     force: bool,
     download_only: bool,
     kind: TapResolveKind,
+    prefetch_slot: ?*?[]const u8,
     sink: OutputSink,
 ) !void {
     const parts = args.parseTapName(pkg_name) orelse {
@@ -436,7 +443,7 @@ fn installTapRb(
             .head_etag = fresh_head_etag,
         },
     };
-    try materializeRubyFormula(ctx, allocator, resolved, &http, db, linker, prefix, dry_run, force, download_only, sink);
+    try materializeRubyFormula(ctx, allocator, resolved, &http, db, linker, prefix, dry_run, force, download_only, prefetch_slot, sink);
 }
 
 /// Install a formula from a local `.rb` file on disk. Gated by the
@@ -580,7 +587,7 @@ pub fn installLocalFormula(
     // `--local` is out of scope for `--download-only`: the user already
     // holds the archive on disk so warming a tap-cache entry adds no
     // value. Hard-wire false here rather than threading the flag.
-    try materializeRubyFormula(ctx, allocator, resolved, &http, db, linker, prefix, dry_run, force, false, sink);
+    try materializeRubyFormula(ctx, allocator, resolved, &http, db, linker, prefix, dry_run, force, false, null, sink);
 }
 
 /// Whether any linker-visible dir under `keg_path` holds an entry - the same
@@ -785,6 +792,7 @@ pub fn materializeRubyFormula(
     dry_run: bool,
     force: bool,
     download_only: bool,
+    prefetch_slot: ?*?[]const u8,
     sink: OutputSink,
 ) InstallError!void {
     sink.info("Found {s} {s}", .{ resolved.name, resolved.version });
@@ -802,7 +810,7 @@ pub fn materializeRubyFormula(
     // mounting, ditto, and `installer` live there. Tar.gz/tar.xz/zip
     // formula archives keep the simple-extract path below.
     if (tapCaskArtifactKind(resolved.url, resolved.app_name != null)) |kind| {
-        return materializeTapCask(ctx, allocator, resolved, db, kind, dry_run, force, download_only, sink);
+        return materializeTapCask(ctx, allocator, resolved, db, kind, dry_run, force, download_only, prefetch_slot, sink);
     }
 
     if (dry_run) {
@@ -1182,6 +1190,7 @@ fn materializeTapCask(
     dry_run: bool,
     force: bool,
     download_only: bool,
+    prefetch_slot: ?*?[]const u8,
     sink: OutputSink,
 ) InstallError!void {
     // `--download-only` deliberately ignores `isInstalled` so a user
@@ -1252,11 +1261,18 @@ fn materializeTapCask(
             };
         };
         if (sp) |*s| s.bar.finish();
-        defer allocator.free(cache_path);
         output.emitNdjsonEvent(.download_complete, cask.token, "ok");
         sink.success("{s} {s} downloaded to {s}", .{ cask.token, cask.version, cache_path });
+        if (prefetch_slot) |slot| {
+            slot.* = cache_path; // ownership moves to the caller
+        } else allocator.free(cache_path);
         return;
     }
+
+    // Bytes an upgrade's prefetch already fetched and verified; installing
+    // from them is what keeps a cask that pins no digest off the network
+    // once its old version is gone.
+    if (prefetch_slot) |slot| installer.prefetched_artifact = slot.*;
 
     const app_path = installer.install(&cask) catch |e| {
         if (sp) |*s| s.bar.finish();

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -1096,8 +1096,10 @@ fn upgradeRoutedTapCask(
     // Fetch and sha-verify the replacement before anything is destroyed: a
     // dropped connection here must leave the installed app in place. Nothing
     // has been opened yet, so there is nothing to roll back.
+    var prefetched: ?[]const u8 = null;
+    defer if (prefetched) |p| allocator.free(p);
     const download_only = true;
-    install_local_mod.installTapCask(ctx, allocator, full_name, db, &linker, prefix, dry_run, true, download_only, install_sink_mod.progress_only) catch |dl_err| {
+    install_local_mod.installTapCask(ctx, allocator, full_name, db, &linker, prefix, dry_run, true, download_only, &prefetched, install_sink_mod.progress_only) catch |dl_err| {
         output.err("Failed to download {s}: {s} (installed version left in place)", .{ full_name, @errorName(dl_err) });
         return error.Aborted;
     };
@@ -1107,6 +1109,8 @@ fn upgradeRoutedTapCask(
     // can't leave the casks row missing once the new app is on disk.
     var installer = cask_mod.CaskInstaller.init(ctx.io, ctx.environ, allocator, db, prefix);
     installer.offline = ctx.offline;
+    // Spares the prefetched artefact from the uninstall's cache sweep.
+    installer.prefetched_artifact = prefetched;
     db.beginTransaction() catch |txn_err| {
         output.err("Could not begin DB transaction for {s}: {s} ({s})", .{ token, @errorName(txn_err), db.errMsg() });
         return error.Aborted;
@@ -1122,8 +1126,8 @@ fn upgradeRoutedTapCask(
         return error.Aborted;
     };
 
-    // Cache hit off the prefetch above, so this does not re-download.
-    install_local_mod.installTapCask(ctx, allocator, full_name, db, &linker, prefix, dry_run, true, false, install_sink_mod.terminal) catch |in_err| {
+    // Installs the bytes the prefetch fetched, so this never re-downloads.
+    install_local_mod.installTapCask(ctx, allocator, full_name, db, &linker, prefix, dry_run, true, false, &prefetched, install_sink_mod.terminal) catch |in_err| {
         output.err("Failed to upgrade tap cask {s}: {s}", .{ full_name, @errorName(in_err) });
         db.rollback();
         return error.Aborted;

--- a/tests/install_download_only_test.zig
+++ b/tests/install_download_only_test.zig
@@ -551,6 +551,7 @@ test "--download-only on tap formula with warm tap cache prints path + skips Cel
         false, // dry_run
         false, // force
         true, // download_only
+        null, // prefetch_slot
         malt.install_sink.terminal,
     );
 
@@ -638,6 +639,7 @@ test "--download-only --force on tap formula with warm cache is a no-op refresh"
         false, // dry_run
         true, // force
         true, // download_only
+        null, // prefetch_slot
         malt.install_sink.terminal,
     );
 
@@ -729,6 +731,7 @@ test "--download-only --ndjson on tap formula emits download_started + complete 
         false, // dry_run
         false, // force
         true, // download_only
+        null, // prefetch_slot
         malt.install_sink.terminal,
     );
 
@@ -866,6 +869,7 @@ test "materializeRubyFormula refuses a source archive that yields no linkable ar
         false, // dry_run
         false, // force
         false, // download_only
+        null, // prefetch_slot
         malt.install_sink.terminal,
     ));
 
@@ -950,6 +954,7 @@ test "materializeRubyFormula installs a lib-only keg that ships no binary" {
         false, // dry_run
         false, // force
         false, // download_only
+        null, // prefetch_slot
         malt.install_sink.terminal,
     );
 
@@ -1063,6 +1068,7 @@ test "materializeRubyFormula installs a tap formula whose url is an uncompressed
         false, // dry_run
         false, // force
         false, // download_only
+        null, // prefetch_slot
         malt.install_sink.terminal,
     );
 
@@ -1136,6 +1142,7 @@ test "materializeRubyFormula honours binary_name when staging an uncompressed bi
         false, // dry_run
         false, // force
         false, // download_only
+        null, // prefetch_slot
         malt.install_sink.terminal,
     );
 
@@ -1200,6 +1207,7 @@ test "materializeRubyFormula refuses a compressed body arriving on the raw-binar
         false, // dry_run
         false, // force
         false, // download_only
+        null, // prefetch_slot
         malt.install_sink.terminal,
     ));
 
@@ -1260,6 +1268,7 @@ test "materializeRubyFormula truncated body on the raw-binary path is refused" {
         false, // dry_run
         false, // force
         false, // download_only
+        null, // prefetch_slot
         malt.install_sink.terminal,
     ));
     try testing.expectEqual(@as(i64, 0), try kegRowCount(prefix));
@@ -1337,6 +1346,7 @@ test "materializeRubyFormula records the declared dependencies of a tap formula"
         false, // dry_run
         false, // force
         false, // download_only
+        null, // prefetch_slot
         malt.install_sink.terminal,
     );
 
@@ -1407,6 +1417,7 @@ test "materializeRubyFormula --dry-run names the dependencies it would pull in" 
         true, // dry_run
         false, // force
         false, // download_only
+        null, // prefetch_slot
         malt.install_sink.terminal,
     );
 
@@ -1487,6 +1498,7 @@ test "materializeRubyFormula stamps an extracted tap archive as relocated, not e
         false, // dry_run
         false, // force
         false, // download_only
+        null, // prefetch_slot
         malt.install_sink.terminal,
     );
 

--- a/tests/install_local_test.zig
+++ b/tests/install_local_test.zig
@@ -944,6 +944,7 @@ test "materializeRubyFormula refuses a symlinked package dir" {
         false,
         false,
         false,
+        null, // prefetch_slot
         malt.install_sink.silent,
     ));
 


### PR DESCRIPTION
## Description

The tap upgrade route already fetched a cask's replacement before destroying the installed app, but then threw the path away - the install pass had to find those bytes again in the cache. It usually did. When the target version was already recorded in history, the uninstall in between swept exactly that file, and the install went back to the network with the app already deleted. `mt upgrade --force <tap-cask>` reproduced it every time.

The fetched artifact now travels between the two passes, so the tap route downloads once and never touches the network after the point of no return. That guarantee no longer rests on tap casks happening to pin a digest.

## Related Issue

- None

## Notes for Reviewers

- None