### PR TITLE
fix(upgrade): stop a refused PKG cask upgrade from destroying the installed version

### DIFF
--- a/justfile
+++ b/justfile
@@ -40,6 +40,7 @@ regressions-static:
     @./scripts/regressions/relocated-store-logic-version-pin.sh
     @./scripts/regressions/clean-misses-tmpdir-test-scratch.sh
     @./scripts/regressions/cask-upgrade-deletes-app-before-download.sh
+    @./scripts/regressions/tap-cask-upgrade-deletes-app-before-pkg-sudo-confirm.sh
     @./scripts/regressions/post-install-native-spawns-inherit-full-environment.sh
     @./scripts/regressions/tar-prescan-followups-925-926-follow-up.sh
     @./scripts/regressions/tui-background-fetch-no-double-reap-start-background-waits-after-kill.sh

--- a/justfile
+++ b/justfile
@@ -41,6 +41,7 @@ regressions-static:
     @./scripts/regressions/clean-misses-tmpdir-test-scratch.sh
     @./scripts/regressions/cask-upgrade-deletes-app-before-download.sh
     @./scripts/regressions/tap-cask-upgrade-deletes-app-before-pkg-sudo-confirm.sh
+    @./scripts/regressions/cask-uninstall-deletes-the-artifact-its-prefetch-fetched.sh
     @./scripts/regressions/post-install-native-spawns-inherit-full-environment.sh
     @./scripts/regressions/tar-prescan-followups-925-926-follow-up.sh
     @./scripts/regressions/tui-background-fetch-no-double-reap-start-background-waits-after-kill.sh

--- a/scripts/regressions/cask-uninstall-deletes-the-artifact-its-prefetch-fetched.sh
+++ b/scripts/regressions/cask-uninstall-deletes-the-artifact-its-prefetch-fetched.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Regression: `CaskInstaller.uninstall` spared the prefetched artifact from its
+# cache sweep but not from the `deleteTree(app_path)` branch. A PKG cask records
+# its cached `.pkg` as `app_path`, so a token reusing one cache name across
+# versions had an upgrade delete the very bytes its install pass was about to
+# read — with the old version already gone.
+#
+# Static only: no network, no build, runs in milliseconds. The behavioural
+# guards run under `zig build test`; this asserts the spare and both tests are
+# still there, since deleting any of them would drop the coverage silently.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+CASK="$ROOT/src/core/cask.zig"
+TESTS="$ROOT/tests/cask_extra_test.zig"
+SPARED="a PKG cask's cached artefact survives uninstall when the prefetch named it"
+NARROW="uninstall still removes an app_path the prefetch does not name"
+fail=0
+
+# 1. The app_path branch must consult the prefetch spare.
+if ! grep -Fqs -- 'and !spared' "$CASK"; then
+  echo "FAIL: uninstall can delete the artifact its own prefetch fetched" >&2
+  fail=1
+fi
+
+# 2. Coverage anchors — the spare and its narrowness.
+if ! grep -Fqs -- "$SPARED" "$TESTS"; then
+  echo "FAIL: the spared-artifact guard test is missing" >&2
+  fail=1
+fi
+if ! grep -Fqs -- "$NARROW" "$TESTS"; then
+  echo "FAIL: the guard-stays-narrow test is missing" >&2
+  fail=1
+fi
+
+if [[ $fail -eq 0 ]]; then
+  echo "PASS: uninstall keeps the artifact an upgrade prefetched"
+fi
+exit $fail

--- a/scripts/regressions/tap-cask-upgrade-deletes-app-before-pkg-sudo-confirm.sh
+++ b/scripts/regressions/tap-cask-upgrade-deletes-app-before-pkg-sudo-confirm.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Regression: the tap cask upgrade route took its PKG sudo confirmation only on
+# the install pass, which runs after `installer.uninstall(token)`. A refusal —
+# deterministic off a TTY — then left the Caskroom entry and every cached
+# artifact for the token deleted while the DB rollback restored the row.
+#
+# Two halves, neither of which needs network or a build:
+#   1. Ordering (static): the gate must no longer be skipped on the pass that
+#      precedes the destructive step, and it must decide via the prefetch slot.
+#   2. Coverage anchors: the predicate's inline test and the tap-upgrade
+#      refusal test both run under `zig build test`; deleting either would drop
+#      the guard while the static half kept passing, so assert they exist.
+#
+# Exits 0 when the bug is absent, non-zero naming the broken invariant when
+# present. Static only: no network, no build, runs in milliseconds.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+LOCAL="$ROOT/src/cli/install/local.zig"
+TESTS="$ROOT/tests/install_download_only_test.zig"
+FILTER="a tap PKG cask upgrade refuses before its prefetch fills the slot"
+fail=0
+
+# 1. The PKG gate must not skip the upgrade's prefetch pass.
+if grep -Fqs -- 'if (!download_only and !install_mod.confirmPkgSudo(' "$LOCAL"; then
+  echo "FAIL: tap PKG confirmation still lands after installer.uninstall(token)" >&2
+  fail=1
+fi
+
+# 2. The gate must consult the prefetch slot via the predicate.
+if ! grep -Fqs -- 'pkgConfirmationDue(' "$LOCAL"; then
+  echo "FAIL: PKG confirmation no longer consults the prefetch slot" >&2
+  fail=1
+fi
+
+# 3. Coverage anchors.
+if ! grep -Fqs -- 'test "pkgConfirmationDue' "$LOCAL"; then
+  echo "FAIL: the predicate's inline test is missing" >&2
+  fail=1
+fi
+if ! grep -Fqs -- "$FILTER" "$TESTS"; then
+  echo "FAIL: the tap PKG-upgrade refusal test is missing" >&2
+  fail=1
+fi
+
+if [[ $fail -eq 0 ]]; then
+  echo "PASS: a tap PKG cask upgrade confirms sudo before anything is removed"
+fi
+exit $fail

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -1174,6 +1174,38 @@ pub fn materializeRubyFormula(
     sink.success("{s} {s} installed", .{ resolved.name, resolved.version });
 }
 
+/// Whether a PKG cask's sudo confirmation is owed on this pass.
+///
+/// The upgrade route calls twice and only the first call runs before the old
+/// version is removed, so a refusal on the second destroys what nothing puts
+/// back. `prefetch_slot` already tells the two passes apart.
+fn pkgConfirmationDue(download_only: bool, prefetch_slot: ?*?[]const u8) bool {
+    // Outside an upgrade: `--download-only` never escalates, a real install does.
+    const slot = prefetch_slot orelse return !download_only;
+
+    // Upgrade: ask on the prefetch pass, reuse that answer on the install pass.
+    return slot.* == null;
+}
+
+test "pkgConfirmationDue asks once, on the pass that precedes the uninstall" {
+    // Plain install escalates, so it confirms.
+    try std.testing.expect(pkgConfirmationDue(false, null));
+    // `mt install --download-only` only fills the cache.
+    try std.testing.expect(!pkgConfirmationDue(true, null));
+
+    // Upgrade prefetch: nothing removed yet, so this is the only safe moment.
+    var empty: ?[]const u8 = null;
+    try std.testing.expect(pkgConfirmationDue(true, &empty));
+
+    // Upgrade install: the prefetch already asked.
+    var filled: ?[]const u8 = "/cache/Cask/tok-1.0.pkg";
+    try std.testing.expect(!pkgConfirmationDue(false, &filled));
+
+    // A slot that never got filled still confirms rather than silently
+    // escalating — the safe side of an unexpected call order.
+    try std.testing.expect(pkgConfirmationDue(false, &empty));
+}
+
 /// Hand a tap cask off to the shared `core/cask.zig` installer by
 /// minting a Homebrew-API-shaped JSON document from the parsed Ruby
 /// directives. Reuses every download/SHA/extract path the brew-API
@@ -1240,7 +1272,9 @@ fn materializeTapCask(
 
     if (kind == .pkg) {
         sink.warn("{s} is a PKG cask and requires sudo to install via macOS Installer.", .{cask.token});
-        if (!download_only and !install_mod.confirmPkgSudo(cask.token)) return InstallError.CaskNotFound;
+        if (pkgConfirmationDue(download_only, prefetch_slot) and !install_mod.confirmPkgSudo(cask.token)) {
+            return InstallError.CaskNotFound;
+        }
     }
 
     // `--download-only` for a cask-shaped tap entry reuses the cask

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -1100,7 +1100,9 @@ fn upgradeRoutedTapCask(
     defer if (prefetched) |p| allocator.free(p);
     const download_only = true;
     install_local_mod.installTapCask(ctx, allocator, full_name, db, &linker, prefix, dry_run, true, download_only, &prefetched, install_sink_mod.progress_only) catch |dl_err| {
-        output.err("Failed to download {s}: {s} (installed version left in place)", .{ full_name, @errorName(dl_err) });
+        // This pass also takes the PKG sudo confirmation, so a decline lands
+        // here having downloaded nothing — the wording has to cover both.
+        output.err("Could not upgrade {s}: {s} (installed version left in place)", .{ full_name, @errorName(dl_err) });
         return error.Aborted;
     };
 

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -747,7 +747,14 @@ pub const CaskInstaller = struct {
             }
         }
 
-        if (app_path_len > 0) {
+        // A PKG cask records its cached artefact as `app_path`, so this can name
+        // the very file an upgrade prefetched for the install pass to read.
+        const spared = if (self.prefetched_artifact) |k|
+            std.mem.eql(u8, k, app_path_buf[0..app_path_len])
+        else
+            false;
+
+        if (app_path_len > 0 and !spared) {
             const app_path = app_path_buf[0..app_path_len];
 
             if (std.mem.eql(u8, std.fs.path.basename(app_path), cask_font.MANIFEST_NAME)) {

--- a/tests/cask_extra_test.zig
+++ b/tests/cask_extra_test.zig
@@ -477,3 +477,85 @@ test "an unpinned artefact fetched once survives uninstall and installs from the
     // install consumed the prefetch instead of reaching for the network.
     try testing.expectError(cask.CaskError.InstallFailed, installer.install(&c));
 }
+
+test "a PKG cask's cached artefact survives uninstall when the prefetch named it" {
+    // `installPkg` records the cached `.pkg` as `app_path`, so on a token whose
+    // cache name is reused across versions the upgrade's prefetch and the row's
+    // `app_path` are the same file. The spare has to cover this branch too, or
+    // the destructive step deletes the bytes the install pass is about to read.
+    var fx = try Fixture.init("prefetch_pkg_apppath");
+    defer fx.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{ .environ = testEnviron() });
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    try std.Io.Dir.cwd().createDirPath(io, fx.p("cache/Cask"));
+
+    const prefetched = fx.p("cache/Cask/pkgroll.pkg");
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, prefetched, .{});
+        defer f.close(io);
+        try f.writeStreamingAll(io, "pkg bytes the install pass needs");
+    }
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var c = try cask.parseCask(testing.allocator,
+        \\{"token":"pkgroll","name":["PkgRoll"],"version":"latest","url":"https://example.invalid/pkgroll.pkg","sha256":"no_check","artifacts":[{"pkg":["PkgRoll.pkg"]}]}
+    );
+    defer c.deinit();
+
+    // The install recorded the artefact itself, which is what a PKG cask does.
+    try cask.recordInstall(&db, &c, prefetched, null);
+
+    var installer = cask.CaskInstaller.init(io, testEnviron(), testing.allocator, &db, fx.base);
+    installer.offline = true;
+    installer.prefetched_artifact = prefetched;
+
+    try installer.uninstall("pkgroll");
+    try std.Io.Dir.accessAbsolute(io, prefetched, .{});
+    try testing.expect(!cask.isInstalled(&db, "pkgroll"));
+}
+
+test "uninstall still removes an app_path the prefetch does not name" {
+    // The spare must stay narrow: a bundle unrelated to the fetched artefact
+    // has to go, or an upgrade would leave the old version behind.
+    var fx = try Fixture.init("prefetch_pkg_unrelated");
+    defer fx.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{ .environ = testEnviron() });
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    try std.Io.Dir.cwd().createDirPath(io, fx.p("cache/Cask"));
+    try std.Io.Dir.cwd().createDirPath(io, fx.p("Applications"));
+
+    const prefetched = fx.p("cache/Cask/other-2.0.zip");
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, prefetched, .{});
+        defer f.close(io);
+        try f.writeStreamingAll(io, "unrelated");
+    }
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var c = try cask.parseCask(testing.allocator,
+        \\{"token":"other","name":["Other"],"version":"1.0","url":"https://example.invalid/other.zip","sha256":"no_check","artifacts":[{"app":["Other.app"]}]}
+    );
+    defer c.deinit();
+
+    const app_path = fx.p("Applications/Other.app");
+    try std.Io.Dir.cwd().createDirPath(io, app_path);
+    try cask.recordInstall(&db, &c, app_path, null);
+
+    var installer = cask.CaskInstaller.init(io, testEnviron(), testing.allocator, &db, fx.base);
+    installer.offline = true;
+    installer.prefetched_artifact = prefetched;
+
+    try installer.uninstall("other");
+    try testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(io, app_path, .{}));
+    try std.Io.Dir.accessAbsolute(io, prefetched, .{});
+}

--- a/tests/install_download_only_test.zig
+++ b/tests/install_download_only_test.zig
@@ -1510,3 +1510,85 @@ test "materializeRubyFormula stamps an extracted tap archive as relocated, not e
         stamp,
     );
 }
+
+/// Seed `<prefix>/cache/Cask/<token>-<version>.pkg` and return its sha256, so a
+/// digest-pinned prefetch takes the warm-cache branch and never hits the network.
+fn seedCaskPkgCache(prefix: []const u8, token: []const u8, version: []const u8, body: []const u8) ![64]u8 {
+    const dir = try std.fmt.allocPrint(testing.allocator, "{s}/cache/Cask", .{prefix});
+    defer testing.allocator.free(dir);
+    try test_io.cwd().createDirPath(std.Options.debug_io, dir);
+
+    const path = try std.fmt.allocPrint(testing.allocator, "{s}/{s}-{s}.pkg", .{ dir, token, version });
+    defer testing.allocator.free(path);
+    const f = try test_io.cwd().createFile(std.Options.debug_io, path, .{});
+    defer f.close(std.Options.debug_io);
+    try f.writeStreamingAll(std.Options.debug_io, body);
+
+    var digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(body, &digest, .{});
+    var hex: [64]u8 = undefined;
+    _ = std.fmt.bufPrint(&hex, "{x}", .{&digest}) catch unreachable;
+    return hex;
+}
+
+test "a tap PKG cask upgrade refuses before its prefetch fills the slot" {
+    // The upgrade route's prefetch pass runs before `installer.uninstall`, so a
+    // PKG cask must face the sudo confirmation there. Off a TTY that refusal is
+    // unconditional, which is exactly the state `zig build test` runs in — the
+    // slot must stay empty so the caller aborts with the old version untouched.
+    const prefix = try setupPrefix("pkgconfirm");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    // Warm cache: pre-fix this pass would succeed and fill the slot, so the
+    // failure below is the missing confirmation and not a network error.
+    const sha = try seedCaskPkgCache(prefix, "pkgcask", "2.0", "pkg fixture\n");
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var http = malt.client.HttpClient.init(ctx.io, ctx.environ, allocator);
+    defer http.deinit();
+
+    const db_path = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/db/malt.db", .{prefix}, 0);
+    defer testing.allocator.free(db_path);
+    var db = try malt.sqlite.Database.open(db_path);
+    defer db.close();
+    try malt.schema.initSchema(&db);
+
+    var linker = malt.linker.Linker.init(ctx.io, allocator, &db, prefix);
+
+    const resolved: malt.install_local.ResolvedRubyFormula = .{
+        .name = "pkgcask",
+        .full_name = "user/repo/pkgcask",
+        .tap_label = "user/repo",
+        .version = "2.0",
+        .url = "https://malt-pkgcask-test.invalid/releases/download/v2.0/pkgcask.pkg",
+        .sha256 = &sha,
+    };
+
+    var slot: ?[]const u8 = null;
+    defer if (slot) |p| allocator.free(p);
+
+    try testing.expectError(install_record.InstallError.CaskNotFound, malt.install_local.materializeRubyFormula(
+        &ctx,
+        allocator,
+        resolved,
+        &http,
+        &db,
+        &linker,
+        prefix,
+        false, // dry_run
+        true, // force
+        true, // download_only — the upgrade route's prefetch pass
+        &slot,
+        malt.install_sink.progress_only,
+    ));
+    try testing.expect(slot == null);
+}


### PR DESCRIPTION
## Description

Upgrading a PKG cask from a tap asked for the sudo confirmation too late. The prompt lived on the install pass, which runs after the installed version has already been removed - so declining it, or running without a terminal at all,
left the Caskroom entry and every cached artifact for the token deleted while the database rollback restored the row. Where the artifact type changed between
versions, the app bundle itself went with it.

The confirmation now happens on the upgrade's first pass, before anything is downloaded or removed, and is not asked again. Declining leaves the installed version exactly as it was. Plain installs and `--download-only` are unaffected.

## Related Issue

- None

## Notes for Reviewers

- None