### PR TITLE
fix(post-install): keep the previous payload when a copy step's clone fails

### DIFF
--- a/justfile
+++ b/justfile
@@ -43,6 +43,7 @@ regressions-static:
     @./scripts/regressions/tap-cask-upgrade-deletes-app-before-pkg-sudo-confirm.sh
     @./scripts/regressions/cask-uninstall-deletes-the-artifact-its-prefetch-fetched.sh
     @./scripts/regressions/post-install-native-spawns-inherit-full-environment.sh
+    @./scripts/regressions/post-install-copy-deletes-destination-before-clone.sh
     @./scripts/regressions/tar-prescan-followups-925-926-follow-up.sh
     @./scripts/regressions/tui-background-fetch-no-double-reap-start-background-waits-after-kill.sh
     @MALT_STATIC_ONLY=1 ./scripts/regressions/post-install-steps-live-artefacts.sh

--- a/scripts/regressions/post-install-copy-deletes-destination-before-clone.sh
+++ b/scripts/regressions/post-install-copy-deletes-destination-before-clone.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Regression: the native post_install `copy` step deleted its destination and
+# only then asked clonefile(2) to produce the replacement. Any clone failure —
+# an unreadable child in a tap-shipped keg, ENOSPC, a part-way non-APFS
+# fallback copy — returned false with the previous payload already unlinked,
+# so a failed node upgrade left <prefix>/lib/node_modules/npm holding neither
+# the old npm nor the new one.
+#
+# No CLI subcommand drives the native executor without a network install, so
+# the guard follows the harness pattern of the env-scrub regression: a
+# throwaway `zig test` root at the repo root (the module's sibling imports
+# only resolve from inside the source tree). Unlike that one, `c_clonefile`
+# keeps the real extern declaration — the failure under test is an actual
+# clonefile(2) EACCES over a mode-000 directory, which creates nothing at the
+# destination.
+#
+# Exits 0 when the previous destination survives a failed clone, non-zero
+# (naming the destroyed payload) when it does not. No network required;
+# one module compile, well under 30s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+STUBS=$(mktemp -d)
+HARNESS="$ROOT/.post-install-copy-clone-regression.$$.zig"
+trap 'rm -rf "$STUBS" "$HARNESS"' EXIT
+
+cat >"$STUBS/c_clonefile.zig" <<'ZIG'
+pub extern "c" fn clonefile(src: [*:0]const u8, dst: [*:0]const u8, flags: c_uint) c_int;
+ZIG
+cat >"$STUBS/c_mount.zig" <<'ZIG'
+pub const struct_statfs = extern struct { f_fstypename: [16]u8 };
+pub extern "c" fn statfs(path: [*:0]const u8, buf: *struct_statfs) c_int;
+ZIG
+
+cat >"$HARNESS" <<'ZIG'
+const std = @import("std");
+const steps = @import("src/core/post_install_steps.zig");
+
+test "a failed copy leaves the previous destination intact" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const prefix = path_buf[0..try std.Io.Dir.realPath(tmp.dir, io, &path_buf)];
+
+    // node's shape: the new npm in the keg, the installed one in the prefix.
+    const keg = try std.fmt.allocPrint(a, "{s}/Cellar/node/1.0", .{prefix});
+    const src = try std.fmt.allocPrint(a, "{s}/libexec/lib/node_modules/npm", .{keg});
+    try std.Io.Dir.cwd().createDirPath(io, src);
+    try writeFile(io, try std.fmt.allocPrint(a, "{s}/version.txt", .{src}), "new\n");
+
+    // A mode-000 child makes clonefile(2) fail with EACCES and write nothing.
+    const blocked = try std.fmt.allocPrint(a, "{s}/blocked", .{src});
+    try std.Io.Dir.cwd().createDirPath(io, blocked);
+    var bd = try std.Io.Dir.openDirAbsolute(io, blocked, .{});
+    defer bd.close(io);
+    const bf: std.Io.File = .{ .handle = bd.handle, .flags = .{ .nonblocking = false } };
+    // Registered after tmp.cleanup so LIFO reopens the mode before teardown
+    // walks it — a mode-000 directory cannot be reopened by its owner.
+    defer bf.setPermissions(io, .fromMode(0o755)) catch {};
+    try bf.setPermissions(io, .fromMode(0o000));
+
+    const dstdir = try std.fmt.allocPrint(a, "{s}/lib/node_modules", .{prefix});
+    const dest = try std.fmt.allocPrint(a, "{s}/npm", .{dstdir});
+    try std.Io.Dir.cwd().createDirPath(io, dest);
+    const installed = try std.fmt.allocPrint(a, "{s}/version.txt", .{dest});
+    try writeFile(io, installed, "old\n");
+
+    var flog = steps.FallbackLog.init(std.testing.allocator);
+    defer flog.deinit();
+    const ctx: steps.StepsCtx = .{
+        .io = io,
+        .allocator = a,
+        .name = "node",
+        .version = "1.0",
+        .prefix = prefix,
+        .keg_path = keg,
+        .flog = &flog,
+        .environ = .empty,
+    };
+
+    const formula =
+        \\{"name":"node","versions":{"stable":"1.0"},"post_install_steps":
+        \\[{"type":"copy","source":{"path":"{{libexec}}/lib/node_modules/npm"},
+        \\  "target":{"path":"{{HOMEBREW_PREFIX}}/lib/node_modules"}}]}
+    ;
+    _ = steps.execute(ctx, formula);
+    // An unsupported step only warns, so the run's own verdict says nothing
+    // about the clone; the logged reason is what proves the probe still bites.
+    if (!sawCloneFailure(&flog)) {
+        std.debug.print("the clone was expected to fail; the probe no longer exercises the bug\n", .{});
+        return error.CloneUnexpectedlySucceeded;
+    }
+
+    const got = readFile(io, a, installed) catch {
+        std.debug.print("the installed payload at {s} is gone\n", .{dest});
+        return error.PreviousDestinationDestroyed;
+    };
+    if (!std.mem.eql(u8, got, "old\n")) {
+        std.debug.print("want 'old\\n' at {s}, got '{s}'\n", .{ installed, got });
+        return error.PreviousDestinationClobbered;
+    }
+
+    // The staging and aside paths are internal; neither may outlive the step.
+    for ([_][]const u8{ ".malt-incoming", ".malt-replaced" }) |suffix| {
+        const leftover = try std.fmt.allocPrint(a, "{s}{s}", .{ dest, suffix });
+        if (std.Io.Dir.accessAbsolute(io, leftover, .{})) |_| {
+            std.debug.print("left {s} behind in the prefix\n", .{leftover});
+            return error.ScratchPathLeaked;
+        } else |_| {}
+    }
+}
+
+fn sawCloneFailure(flog: *const steps.FallbackLog) bool {
+    for (flog.entries()) |e| {
+        if (std.mem.eql(u8, e.detail, "copy (clone failed)")) return true;
+    }
+    return false;
+}
+
+fn writeFile(io: std.Io, path: []const u8, bytes: []const u8) !void {
+    const f = try std.Io.Dir.createFileAbsolute(io, path, .{ .truncate = true });
+    defer f.close(io);
+    try f.writeStreamingAll(io, bytes);
+}
+
+fn readFile(io: std.Io, a: std.mem.Allocator, path: []const u8) ![]const u8 {
+    const f = try std.Io.Dir.openFileAbsolute(io, path, .{});
+    defer f.close(io);
+    const buf = try a.alloc(u8, 4096);
+    var r = f.reader(io, &.{});
+    return buf[0..try r.interface.readSliceShort(buf)];
+}
+ZIG
+
+run_harness() {
+  (cd "$ROOT" && zig test -lc -framework Security -framework CoreFoundation \
+    --dep c_clonefile --dep c_mount \
+    -Mroot="$HARNESS" \
+    -Mc_clonefile="$STUBS/c_clonefile.zig" \
+    -Mc_mount="$STUBS/c_mount.zig")
+}
+
+if run_harness >/dev/null 2>&1; then
+  echo "PASS: a failed post_install copy keeps the previous destination"
+else
+  run_harness 2>&1 | grep -Ev '\.\.\.OK$' | tail -20 >&2
+  echo "FAIL: a failed copy step destroyed the previous payload" >&2
+  exit 1
+fi

--- a/src/core/post_install_steps.zig
+++ b/src/core/post_install_steps.zig
@@ -582,15 +582,35 @@ fn stepCopy(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
         mkParent(ctx, target);
     }
 
-    // Always replace, as `cp_r` does — formulae omit `force` and rely on it.
-    // Skipping an existing destination would leave a stale payload behind.
-    std.Io.Dir.cwd().deleteTree(ctx.io, dest) catch {};
+    // Staged beside the destination rather than into it: the replace is only
+    // committed once the replacement exists.
+    const staging = std.fmt.allocPrint(ctx.allocator, "{s}.malt-incoming", .{dest}) catch return false;
+    // clonefile(2) refuses a destination that exists, and a crashed run can
+    // have left one behind.
+    std.Io.Dir.cwd().deleteTree(ctx.io, staging) catch {};
+    // Scrap on every path out; the swap consumes it on success.
+    defer std.Io.Dir.cwd().deleteTree(ctx.io, staging) catch {};
 
     // APFS clone: same bytes, no double disk cost, mtimes preserved.
-    clonefile.cloneTree(ctx.io, ctx.allocator, source, dest) catch {
+    clonefile.cloneTree(ctx.io, ctx.allocator, source, staging) catch {
         logUnsupported(ctx, "copy (clone failed)");
         return false;
     };
+
+    // Always replace, as `cp_r` does — formulae omit `force` and rely on it.
+    // Skipping an existing destination would leave a stale payload behind.
+    // Swapped aside rather than deleted so a failed rename is recoverable.
+    const aside = asidePath(ctx, dest) orelse return false;
+    std.Io.Dir.cwd().deleteTree(ctx.io, aside) catch {};
+    // The rename doubles as the existence probe: a stat would follow a
+    // symlink at `dest`, leaving a dangling one in place to block the swap.
+    const displaced = if (std.Io.Dir.renameAbsolute(dest, aside, ctx.io)) |_| true else |_| false;
+    atomic.atomicRename(ctx.io, ctx.allocator, staging, dest) catch {
+        if (displaced) std.Io.Dir.renameAbsolute(aside, dest, ctx.io) catch {};
+        logUnsupported(ctx, "copy (could not replace the destination)");
+        return false;
+    };
+    std.Io.Dir.cwd().deleteTree(ctx.io, aside) catch {};
     return true;
 }
 
@@ -2159,6 +2179,49 @@ fn seedEtc(h: *TestHarness, rel: []const u8, body: []const u8) ![]const u8 {
     try f.writeStreamingAll(h.io, body);
     f.close(h.io);
     return path;
+}
+
+fn writeAt(h: *TestHarness, path: []const u8, bytes: []const u8) !void {
+    const f = try std.Io.Dir.createFileAbsolute(h.io, path, .{ .truncate = true });
+    defer f.close(h.io);
+    try f.writeStreamingAll(h.io, bytes);
+}
+
+/// node's shape, the one the copy step exists to serve: npm in the keg.
+fn seedNpmSrc(h: *TestHarness, version: []const u8) ![]const u8 {
+    const a = h.arena.allocator();
+    const src = try std.fmt.allocPrint(a, "{s}/libexec/lib/node_modules/npm", .{h.keg});
+    try std.Io.Dir.cwd().createDirPath(h.io, src);
+    try writeAt(h, try std.fmt.allocPrint(a, "{s}/version.txt", .{src}), version);
+    return src;
+}
+
+/// The copy step node ships — no `force`, so it also pins replace semantics.
+fn npmCopyJson(h: *TestHarness) ![]const u8 {
+    return testFormulaJson(h,
+        \\[{"type":"copy",
+        \\  "source":{"path":"{{libexec}}/lib/node_modules/npm"},
+        \\  "target":{"path":"{{HOMEBREW_PREFIX}}/lib/node_modules"}}]
+    );
+}
+
+/// Lock `path` to mode 000 so clonefile(2) refuses the tree holding it. The
+/// handle comes back because the caller has to restore the mode before its own
+/// teardown walks it, and a mode-000 directory cannot be reopened by its owner.
+fn blockTree(h: *TestHarness, path: []const u8) !std.Io.File {
+    try std.Io.Dir.cwd().createDirPath(h.io, path);
+    var d = try std.Io.Dir.openDirAbsolute(h.io, path, .{});
+    errdefer d.close(h.io);
+    const f: std.Io.File = .{ .handle = d.handle, .flags = .{ .nonblocking = false } };
+    try f.setPermissions(h.io, .fromMode(0o000));
+    return f;
+}
+
+fn expectNoScratch(h: *TestHarness, dest: []const u8) !void {
+    for ([_][]const u8{ ".malt-incoming", ".malt-replaced" }) |suffix| {
+        const leftover = try std.fmt.allocPrint(h.arena.allocator(), "{s}{s}", .{ dest, suffix });
+        try testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(h.io, leftover, .{}));
+    }
 }
 
 fn readBack(h: *TestHarness, path: []const u8) ![]const u8 {
@@ -3738,6 +3801,9 @@ test "copy places the source inside an existing directory target, not its conten
     // … and not flattened one level up.
     const flat = try std.fmt.allocPrint(a, "{s}/bin/npm-cli.js", .{dstdir});
     try testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(h.io, flat, .{}));
+    // A first install has nothing to move aside; neither scratch path may
+    // survive the step regardless.
+    try expectNoScratch(&h, try std.fmt.allocPrint(a, "{s}/npm", .{dstdir}));
 }
 
 test "copy refuses a source outside the keg and prefix" {
@@ -3874,6 +3940,118 @@ test "copy replaces a stale destination even without a force flag" {
 
     const got = try readBack(&h, try std.fmt.allocPrint(a, "{s}/version.txt", .{stale}));
     try testing.expectEqualStrings("new\n", got);
+}
+
+test "copy keeps the previous destination when the clone fails" {
+    // The replace used to be committed before the replacement existed, so a
+    // clone that fails left the prefix with neither payload — which is how a
+    // failed node upgrade lost npm outright.
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    const src = try seedNpmSrc(&h, "new\n");
+    const blocked = try blockTree(&h, try std.fmt.allocPrint(a, "{s}/blocked", .{src}));
+    defer blocked.close(h.io);
+    defer blocked.setPermissions(h.io, .fromMode(0o755)) catch {};
+
+    const dest = try std.fmt.allocPrint(a, "{s}/lib/node_modules/npm", .{h.prefix});
+    try std.Io.Dir.cwd().createDirPath(h.io, dest);
+    const installed = try std.fmt.allocPrint(a, "{s}/version.txt", .{dest});
+    try writeAt(&h, installed, "old\n");
+
+    _ = execute(h.ctx(), try npmCopyJson(&h));
+    // An unsupported step only warns, so the run's verdict says nothing about
+    // the clone; the logged reason is what proves it failed.
+    try testing.expectEqualStrings("copy (clone failed)", h.flog.entries()[0].detail);
+    try testing.expectEqualStrings("old\n", try readBack(&h, installed));
+    try expectNoScratch(&h, dest);
+}
+
+test "copy keeps the destination when the swap itself fails" {
+    // The clone succeeds here and the rename does not, so the step must say
+    // so rather than blaming the clone — and the installed payload still has
+    // to survive. An aside a crashed run left unreclaimable blocks the swap.
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    _ = try seedNpmSrc(&h, "new\n");
+    const dest = try std.fmt.allocPrint(a, "{s}/lib/node_modules/npm", .{h.prefix});
+    try std.Io.Dir.cwd().createDirPath(h.io, dest);
+    const installed = try std.fmt.allocPrint(a, "{s}/version.txt", .{dest});
+    try writeAt(&h, installed, "old\n");
+
+    // An unreadable child keeps the aside non-empty, so both renames refuse it.
+    const stuck = try blockTree(&h, try std.fmt.allocPrint(a, "{s}.malt-replaced/stuck", .{dest}));
+    defer stuck.close(h.io);
+    defer stuck.setPermissions(h.io, .fromMode(0o755)) catch {};
+
+    _ = execute(h.ctx(), try npmCopyJson(&h));
+    try testing.expectEqualStrings("copy (could not replace the destination)", h.flog.entries()[0].detail);
+    try testing.expectEqualStrings("old\n", try readBack(&h, installed));
+}
+
+test "copy replaces a dangling symlink left at the destination" {
+    // A stat-based existence check reports a dangling symlink as absent, so it
+    // would survive the swap — and renaming a directory onto a symlink is
+    // ENOTDIR, failing a copy that has every right to succeed.
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    _ = try seedNpmSrc(&h, "new\n");
+    const dstdir = try std.fmt.allocPrint(a, "{s}/lib/node_modules", .{h.prefix});
+    try std.Io.Dir.cwd().createDirPath(h.io, dstdir);
+    const dest = try std.fmt.allocPrint(a, "{s}/npm", .{dstdir});
+    try std.Io.Dir.symLinkAbsolute(h.io, try std.fmt.allocPrint(a, "{s}/gone", .{dstdir}), dest, .{});
+
+    try testing.expect(execute(h.ctx(), try npmCopyJson(&h)));
+    try testing.expect(!h.flog.hasErrors());
+    try testing.expectEqualStrings("new\n", try readBack(&h, try std.fmt.allocPrint(a, "{s}/version.txt", .{dest})));
+}
+
+test "copy keeps a plain-file destination when the clone fails" {
+    // A target that is not an existing directory *is* the destination, so the
+    // aside dance has to cover a plain file, not just a tree.
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    const src = try std.fmt.allocPrint(a, "{s}/libexec/payload", .{h.keg});
+    try std.Io.Dir.cwd().createDirPath(h.io, src);
+    const blocked = try blockTree(&h, try std.fmt.allocPrint(a, "{s}/blocked", .{src}));
+    defer blocked.close(h.io);
+    defer blocked.setPermissions(h.io, .fromMode(0o755)) catch {};
+
+    try std.Io.Dir.cwd().createDirPath(h.io, try std.fmt.allocPrint(a, "{s}/share", .{h.prefix}));
+    const dest = try std.fmt.allocPrint(a, "{s}/share/payload", .{h.prefix});
+    try writeAt(&h, dest, "old\n");
+
+    const json = try testFormulaJson(&h,
+        \\[{"type":"copy",
+        \\  "source":{"path":"{{libexec}}/payload"},
+        \\  "target":{"path":"{{HOMEBREW_PREFIX}}/share/payload"}}]
+    );
+    _ = execute(h.ctx(), json);
+    try testing.expectEqualStrings("copy (clone failed)", h.flog.entries()[0].detail);
+    try testing.expectEqualStrings("old\n", try readBack(&h, dest));
+}
+
+test "copy reclaims a staging path a crashed run left behind" {
+    // clonefile(2) refuses a destination that already exists, so a stale
+    // `.malt-incoming` would otherwise wedge every later copy of that path.
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    _ = try seedNpmSrc(&h, "new\n");
+    const dest = try std.fmt.allocPrint(a, "{s}/lib/node_modules/npm", .{h.prefix});
+    try std.Io.Dir.cwd().createDirPath(h.io, try std.fmt.allocPrint(a, "{s}.malt-incoming/junk", .{dest}));
+
+    try testing.expect(execute(h.ctx(), try npmCopyJson(&h)));
+    try testing.expect(!h.flog.hasErrors());
+    try testing.expectEqualStrings("new\n", try readBack(&h, try std.fmt.allocPrint(a, "{s}/version.txt", .{dest})));
 }
 
 // --- migrated step types ---------------------------------------------------


### PR DESCRIPTION
## Description

A `copy` post_install step deleted its destination before cloning the replacement. Any clone failure - an unreadable child in a tap-shipped keg, ENOSPC, a part-way non-APFS fallback copy - left the prefix holding neither the old payload nor the new one, so a failed `node` upgrade lost npm outright.

The clone now lands beside the destination and is swapped in only once it exists. The payload it replaces is moved aside rather than deleted, and restored if the swap fails, so a failure is always recoverable. Replace-without-`force` semantics are unchanged.

## Related Issue

- None

## Notes for Reviewers

- The swap reuses `stepMove`'s aside pattern rather than extracting a shared helper.
