### PR TITLE
fix(smoke): stop the install smoke's teardown tripping over an untracked dependency

### DIFF
--- a/scripts/smokes/local-smoke-install.sh
+++ b/scripts/smokes/local-smoke-install.sh
@@ -477,16 +477,19 @@ install_tap_formulas() {
 # not block the script from completing.
 cleanup_installs() {
   printf '\n── Cleanup ───────────────────────────────────────\n'
-  local item
+  local item out
   for item in "${INSTALLED_CASKS[@]}"; do
     printf '  uninstall cask %s\n' "$item"
-    "$MT_BIN" uninstall --cask "$item" >/dev/null 2>&1 ||
-      printf '  WARN: uninstall --cask %s exited non-zero (continuing)\n' "$item"
+    out=$("$MT_BIN" uninstall --cask "$item" 2>&1) ||
+      printf '  WARN: uninstall --cask %s exited non-zero (continuing): %s\n' "$item" "$out"
   done
+  # Forced because only top-level installs are tracked: a dependency the
+  # script never named still holds a reference and would refuse an otherwise
+  # correct teardown (mongosh, pulled in by mongodb-community, pins node).
   for item in "${INSTALLED_FORMULAS[@]}"; do
     printf '  uninstall formula %s\n' "$item"
-    "$MT_BIN" uninstall "$item" >/dev/null 2>&1 ||
-      printf '  WARN: uninstall %s exited non-zero (continuing)\n' "$item"
+    out=$("$MT_BIN" uninstall --force "$item" 2>&1) ||
+      printf '  WARN: uninstall %s exited non-zero (continuing): %s\n' "$item" "$out"
   done
 }
 


### PR DESCRIPTION
## Description

The install smoke's teardown could not finish. It tracks only the formulas it installs top-level, so a dependency it never named still held a reference - `mongosh`, pulled in by `mongodb-community`, pins `node` - and the uninstall was correctly refused. Teardown now forces the removal, which is what a throwaway prefix wants.

The warning it printed also discarded the command's output, so the one line that explained the refusal was thrown away. It now reports what the command actually said.

## Related Issue

- None

## Notes for Reviewers

- This is a test-harness fix; malt's behaviour is unchanged and was never wrong here — refusing to remove a formula another package depends on is the point.
