### PR TITLE
fix(purge): write the wipe manifest with the same rows mt backup writes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,9 @@ jobs:
       - name: Regression guard - doctor survives a relative keg path
         run: ./scripts/regressions/doctor-survives-a-relative-keg-path.sh
 
+      - name: Regression guard - wipe manifest matches mt backup
+        run: ./scripts/regressions/wipe-manifest-tap-qualification-wipe-manifest-drops-tap-qualification-for-casks.sh
+
       - name: Build universal binary
         run: just build-universal
 

--- a/scripts/regressions/wipe-manifest-tap-qualification-wipe-manifest-drops-tap-qualification-for-casks.sh
+++ b/scripts/regressions/wipe-manifest-tap-qualification-wipe-manifest-drops-tap-qualification-for-casks.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Regression: the wipe manifest is the one backup guaranteed to be needed, so
+# it must carry exactly the rows `mt backup` writes. `purge --wipe --backup`
+# used to dump casks as bare tokens (losing the `<tap>/` prefix that lets
+# `mt restore` reach a third-party tap) and dropped auto-start services
+# entirely - and the drift only surfaced after the prefix was gone.
+#
+# Exits 0 when the bug is absent, non-zero (with a clear message) when present.
+# No network; all state lives under a throwaway prefix removed on EXIT.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+
+# The shell harness runs the built binary; `zig build test` does not refresh
+# it, so a stale binary would mask the fix.
+zig build >/dev/null
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+export NO_COLOR=1 MALT_NO_EMOJI=1
+
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+P="$tmp/prefix"
+mkdir -p "$P/db" "$P/Cellar"
+: >"$P/Cellar/marker"
+# A first backup materialises the schema so the seed rows have tables.
+MALT_PREFIX="$P" "$BIN" backup -o - >/dev/null 2>&1
+sqlite3 "$P/db/malt.db" "
+  INSERT INTO casks (token, name, version, url, tap) VALUES
+    ('foo', 'Foo', '1.0', 'https://x/foo.dmg', 'acme/tools'),
+    ('bar', 'Bar', '2.0', 'https://x/bar.dmg', 'homebrew/cask');
+  INSERT INTO services (name, keg_name, plist_path, auto_start)
+    VALUES ('svc', 'svc', '/svc.plist', 1);"
+
+MALT_PREFIX="$P" "$BIN" backup --versions --services -o "$tmp/b.txt" >/dev/null 2>&1 ||
+  fail "mt backup failed on the seeded prefix"
+MALT_PREFIX="$P" "$BIN" purge --wipe --backup="$tmp/m.txt" --yes >/dev/null 2>&1 ||
+  fail "wipe failed on the seeded prefix"
+
+grep -q '^cask acme/tools/foo@1.0$' "$tmp/m.txt" ||
+  fail "wipe manifest lost tap qualification for a third-party cask"
+grep -q '^cask bar@2.0$' "$tmp/m.txt" || fail "core cask must stay bare"
+grep -q '^service svc$' "$tmp/m.txt" || fail "wipe manifest dropped an auto-start service"
+diff <(grep -E '^(cask|service|formula) ' "$tmp/b.txt") \
+  <(grep -E '^(cask|service|formula) ' "$tmp/m.txt") ||
+  fail "wipe manifest diverges from mt backup"
+
+printf '  ✓ wipe manifest matches mt backup, including tap-qualified casks and services\n'

--- a/src/cli/backup.zig
+++ b/src/cli/backup.zig
@@ -170,11 +170,10 @@ pub fn writeRows(w: *std.Io.Writer, db: *sqlite.Database, include_versions: bool
             if (tap.len > 0 and !std.mem.eql(u8, tap, "homebrew/cask")) {
                 var qual_buf: [256]u8 = undefined;
                 const qualified = std.fmt.bufPrint(&qual_buf, "{s}/{s}", .{ tap, token }) catch {
-                    // Tap label too long for the qualified-name buffer —
-                    // fall back to the bare token so the entry isn't lost.
-                    try writeEntry(w, .cask, token, version, include_versions);
-                    count += 1;
-                    continue;
+                    // No legitimate slug overflows this; a bare token here
+                    // would be a line restore cannot use.
+                    output.err("Tap label too long for cask {s} ({s})", .{ token, tap });
+                    return RowsError.DatabaseError;
                 };
                 try writeEntry(w, .cask, qualified, version, include_versions);
             } else {
@@ -716,9 +715,9 @@ test "writeRows aborts on an unreadable table instead of truncating" {
     try std.testing.expectError(Error.DatabaseError, writeRows(&aw.writer, &db, true, true));
 }
 
-test "writeRows falls back to the bare token when the qualified slug overflows" {
-    // Pins the moved fallback: a tap label too long for `qual_buf` still
-    // yields an entry rather than a silently shorter manifest.
+test "writeRows refuses a tap label the qualified slug cannot hold" {
+    // Every legitimate `<user>/<repo>/<token>` fits; an oversized label is a
+    // corrupt row, and a bare token would be a line restore cannot use.
     var db = try sqlite.Database.open(":memory:");
     defer db.close();
     try schema.initSchema(&db);
@@ -727,8 +726,5 @@ test "writeRows falls back to the bare token when the qualified slug overflows" 
     var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
     defer aw.deinit();
 
-    const count = try writeRows(&aw.writer, &db, true, false);
-
-    try std.testing.expectEqualStrings("cask foo@1.0\n", aw.written());
-    try std.testing.expectEqual(@as(usize, 1), count);
+    try std.testing.expectError(error.DatabaseError, writeRows(&aw.writer, &db, true, false));
 }

--- a/src/cli/backup.zig
+++ b/src/cli/backup.zig
@@ -100,6 +100,33 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     if (output.isJson()) return executeJson(ctx, allocator, &db, output_path, include_services);
 
     try writeHeader(w);
+    const count = try writeRows(w, &db, include_versions, include_services);
+
+    const bytes = aw.written();
+
+    // ── Resolve destination and write ────────────────────────────────────
+    if (output_path) |p| {
+        if (std.mem.eql(u8, p, "-")) {
+            output.writeStdoutAll(bytes);
+            return;
+        }
+        try writeToPath(ctx, p, bytes);
+        output.success("Backup written to {s} ({d} packages)", .{ p, count });
+        return;
+    }
+
+    const default_path = try defaultBackupPath(ctx, allocator);
+    defer allocator.free(default_path);
+    try writeToPath(ctx, default_path, bytes);
+    output.success("Backup written to {s} ({d} packages)", .{ default_path, count });
+}
+
+pub const RowsError = error{ DatabaseError, WriteFailed };
+
+/// The plain-text row dump shared with the wipe manifest: the wipe copy is
+/// the one backup guaranteed to be needed, so it must never drift from what
+/// `mt restore` expects. Returns the number of entries written.
+pub fn writeRows(w: *std.Io.Writer, db: *sqlite.Database, include_versions: bool, include_services: bool) RowsError!usize {
     var count: usize = 0;
 
     // Directly-installed formulae only — dependencies are pulled transitively
@@ -109,7 +136,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         "WHERE install_reason = 'direct' " ++
         "ORDER BY name;";
     {
-        var fstmt = try prepareOrFail(&db, formulae_sql);
+        var fstmt = try prepareOrFail(db, formulae_sql);
         defer fstmt.finalize();
         while (try stepOrFail(&fstmt)) {
             const name_ptr = fstmt.columnText(0) orelse continue;
@@ -127,7 +154,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     // on restore; the qualified form routes through
     // `installTapFormula` and re-installs from the owning tap.
     {
-        var s = try prepareOrFail(&db, "SELECT token, version, tap FROM casks ORDER BY token;");
+        var s = try prepareOrFail(db, "SELECT token, version, tap FROM casks ORDER BY token;");
         defer s.finalize();
         while (try stepOrFail(&s)) {
             const name_ptr = s.columnText(0) orelse continue;
@@ -162,7 +189,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     // auto_start, no extra token needed.
     if (include_services) {
         {
-            var st = try prepareOrFail(&db, "SELECT name FROM services WHERE auto_start = 1 ORDER BY name;");
+            var st = try prepareOrFail(db, "SELECT name FROM services WHERE auto_start = 1 ORDER BY name;");
             defer st.finalize();
             while (try stepOrFail(&st)) {
                 const name_ptr = st.columnText(0) orelse continue;
@@ -173,38 +200,22 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         }
     }
 
-    const bytes = aw.written();
-
-    // ── Resolve destination and write ────────────────────────────────────
-    if (output_path) |p| {
-        if (std.mem.eql(u8, p, "-")) {
-            output.writeStdoutAll(bytes);
-            return;
-        }
-        try writeToPath(ctx, p, bytes);
-        output.success("Backup written to {s} ({d} packages)", .{ p, count });
-        return;
-    }
-
-    const default_path = try defaultBackupPath(ctx, allocator);
-    defer allocator.free(default_path);
-    try writeToPath(ctx, default_path, bytes);
-    output.success("Backup written to {s} ({d} packages)", .{ default_path, count });
+    return count;
 }
 
 /// A backup that silently drops rows is worse than no backup — restore would
 /// quietly rebuild a smaller machine. Both faults abort instead.
-fn prepareOrFail(db: *sqlite.Database, sql: []const u8) Error!sqlite.Statement {
+fn prepareOrFail(db: *sqlite.Database, sql: []const u8) RowsError!sqlite.Statement {
     return db.prepare(sql) catch |e| {
         output.err("Failed to read installed packages ({s})", .{@errorName(e)});
-        return Error.DatabaseError;
+        return RowsError.DatabaseError;
     };
 }
 
-fn stepOrFail(stmt: *sqlite.Statement) Error!bool {
+fn stepOrFail(stmt: *sqlite.Statement) RowsError!bool {
     return stmt.step() catch |e| {
         output.err("Database read failed mid-scan ({s})", .{@errorName(e)});
-        return Error.DatabaseError;
+        return RowsError.DatabaseError;
     };
 }
 
@@ -631,4 +642,93 @@ test "parseBackup silently drops any future unknown kind (forward-compat)" {
     try std.testing.expectEqual(@as(usize, 2), entries.len);
     try std.testing.expectEqualStrings("git", entries[0].name);
     try std.testing.expectEqualStrings("firefox", entries[1].name);
+}
+
+fn seedRowsDb() !sqlite.Database {
+    var db = try sqlite.Database.open(":memory:");
+    errdefer db.close();
+    try schema.initSchema(&db);
+    try db.exec(
+        \\INSERT INTO kegs(name, full_name, version, store_sha256, cellar_path, install_reason) VALUES
+        \\  ('git', 'git', '2.0', 'a', '/c/git', 'direct'),
+        \\  ('pcre', 'pcre', '10.0', 'b', '/c/pcre', 'dependency');
+        \\INSERT INTO casks(token, name, version, url, tap) VALUES
+        \\  ('foo', 'Foo', '1.0', 'https://x/foo.dmg', 'acme/tools'),
+        \\  ('bar', 'Bar', '2.0', 'https://x/bar.dmg', 'homebrew/cask'),
+        \\  ('baz', 'Baz', '3.0', 'https://x/baz.dmg', NULL),
+        \\  ('qux', 'Qux', '4.0', 'https://x/qux.dmg', '');
+        \\INSERT INTO services(name, keg_name, plist_path, auto_start) VALUES
+        \\  ('svc', 'svc', '/svc.plist', 1),
+        \\  ('idle', 'idle', '/idle.plist', 0);
+    );
+    return db;
+}
+
+test "writeRows qualifies third-party casks and leaves core, NULL and empty taps bare" {
+    // Row order follows the raw token, not the emitted slug: `mt restore`
+    // consumers pin these bytes, so the ordering is part of the contract.
+    var db = try seedRowsDb();
+    defer db.close();
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+
+    const count = try writeRows(&aw.writer, &db, true, false);
+
+    try std.testing.expectEqualStrings(
+        "formula git@2.0\n" ++
+            "cask bar@2.0\n" ++
+            "cask baz@3.0\n" ++
+            "cask acme/tools/foo@1.0\n" ++
+            "cask qux@4.0\n",
+        aw.written(),
+    );
+    try std.testing.expectEqual(@as(usize, 5), count);
+}
+
+test "writeRows emits auto-start services only when asked" {
+    var db = try seedRowsDb();
+    defer db.close();
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+
+    const count = try writeRows(&aw.writer, &db, false, true);
+
+    try std.testing.expectEqualStrings(
+        "formula git\n" ++
+            "cask bar\n" ++
+            "cask baz\n" ++
+            "cask acme/tools/foo\n" ++
+            "cask qux\n" ++
+            "service svc\n",
+        aw.written(),
+    );
+    try std.testing.expectEqual(@as(usize, 6), count);
+}
+
+test "writeRows aborts on an unreadable table instead of truncating" {
+    // A short manifest reads as "fewer packages"; the fault must surface.
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try db.exec("CREATE TABLE kegs(x);");
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+
+    try std.testing.expectError(Error.DatabaseError, writeRows(&aw.writer, &db, true, true));
+}
+
+test "writeRows falls back to the bare token when the qualified slug overflows" {
+    // Pins the moved fallback: a tap label too long for `qual_buf` still
+    // yields an entry rather than a silently shorter manifest.
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    const long_tap = "x" ** 300;
+    try db.exec("INSERT INTO casks(token, name, version, url, tap) VALUES ('foo', 'Foo', '1.0', 'https://x/foo.dmg', '" ++ long_tap ++ "');");
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+
+    const count = try writeRows(&aw.writer, &db, true, false);
+
+    try std.testing.expectEqualStrings("cask foo@1.0\n", aw.written());
+    try std.testing.expectEqual(@as(usize, 1), count);
 }

--- a/src/cli/purge/wipe.zig
+++ b/src/cli/purge/wipe.zig
@@ -115,13 +115,16 @@ pub fn writeManifest(ctx: *const AppCtx, allocator: std.mem.Allocator, path: []c
             // Guarantees the tables exist, so a failing `prepare` below can
             // only mean a genuinely broken database, never a fresh one.
             schema.initSchema(&db) catch |e| return refuseUnusableDb(prefix, e);
-            try writeRows(
-                w,
-                &db,
-                .formula,
-                "SELECT name, version FROM kegs WHERE install_reason = 'direct' ORDER BY name;",
-            );
-            try writeRows(w, &db, .cask, "SELECT token, version FROM casks ORDER BY token;");
+            // Versions always pinned and services always included: the
+            // wipe destroys the launchd plists, so this manifest is the
+            // only record of the auto-start set.
+            _ = backup_mod.writeRows(w, &db, true, true) catch |e| switch (e) {
+                error.DatabaseError => {
+                    output.err("cannot read installed packages — refusing to wipe without a usable backup", .{});
+                    return Error.DatabaseError;
+                },
+                error.WriteFailed => return Error.WriteFailed,
+            };
         },
     }
 
@@ -133,26 +136,6 @@ pub fn writeManifest(ctx: *const AppCtx, allocator: std.mem.Allocator, path: []c
 fn refuseUnusableDb(prefix: []const u8, e: anyerror) Error {
     output.err("cannot read database at {s}/db/malt.db ({s}) — refusing to wipe without a usable backup", .{ prefix, @errorName(e) });
     return Error.DatabaseError;
-}
-
-/// Query failures abort rather than truncate — a short manifest reads as
-/// "fewer packages installed", which is exactly the lie to avoid here.
-fn writeRows(w: *std.Io.Writer, db: *sqlite.Database, kind: backup_mod.Kind, sql: []const u8) Error!void {
-    var stmt = db.prepare(sql) catch |e| {
-        output.err("cannot read installed packages ({s}) — refusing to wipe without a usable backup", .{@errorName(e)});
-        return Error.DatabaseError;
-    };
-    defer stmt.finalize();
-    while (stmt.step() catch |e| {
-        output.err("database read failed mid-scan ({s}) — refusing to wipe with a partial backup", .{@errorName(e)});
-        return Error.DatabaseError;
-    }) {
-        const name_ptr = stmt.columnText(0) orelse continue;
-        const ver_ptr = stmt.columnText(1);
-        const name = std.mem.sliceTo(name_ptr, 0);
-        const version = if (ver_ptr) |p| std.mem.sliceTo(p, 0) else "";
-        backup_mod.writeEntry(w, kind, name, version, true) catch return Error.WriteFailed;
-    }
 }
 
 fn writeBytesToPath(ctx: *const AppCtx, path: []const u8, bytes: []const u8) Error!void {
@@ -446,4 +429,85 @@ test "writeBytesToPath maps a path_write failure to OpenFileFailed" {
 
     const ctx: AppCtx = .{ .io = io, .environ = .empty };
     try std.testing.expectError(Error.OpenFileFailed, writeBytesToPath(&ctx, dest, "formula git\n"));
+}
+
+/// Points MALT_PREFIX at a test prefix and puts the prior value back: the
+/// harness sets a throwaway, and unsetting it would send every later test
+/// at the real /opt/malt. The prior value is copied because setenv may free
+/// the environ string it replaces.
+const PrefixEnv = struct {
+    const c = struct {
+        extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+        extern "c" fn unsetenv(name: [*:0]const u8) c_int;
+        extern "c" fn getenv(name: [*:0]const u8) ?[*:0]u8;
+    };
+    prev: ?[:0]u8,
+
+    fn set(base: [:0]const u8) !PrefixEnv {
+        const prev: ?[:0]u8 = if (c.getenv("MALT_PREFIX")) |v| try std.testing.allocator.dupeZ(u8, std.mem.span(v)) else null;
+        _ = c.setenv("MALT_PREFIX", base.ptr, 1);
+        return .{ .prev = prev };
+    }
+
+    fn restore(self: *PrefixEnv) void {
+        if (self.prev) |v| {
+            _ = c.setenv("MALT_PREFIX", v.ptr, 1);
+            std.testing.allocator.free(v);
+        } else {
+            _ = c.unsetenv("MALT_PREFIX");
+        }
+    }
+};
+
+test "writeManifest writes the same tap-qualified cask and service rows as mt backup" {
+    // The wipe manifest is the only record left once the prefix is gone, so
+    // it must be restorable: third-party casks keep their tap and auto-start
+    // services are always included.
+    const io = std.Options.debug_io;
+    var s = try Scratch.init("purge_manifest_rows");
+    defer s.deinit();
+    try std.Io.Dir.cwd().createDirPath(io, s.p("/db"));
+
+    var db = try sqlite.Database.open(s.p("/db/malt.db"));
+    try schema.initSchema(&db);
+    try db.exec(
+        \\INSERT INTO casks(token, name, version, url, tap) VALUES
+        \\  ('foo', 'Foo', '1.0', 'https://x/foo.dmg', 'acme/tools'),
+        \\  ('bar', 'Bar', '2.0', 'https://x/bar.dmg', 'homebrew/cask');
+        \\INSERT INTO services(name, keg_name, plist_path, auto_start)
+        \\  VALUES ('svc', 'svc', '/svc.plist', 1);
+    );
+    db.close();
+
+    var env = try PrefixEnv.set(s.base);
+    defer env.restore();
+    const ctx: AppCtx = .{ .io = io, .environ = .empty };
+    const dest = s.p("/manifest.txt");
+    try writeManifest(&ctx, std.testing.allocator, dest);
+
+    const got = try std.Io.Dir.cwd().readFileAlloc(io, dest, std.testing.allocator, .unlimited);
+    defer std.testing.allocator.free(got);
+    try std.testing.expect(std.mem.indexOf(u8, got, "cask bar@2.0\ncask acme/tools/foo@1.0\nservice svc\n") != null);
+}
+
+test "writeManifest refuses a database whose tables cannot be read and leaves no manifest" {
+    // A bad table must abort like a bad file: a partial manifest followed
+    // by the wipe would be worse than no manifest at all.
+    const io = std.Options.debug_io;
+    var s = try Scratch.init("purge_manifest_badtable");
+    defer s.deinit();
+    try std.Io.Dir.cwd().createDirPath(io, s.p("/db"));
+
+    var db = try sqlite.Database.open(s.p("/db/malt.db"));
+    // `initSchema` is CREATE IF NOT EXISTS, so this shape survives it.
+    try db.exec("CREATE TABLE kegs(x);");
+    db.close();
+
+    var env = try PrefixEnv.set(s.base);
+    defer env.restore();
+    const ctx: AppCtx = .{ .io = io, .environ = .empty };
+    const dest = s.p("/manifest.txt");
+
+    try std.testing.expectError(Error.DatabaseError, writeManifest(&ctx, std.testing.allocator, dest));
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, dest, .{}));
 }

--- a/tests/backup_test.zig
+++ b/tests/backup_test.zig
@@ -220,6 +220,40 @@ test "writeEntry + parseBackup round-trip preserves every entry" {
     }
 }
 
+test "writeRows output parses back into restore entries with the tap kept on the cask" {
+    // The row writer and `parseBackup` are the two ends of the restore
+    // contract: a tap-qualified cask must come back as one name that
+    // `install --cask` can route to the owning tap.
+    var db = try malt.sqlite.Database.open(":memory:");
+    defer db.close();
+    try malt.schema.initSchema(&db);
+    try db.exec(
+        \\INSERT INTO kegs(name, full_name, version, store_sha256, cellar_path)
+        \\  VALUES ('git', 'git', '2.0', 'a', '/c/git');
+        \\INSERT INTO casks(token, name, version, url, tap)
+        \\  VALUES ('foo', 'Foo', '1.0', 'https://x/foo.dmg', 'acme/tools');
+        \\INSERT INTO services(name, keg_name, plist_path, auto_start)
+        \\  VALUES ('svc', 'svc', '/svc.plist', 1);
+    );
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try backup.writeHeader(&aw.writer);
+    _ = try backup.writeRows(&aw.writer, &db, true, true);
+
+    const entries = try backup.parseBackup(testing.allocator, aw.written());
+    defer testing.allocator.free(entries);
+
+    try testing.expectEqual(@as(usize, 3), entries.len);
+    try testing.expectEqual(backup.Kind.formula, entries[0].kind);
+    try testing.expectEqualStrings("git", entries[0].name);
+    try testing.expectEqual(backup.Kind.cask, entries[1].kind);
+    try testing.expectEqualStrings("acme/tools/foo", entries[1].name);
+    try testing.expectEqualStrings("1.0", entries[1].version);
+    try testing.expectEqual(backup.Kind.service, entries[2].kind);
+    try testing.expectEqualStrings("svc", entries[2].name);
+}
+
 // ── defaultBackupPath ────────────────────────────────────────────────────
 
 test "writeBackupJson: empty inputs emit `{formulas:[],casks:[]}\\n`" {


### PR DESCRIPTION
## Description

`purge --wipe --backup` kept its own copy of the backup dump, so third-party-tap casks were written as bare tokens that `mt restore` could not install, and auto-start services were dropped - discovered only after the prefix was gone. The wipe manifest now goes through the same row writer as `mt backup`, with versions pinned and services always included.

## Related Issue

- None

## Notes for Reviewers

- The old "tap label too long" fallback silently wrote a bare token - the same unrestorable line; it now aborts the backup instead.