### PR TITLE
fix(bundle): record the imported manifest by its canonical path so purge reads the right file from any cwd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,9 @@ jobs:
       - name: Regression guard - wipe manifest matches mt backup
         run: ./scripts/regressions/wipe-manifest-tap-qualification-wipe-manifest-drops-tap-qualification-for-casks.sh
 
+      - name: Regression guard - bundle import records the canonical manifest path
+        run: ./scripts/regressions/bundle-import-canonical-manifest-path-bundle-import-records-relative-manifest-path.sh
+
       - name: Build universal binary
         run: just build-universal
 

--- a/scripts/regressions/bundle-import-canonical-manifest-path-bundle-import-records-relative-manifest-path.sh
+++ b/scripts/regressions/bundle-import-canonical-manifest-path-bundle-import-records-relative-manifest-path.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Regression: `bundle import` must record the manifest by its canonical
+# absolute path, and `remove --purge` must refuse a stored relative one.
+#
+# The bug: `import` persisted the typed path verbatim, so a later
+# `remove --purge` re-opened it against whatever cwd that invocation ran
+# from. A same-named file there silently became the purge plan; no file at
+# all made the command fail. Rows written by older binaries still carry the
+# relative path, so the read side has to refuse them rather than resolve.
+#
+# Runs the built binary against a throwaway prefix; the purge is a dry run
+# so nothing is ever uninstalled. No network.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+# `zig build test` never refreshes the CLI binary; build it so this exercises
+# current source rather than a stale artefact.
+if ! zig build >/dev/null 2>&1; then
+  echo "FAIL: could not build the malt binary (zig build)" >&2
+  exit 1
+fi
+
+MT="${MT:-$ROOT/zig-out/bin/mt}"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export MALT_PREFIX="$TMP/p" NO_COLOR=1 MALT_NO_EMOJI=1
+mkdir -p "$MALT_PREFIX" "$TMP/a" "$TMP/b"
+DB="$MALT_PREFIX/db/malt.db"
+
+printf 'brew "only-in-a"\n' >"$TMP/a/Brewfile"
+# Deliberately unparsable: reading it from `b` is unmistakable in the output.
+printf 'not a brewfile ((\n' >"$TMP/b/Brewfile"
+
+fail=0
+
+(cd "$TMP/a" && "$MT" bundle import Brewfile >/dev/null 2>&1)
+stored=$(sqlite3 "$DB" "select manifest_path from bundles where name='Brewfile';")
+# `pwd -P` resolves symlinks the same way the store does.
+want="$(cd "$TMP/a" && pwd -P)/Brewfile"
+if [[ "$stored" != "$want" ]]; then
+  echo "FAIL: import stored '$stored', want '$want'" >&2
+  fail=1
+fi
+
+if ! out=$(cd "$TMP/b" && "$MT" bundle remove --purge --dry-run Brewfile 2>&1); then
+  echo "FAIL: purge from another cwd failed: $out" >&2
+  fail=1
+elif grep -q "parse error" <<<"$out"; then
+  echo "FAIL: purge read b/Brewfile instead of the imported file" >&2
+  fail=1
+fi
+
+# Legacy row: a pre-fix binary stored the relative path as typed.
+sqlite3 "$DB" "insert into bundles(name,manifest_path,created_at,version) values('legacy','Brewfile',0,1);"
+if msg=$(cd "$TMP/a" && "$MT" bundle remove --purge --dry-run legacy 2>&1); then
+  echo "FAIL: legacy relative manifest_path was resolved against cwd instead of refused" >&2
+  fail=1
+elif ! grep -Fq 're-import' <<<"$msg"; then
+  echo "FAIL: refusal did not tell the user to re-import: $msg" >&2
+  fail=1
+fi
+# The row must survive so the user can re-import under the same name.
+if [[ "$(sqlite3 "$DB" "select count(*) from bundles where name='legacy';")" != "1" ]]; then
+  echo "FAIL: refused purge unregistered the legacy bundle" >&2
+  fail=1
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "PASS: bundle import records the canonical manifest path"

--- a/src/cli/bundle.zig
+++ b/src/cli/bundle.zig
@@ -486,11 +486,17 @@ fn lookupManifestPath(
         output.err("bundle not registered: {s}", .{name});
         return BundleError.BundlefileNotFound;
     }
-    const raw = stmt.columnText(0) orelse {
+    const raw = std.mem.sliceTo(stmt.columnText(0) orelse {
         output.err("bundle {s} has no recorded manifest path", .{name});
         return BundleError.BundlefileNotFound;
-    };
-    return allocator.dupe(u8, std.mem.sliceTo(raw, 0)) catch return BundleError.DatabaseError;
+    }, 0);
+    // Rows written before import canonicalised the path: resolving them
+    // against this process's cwd could purge from an unrelated file.
+    if (!std.fs.path.isAbsolute(raw)) {
+        output.err("bundle {s} was registered with a relative manifest path ({s}); re-import it", .{ name, raw });
+        return BundleError.BundlefileNotFound;
+    }
+    return allocator.dupe(u8, raw) catch return BundleError.DatabaseError;
 }
 
 const CreateArgs = struct { format: Format, out_path: []const u8, include_services: bool };
@@ -587,6 +593,12 @@ fn cmdImport(ctx: *const AppCtx, allocator: std.mem.Allocator, rest: []const []c
     defer manifest.deinit();
     for (diag.warnings.items) |w| output.warn("{s}", .{w});
 
+    // The row outlives this process, so a cwd-relative path would be
+    // re-resolved against whatever cwd `remove --purge` later runs from.
+    const canonical = std.Io.Dir.cwd().realPathFileAlloc(ctx.io, path, allocator) catch
+        return BundleError.BundlefileNotFound;
+    defer allocator.free(canonical);
+
     var db = try openDb(ctx);
     defer db.close();
 
@@ -598,7 +610,7 @@ fn cmdImport(ctx: *const AppCtx, allocator: std.mem.Allocator, rest: []const []c
     defer stmt.finalize();
     const name = if (manifest.name.len > 0) manifest.name else path;
     stmt.bindText(1, name) catch return BundleError.DatabaseError;
-    stmt.bindText(2, path) catch return BundleError.DatabaseError;
+    stmt.bindText(2, canonical) catch return BundleError.DatabaseError;
     stmt.bindInt(3, std.Io.Clock.real.now(ctx.io).toSeconds()) catch return BundleError.DatabaseError;
     stmt.bindInt(4, @intCast(manifest.version)) catch return BundleError.DatabaseError;
     _ = stmt.step() catch return BundleError.DatabaseError;

--- a/tests/bundle_cli_test.zig
+++ b/tests/bundle_cli_test.zig
@@ -297,6 +297,210 @@ test "import on a malformed Maltfile.json surfaces BundlefileParse" {
     );
 }
 
+// --- import: manifest_path canonicalisation ---------------------------
+
+fn writeFile(path: []const u8, body: []const u8) !void {
+    const f = try test_io.createFileAbsolute(std.Options.debug_io, path, .{ .truncate = true });
+    defer f.close(std.Options.debug_io);
+    try f.writeStreamingAll(std.Options.debug_io, body);
+}
+
+/// A cwd-relative spelling of `path` without chdir: the runner is parallel
+/// and cwd is process-global.
+fn relativeToCwd(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    var cwd_buf: [test_io.max_path_bytes]u8 = undefined;
+    const cwd = cwd_buf[0..try test_io.cwd().realPathFile(std.Options.debug_io, ".", &cwd_buf)];
+    return std.fs.path.relativePosix(allocator, cwd, cwd, path);
+}
+
+fn storedManifestPath(allocator: std.mem.Allocator, prefix: []const u8, name: []const u8) ![]u8 {
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    var stmt = try db.prepare("SELECT manifest_path FROM bundles WHERE name = ?;");
+    defer stmt.finalize();
+    try stmt.bindText(1, name);
+    try testing.expect(try stmt.step());
+    return allocator.dupe(u8, std.mem.sliceTo(stmt.columnText(0).?, 0));
+}
+
+test "import stores the canonical absolute path for a relative manifest argument" {
+    var s = try Scratch.init(testing.allocator, "import_relpath");
+    defer s.deinit(testing.allocator);
+    try initDb(s.path);
+
+    const path = try std.fmt.allocPrint(testing.allocator, "{s}/Maltfile.json", .{s.path});
+    defer testing.allocator.free(path);
+    try writeFile(path,
+        \\{"name": "relpath", "version": 1, "formulas": []}
+    );
+
+    const rel = try relativeToCwd(testing.allocator, path);
+    defer testing.allocator.free(rel);
+    try testing.expect(!std.fs.path.isAbsolute(rel));
+
+    quiet();
+    defer unquiet();
+    try bundle.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "import", rel });
+
+    const want = try test_io.cwd().realPathFileAlloc(std.Options.debug_io, path, testing.allocator);
+    defer testing.allocator.free(want);
+    const stored = try storedManifestPath(testing.allocator, s.path, "relpath");
+    defer testing.allocator.free(stored);
+    try testing.expectEqualStrings(want, stored);
+}
+
+test "import collapses dot-dot segments in an absolute manifest argument" {
+    var s = try Scratch.init(testing.allocator, "import_dotdot");
+    defer s.deinit(testing.allocator);
+    try initDb(s.path);
+
+    const sub = try std.fmt.allocPrint(testing.allocator, "{s}/sub", .{s.path});
+    defer testing.allocator.free(sub);
+    try test_io.cwd().createDirPath(std.Options.debug_io, sub);
+    const path = try std.fmt.allocPrint(testing.allocator, "{s}/Maltfile.json", .{s.path});
+    defer testing.allocator.free(path);
+    try writeFile(path,
+        \\{"name": "dotdot", "version": 1, "formulas": []}
+    );
+    const dotted = try std.fmt.allocPrint(testing.allocator, "{s}/sub/../Maltfile.json", .{s.path});
+    defer testing.allocator.free(dotted);
+
+    quiet();
+    defer unquiet();
+    try bundle.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "import", dotted });
+
+    const want = try test_io.cwd().realPathFileAlloc(std.Options.debug_io, path, testing.allocator);
+    defer testing.allocator.free(want);
+    const stored = try storedManifestPath(testing.allocator, s.path, "dotdot");
+    defer testing.allocator.free(stored);
+    try testing.expectEqualStrings(want, stored);
+}
+
+test "import records a symlinked manifest by its target" {
+    var s = try Scratch.init(testing.allocator, "import_symlink");
+    defer s.deinit(testing.allocator);
+    try initDb(s.path);
+
+    const target = try std.fmt.allocPrint(testing.allocator, "{s}/Maltfile.json", .{s.path});
+    defer testing.allocator.free(target);
+    try writeFile(target,
+        \\{"name": "linked", "version": 1, "formulas": []}
+    );
+    const link = try std.fmt.allocPrint(testing.allocator, "{s}/link.json", .{s.path});
+    defer testing.allocator.free(link);
+    try test_io.cwd().symLink(std.Options.debug_io, target, link, .{});
+
+    quiet();
+    defer unquiet();
+    try bundle.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "import", link });
+
+    // Same canonicalisation every other site uses: the row names the file
+    // that will actually be read, not the link.
+    const want = try test_io.cwd().realPathFileAlloc(std.Options.debug_io, target, testing.allocator);
+    defer testing.allocator.free(want);
+    const stored = try storedManifestPath(testing.allocator, s.path, "linked");
+    defer testing.allocator.free(stored);
+    try testing.expectEqualStrings(want, stored);
+}
+
+test "import keeps the typed path as the registered name when the manifest has none" {
+    var s = try Scratch.init(testing.allocator, "import_name_fallback");
+    defer s.deinit(testing.allocator);
+    try initDb(s.path);
+
+    const path = try std.fmt.allocPrint(testing.allocator, "{s}/Brewfile", .{s.path});
+    defer testing.allocator.free(path);
+    try writeFile(path, "brew \"wget\"\n");
+
+    const rel = try relativeToCwd(testing.allocator, path);
+    defer testing.allocator.free(rel);
+
+    quiet();
+    defer unquiet();
+    try bundle.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "import", rel });
+
+    // The name stays what the user typed; only the path column is canonical.
+    const stored = try storedManifestPath(testing.allocator, s.path, rel);
+    defer testing.allocator.free(stored);
+    try testing.expect(std.fs.path.isAbsolute(stored));
+}
+
+test "remove --purge refuses a legacy relative manifest_path and keeps the row" {
+    var s = try Scratch.init(testing.allocator, "purge_legacy_rel");
+    defer s.deinit(testing.allocator);
+    try initDb(s.path);
+
+    // A relative path that *does* resolve from the runner's cwd: a purge that
+    // opens it instead of refusing is exactly the cwd-dependent read.
+    const path = try std.fmt.allocPrint(testing.allocator, "{s}/Brewfile", .{s.path});
+    defer testing.allocator.free(path);
+    try writeFile(path, "brew \"wget\"\n");
+    const rel = try relativeToCwd(testing.allocator, path);
+    defer testing.allocator.free(rel);
+    {
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{s.path}, 0);
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        var stmt = try db.prepare(
+            \\INSERT INTO bundles (name, manifest_path, created_at, version)
+            \\VALUES ('legacy', ?, 1700000000, 1);
+        );
+        defer stmt.finalize();
+        try stmt.bindText(1, rel);
+        _ = try stmt.step();
+    }
+
+    quiet();
+    defer unquiet();
+    try testing.expectError(
+        bundle.BundleError.BundlefileNotFound,
+        bundle.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "remove", "--purge", "--dry-run", "legacy" }),
+    );
+
+    // Refusal happens before unregister, so the user can re-import by name.
+    const stored = try storedManifestPath(testing.allocator, s.path, "legacy");
+    defer testing.allocator.free(stored);
+    try testing.expectEqualStrings(rel, stored);
+}
+
+test "re-import replaces a legacy relative row with the canonical path" {
+    var s = try Scratch.init(testing.allocator, "reimport_legacy");
+    defer s.deinit(testing.allocator);
+    try initDb(s.path);
+    {
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{s.path}, 0);
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        var stmt = try db.prepare(
+            \\INSERT INTO bundles (name, manifest_path, created_at, version)
+            \\VALUES ('legacy', 'Brewfile', 1700000000, 1);
+        );
+        defer stmt.finalize();
+        _ = try stmt.step();
+    }
+
+    // The recovery the refusal message asks for: same name, fresh import.
+    const path = try std.fmt.allocPrint(testing.allocator, "{s}/Maltfile.json", .{s.path});
+    defer testing.allocator.free(path);
+    try writeFile(path,
+        \\{"name": "legacy", "version": 1, "formulas": []}
+    );
+
+    quiet();
+    defer unquiet();
+    try bundle.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "import", path });
+
+    const want = try test_io.cwd().realPathFileAlloc(std.Options.debug_io, path, testing.allocator);
+    defer testing.allocator.free(want);
+    const stored = try storedManifestPath(testing.allocator, s.path, "legacy");
+    defer testing.allocator.free(stored);
+    try testing.expectEqualStrings(want, stored);
+}
+
 // --- export -----------------------------------------------------------
 
 test "export with no installed packages emits an empty Brewfile body to stdout" {


### PR DESCRIPTION
## Description

`bundle import` stored the manifest path exactly as typed, so a later `bundle remove --purge` re-opened it relative to whatever directory that command ran from - silently planning the purge from an unrelated same-named file, or failing when none was there. Import now records the canonical absolute path, and purge refuses rows that still hold a relative one (asking for a re-import) instead of resolving them against the current directory.

## Related Issue

- None

## Notes for Reviewers

- None