### PR TITLE
fix(post-install): let the Ruby fallback run with a package-manager Ruby inside the fence

### DIFF
--- a/justfile
+++ b/justfile
@@ -86,6 +86,7 @@ regressions-harness:
     @./scripts/regressions/ghcr-bearer-header-fixed-stack-buffer.sh
     @./scripts/regressions/post-install-run-step-gh804.sh
     @./scripts/regressions/progress-shared-counters-atomic-progressbar-update-lock-free-data-race.sh
+    @./scripts/regressions/ruby-fallback-fenced-interpreter-homebrew-ruby-is-not-usable.sh
     @./scripts/regressions/scaled-timeout-clamp-scaled-timeout-overflow-on-content-length.sh
     @./scripts/regressions/term-sanitize-anti-injection-guarantee.sh
     @./scripts/regressions/tui-startup-outdated-network-freeze.sh

--- a/scripts/regressions/ruby-fallback-fenced-interpreter-homebrew-ruby-is-not-usable.sh
+++ b/scripts/regressions/ruby-fallback-fenced-interpreter-homebrew-ruby-is-not-usable.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Regression: the Ruby fence denies `file-read-data` under every package-manager
+# prefix, but `detectRuby` prefers exactly those interpreters. A Homebrew Ruby
+# links its `libruby` dylib from `<prefix>/Cellar`, so under the fence dyld
+# aborts before Ruby runs a line and every post-install fallback fails on a box
+# with Homebrew Ruby installed. The system Ruby loads from a framework tree
+# that is never denied, which is why the gap stayed invisible elsewhere.
+#
+# A standalone `zig test` harness drives the real `runRubySandboxed` with the
+# package-manager Ruby and a script that records its version inside the keg.
+# The interpreter must start and the file must appear. Skips loudly when no
+# package-manager Ruby is present. No network, no prefix writes, under 30s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+
+RUBY=""
+for c in /opt/homebrew/opt/ruby/bin/ruby /usr/local/opt/ruby/bin/ruby; do
+  [[ -x "$c" ]] && {
+    RUBY="$c"
+    break
+  }
+done
+[[ -n "$RUBY" ]] || {
+  echo "SKIP: no package-manager Ruby on this box"
+  exit 0
+}
+
+TMP=$(mktemp -d)
+# Unique per run: concurrent runs sharing a harness path wipe each other's
+# fixtures mid-compile.
+HARNESS="$ROOT/.ruby-fence-interpreter-$$.zig"
+trap 'rm -rf "$TMP" "$HARNESS"' EXIT
+
+PREFIX="$TMP/prefix"
+KEG="$PREFIX/Cellar/probe/1.0"
+mkdir -p "$KEG"
+printf 'File.write("%s/version", RUBY_VERSION)\n' "$KEG" >"$TMP/probe.rb"
+
+cat >"$HARNESS" <<ZIG
+const std = @import("std");
+const sandbox = @import("src/core/sandbox/macos.zig");
+
+test "a package-manager Ruby starts inside the fence" {
+    const env: sandbox.ScrubbedEnv = .{
+        .home = "$TMP",
+        .path = sandbox.sandbox_path,
+        .malt_prefix = "$PREFIX",
+        .tmpdir = "$TMP",
+    };
+    const code = try sandbox.runRubySandboxed(
+        std.testing.allocator,
+        .empty,
+        "$RUBY",
+        "$TMP/probe.rb",
+        "$KEG",
+        "$PREFIX",
+        env,
+        .{},
+        .{},
+    );
+    if (code != 0) {
+        std.debug.print("fenced $RUBY exited {d}\n", .{code});
+        return error.FencedInterpreterDidNotStart;
+    }
+}
+ZIG
+
+run_harness() {
+  (cd "$ROOT" && zig test -lc "$HARNESS")
+}
+
+if ! run_harness >"$TMP/harness.log" 2>&1; then
+  grep -Ev '\.\.\.OK$' "$TMP/harness.log" | tail -20 >&2
+  echo "FAIL: the fenced $RUBY did not start" >&2
+  exit 1
+fi
+
+GOT=""
+[[ -f "$KEG/version" ]] && GOT=$(<"$KEG/version")
+[[ "$GOT" =~ ^[0-9]+\.[0-9]+ ]] || {
+  echo "FAIL: fenced $RUBY ran but recorded no version (got '$GOT')" >&2
+  exit 1
+}
+
+echo "PASS: the fenced $RUBY runs ($GOT)"

--- a/src/core/sandbox/macos.zig
+++ b/src/core/sandbox/macos.zig
@@ -129,6 +129,10 @@ pub const ProfileOpts = struct {
     /// Individual files needed by this spawn, such as the generated Ruby
     /// wrapper. These are literal rules, not directory grants.
     read_files: []const []const u8 = &.{},
+    /// Read-only trees the interpreter itself lives in; the deny list above
+    /// covers every package-manager prefix, so a fenced Ruby installed by
+    /// one cannot load its own dylibs without this.
+    read_dirs: []const []const u8 = &.{},
 };
 
 /// Render the deny-by-default SCL profile; writes limited to `cellar_path`
@@ -166,6 +170,7 @@ pub fn renderRubyProfile(
     buf.appendSlice(allocator, header) catch return SandboxError.ProfileBuildFailed;
 
     for (opts.read_files) |path| try validatePathForProfile(path);
+    for (opts.read_dirs) |path| try validatePathForProfile(path);
 
     var aw: std.Io.Writer.Allocating = .fromArrayList(allocator, &buf);
     const w = &aw.writer;
@@ -229,6 +234,12 @@ pub fn renderRubyProfile(
         var real_buf: [std.fs.max_path_bytes]u8 = undefined;
         if (resolvedForProfile(path, &real_buf)) |real|
             w.print("\n  (literal \"{s}\")", .{real}) catch return SandboxError.ProfileBuildFailed;
+    }
+    for (opts.read_dirs) |path| {
+        writeCellarRule(w, path) catch return SandboxError.ProfileBuildFailed;
+        var real_buf: [std.fs.max_path_bytes]u8 = undefined;
+        if (resolvedForProfile(path, &real_buf)) |real|
+            writeCellarRule(w, real) catch return SandboxError.ProfileBuildFailed;
     }
     w.writeAll(")\n") catch return SandboxError.ProfileBuildFailed;
 
@@ -400,9 +411,23 @@ pub fn runRubySandboxed(
 ) SandboxError!u8 {
     if (builtin.os.tag != .macos) return SandboxError.SandboxUnsupported;
 
+    // A package-manager Ruby links its dylibs through `<prefix>/opt/*`
+    // into `<prefix>/Cellar/*`; grant those two trees and nothing else
+    // there (no `etc`/`var`).
+    var cellar_dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    var opt_dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    var dirs: [2][]const u8 = undefined;
+    const read_dirs: []const []const u8 = if (interpreterPrefix(ruby_path)) |prefix| blk: {
+        dirs = .{
+            std.fmt.bufPrint(&cellar_dir_buf, "{s}/Cellar", .{prefix}) catch return SandboxError.ProfileBuildFailed,
+            std.fmt.bufPrint(&opt_dir_buf, "{s}/opt", .{prefix}) catch return SandboxError.ProfileBuildFailed,
+        };
+        break :blk &dirs;
+    } else &.{};
     const profile = try renderRubyProfile(allocator, cellar_path, malt_prefix, .{
         .home = env.home,
         .read_files = &.{script_path},
+        .read_dirs = read_dirs,
     });
     defer allocator.free(profile);
 
@@ -419,6 +444,15 @@ pub fn runRubySandboxed(
         return spawnInherit(argv_z, envp, limits, stdio);
     }
     return spawnFiltered(argv_z, envp, limits, stdio);
+}
+
+/// The package-manager prefix a Ruby was installed under, or null for a
+/// Ruby that already lives in an always-readable system tree.
+fn interpreterPrefix(ruby_path: []const u8) ?[]const u8 {
+    const suffix = "/opt/ruby/bin/ruby";
+    if (!std.mem.endsWith(u8, ruby_path, suffix)) return null;
+    const prefix = ruby_path[0 .. ruby_path.len - suffix.len];
+    return if (prefix.len == 0) null else prefix;
 }
 
 pub fn rawPassthroughEnabled(environ: std.process.Environ) bool {
@@ -802,6 +836,60 @@ test "renderRubyProfile emits deny-default + cellar + prefix subpaths" {
     try std.testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/lib\")\n") == null);
     // IPC is opt-in: the default profile must NOT grant it.
     try std.testing.expect(std.mem.indexOf(u8, profile, "ipc-sysv-shm") == null);
+}
+
+test "renderRubyProfile grants read-only access to read_dirs, never writes" {
+    const profile = try renderRubyProfile(
+        std.testing.allocator,
+        "/opt/malt/Cellar/foo/1.0",
+        "/opt/malt",
+        .{ .read_dirs = &.{"/opt/homebrew/Cellar"} },
+    );
+    defer std.testing.allocator.free(profile);
+    const read_start = std.mem.indexOf(u8, profile, "(allow file-read-data").?;
+    const write_start = std.mem.indexOf(u8, profile, "(allow file-write*").?;
+    const grant = std.mem.indexOf(u8, profile, "(subpath \"/opt/homebrew/Cellar\")").?;
+    try std.testing.expect(grant > read_start and grant < write_start);
+    try std.testing.expect(std.mem.indexOf(u8, profile[write_start..], "/opt/homebrew/Cellar") == null);
+}
+
+test "renderRubyProfile also grants read_dirs under their resolved form" {
+    var s = try Scratch.init("sbx_read_dirs_test");
+    defer s.deinit();
+    _ = std.c.mkdir(s.base.ptr, 0o755); // EEXIST is fine
+
+    const a = s.arena.allocator();
+    const profile = try renderRubyProfile(
+        std.testing.allocator,
+        "/opt/malt/Cellar/foo/1.0",
+        "/opt/malt",
+        .{ .read_dirs = &.{s.base} },
+    );
+    defer std.testing.allocator.free(profile);
+
+    // /tmp resolves to /private/tmp; without the resolved grant a Ruby
+    // living under a symlinked prefix is denied its own files.
+    const lit = try std.fmt.allocPrint(a, "(subpath \"{s}\")", .{s.base});
+    const res = try std.fmt.allocPrint(a, "(subpath \"/private{s}\")", .{s.base});
+    try std.testing.expect(std.mem.indexOf(u8, profile, lit) != null);
+    try std.testing.expect(std.mem.indexOf(u8, profile, res) != null);
+}
+
+test "renderRubyProfile rejects an unsafe read_dirs entry" {
+    try std.testing.expectError(SandboxError.UnsafePath, renderRubyProfile(
+        std.testing.allocator,
+        "/opt/malt/Cellar/foo/1.0",
+        "/opt/malt",
+        .{ .read_dirs = &.{"/opt/homebrew/Cellar\"; (allow default)"} },
+    ));
+}
+
+test "interpreterPrefix names the package manager prefix that owns a Ruby" {
+    try std.testing.expectEqualStrings("/opt/homebrew", interpreterPrefix("/opt/homebrew/opt/ruby/bin/ruby").?);
+    try std.testing.expectEqualStrings("/usr/local", interpreterPrefix("/usr/local/opt/ruby/bin/ruby").?);
+    // The system Ruby lives in the always-readable /usr tree.
+    try std.testing.expect(interpreterPrefix("/usr/bin/ruby") == null);
+    try std.testing.expect(interpreterPrefix("/opt/ruby/bin/ruby") == null);
 }
 
 test "renderRubyProfile grants IPC only when allow_ipc is set" {


### PR DESCRIPTION
## Description

On a box with a Homebrew Ruby the post-install fallback picked that interpreter, but the sandbox fence denied it its own runtime, so `--use-system-ruby` and the automatic `ruby`/`ruby@N` routing could never succeed for exactly the users most likely to need them. The fence now lets a package-manager Ruby read the trees it is installed from - read-only, nothing more - and the system Ruby is untouched. A regression guard drives the real fenced spawn with whatever package-manager Ruby the box has, and skips loudly when there is none.

## Related Issue

- None

## Notes for Reviewers

- The grant is the whole package-manager `Cellar` and `opt` trees, read-only. Narrower is not viable statically: the interpreter's native extensions link other kegs through `opt/` symlinks (`openssl.bundle` -> `opt/openssl@3`). This mirrors how the fence already trusts malt's own prefix; a per-binary dylib-closure walk is tracked separately.