### PR TITLE
fix(post-install): stop offering the Ruby fallback interpreters the fence cannot run

### DIFF
--- a/justfile
+++ b/justfile
@@ -87,6 +87,7 @@ regressions-harness:
     @./scripts/regressions/post-install-run-step-gh804.sh
     @./scripts/regressions/progress-shared-counters-atomic-progressbar-update-lock-free-data-race.sh
     @./scripts/regressions/ruby-fallback-fenced-interpreter-homebrew-ruby-is-not-usable.sh
+    @./scripts/regressions/ruby-fallback-ruby-fence-rejects-version-manager-and-path-rubies.sh
     @./scripts/regressions/scaled-timeout-clamp-scaled-timeout-overflow-on-content-length.sh
     @./scripts/regressions/term-sanitize-anti-injection-guarantee.sh
     @./scripts/regressions/tui-startup-outdated-network-freeze.sh

--- a/scripts/regressions/ruby-fallback-ruby-fence-rejects-version-manager-and-path-rubies.sh
+++ b/scripts/regressions/ruby-fallback-ruby-fence-rejects-version-manager-and-path-rubies.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Regression: `detectRuby` used to fall through to rbenv/asdf shims under
+# `$HOME` and then to the first `ruby` on `$PATH`, but the fence denies
+# `file-read-data` under every root those interpreters live in and scrubs
+# `$PATH` to the system dirs. A shim cannot even be read; a PATH Ruby aborts in
+# dyld on its first dylib. Both ends of the pipeline must agree on what a
+# usable Ruby is, so detection stops at the interpreters the fence can run.
+#
+# Two assertions: (a) `detect.zig` no longer consults `HOME` or `PATH`; (b) the
+# Ruby detected on this box actually starts inside the real `runRubySandboxed`
+# and records its version in the keg. No Ruby at all is a
+# FAIL, not a skip: every macOS ships `/usr/bin/ruby`. No network, no prefix
+# writes, under 30s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+DETECT="$ROOT/src/core/ruby/detect.zig"
+
+if rg -n '"HOME"|"PATH"|rbenv|asdf' "$DETECT"; then
+  echo "FAIL: detectRuby probes HOME/PATH again; the fence cannot run those Rubies" >&2
+  exit 1
+fi
+
+TMP=$(mktemp -d)
+# Unique per run: concurrent runs sharing a harness path wipe each other's
+# fixtures mid-compile.
+HARNESS="$ROOT/.ruby-fence-detect-$$.zig"
+trap 'rm -rf "$TMP" "$HARNESS"' EXIT
+
+PREFIX="$TMP/prefix"
+KEG="$PREFIX/Cellar/probe/1.0"
+mkdir -p "$KEG"
+printf 'File.write("%s/version", RUBY_VERSION)\n' "$KEG" >"$TMP/probe.rb"
+
+cat >"$HARNESS" <<ZIG
+const std = @import("std");
+const detect = @import("src/core/ruby/detect.zig");
+const sandbox = @import("src/core/sandbox/macos.zig");
+
+test "the detected Ruby starts inside the fence" {
+    const ruby = detect.detectRuby(std.Options.debug_io, std.testing.allocator) orelse
+        return error.NoRubyDetected;
+    defer std.testing.allocator.free(ruby);
+    std.debug.print("DETECTED {s}\n", .{ruby});
+    const env: sandbox.ScrubbedEnv = .{
+        .home = "$TMP",
+        .path = sandbox.sandbox_path,
+        .malt_prefix = "$PREFIX",
+        .tmpdir = "$TMP",
+    };
+    const code = try sandbox.runRubySandboxed(
+        std.testing.allocator,
+        .empty,
+        ruby,
+        "$TMP/probe.rb",
+        "$KEG",
+        "$PREFIX",
+        env,
+        .{},
+        .{},
+    );
+    if (code != 0) {
+        std.debug.print("fenced {s} exited {d}\n", .{ ruby, code });
+        return error.FencedInterpreterDidNotStart;
+    }
+}
+ZIG
+
+run_harness() {
+  (cd "$ROOT" && zig test -lc "$HARNESS")
+}
+
+if ! run_harness >"$TMP/harness.log" 2>&1; then
+  grep -Ev '\.\.\.OK$' "$TMP/harness.log" | tail -20 >&2
+  echo "FAIL: the detected Ruby does not start inside the fence" >&2
+  exit 1
+fi
+
+RUBY=$(grep -o "DETECTED [^[:space:]]*" "$TMP/harness.log" | head -1 | cut -d" " -f2 || true)
+GOT=""
+[[ -f "$KEG/version" ]] && GOT=$(<"$KEG/version")
+[[ "$GOT" =~ ^[0-9]+\.[0-9]+ ]] || {
+  echo "FAIL: fenced $RUBY ran but recorded no version (got '$GOT')" >&2
+  exit 1
+}
+
+echo "PASS: detected $RUBY and it runs fenced ($GOT)"

--- a/src/core/ruby/detect.zig
+++ b/src/core/ruby/detect.zig
@@ -5,52 +5,35 @@
 //! cross-linking through `ruby_subprocess.zig`.
 
 const std = @import("std");
+const builtin = @import("builtin");
 
-/// Detect a usable Ruby interpreter. Returns a caller-owned absolute path
-/// or null. Caller must free the returned slice with `allocator.free`.
+// Order matters: the package-manager Ruby is preferred, the system one is last.
+const candidates = [_][]const u8{
+    "/opt/homebrew/opt/ruby/bin/ruby",
+    "/usr/local/opt/ruby/bin/ruby",
+    "/usr/bin/ruby",
+};
+
+/// Detect a Ruby interpreter the sandbox fence can start. Returns a
+/// caller-owned absolute path or null. Caller must free the returned slice
+/// with `allocator.free`.
 ///
-/// Previously this function returned static slices for the hardcoded
-/// candidates and `allocator.dupe`d slices for the rbenv/asdf/PATH
-/// branches — the only call site never freed, so the heap branches
-/// leaked. Unifying the contract on "always heap-owned" lets the caller
-/// pair every successful return with one `defer allocator.free(...)`.
+/// Only package-manager and system Rubies are probed: the fence denies
+/// reads under `$HOME` and scrubs `$PATH`, so version-manager shims and
+/// arbitrary PATH interpreters cannot run inside it. Keep `candidates` in
+/// step with the interpreter prefix the fence re-grants.
+///
+/// Previously the hardcoded candidates returned static slices while other
+/// branches `allocator.dupe`d — the only call site never freed, so the heap
+/// branches leaked. Unifying on "always heap-owned" lets the caller pair
+/// every successful return with one `defer allocator.free(...)`.
 ///
 /// Public for testability; not part of the stable surface.
-pub fn detectRuby(io: std.Io, environ: std.process.Environ, allocator: std.mem.Allocator) ?[]const u8 {
-    const candidates = [_][]const u8{
-        "/opt/homebrew/opt/ruby/bin/ruby",
-        "/usr/local/opt/ruby/bin/ruby",
-        "/usr/bin/ruby",
-    };
+pub fn detectRuby(io: std.Io, allocator: std.mem.Allocator) ?[]const u8 {
     for (candidates) |path| {
         std.Io.Dir.accessAbsolute(io, path, .{}) catch continue;
         return allocator.dupe(u8, path) catch return null;
     }
-
-    // Reusable scratch for path joining — avoids per-iteration heap churn.
-    var buf: [std.fs.max_path_bytes]u8 = undefined;
-
-    // User-local version managers: rbenv, asdf
-    if (std.process.Environ.getPosix(environ, "HOME")) |home| {
-        const shim_suffixes = [_][]const u8{ "/.rbenv/shims/ruby", "/.asdf/shims/ruby" };
-        for (shim_suffixes) |suffix| {
-            const path = std.fmt.bufPrint(&buf, "{s}{s}", .{ home, suffix }) catch continue;
-            std.Io.Dir.accessAbsolute(io, path, .{}) catch continue;
-            return allocator.dupe(u8, path) catch return null;
-        }
-    }
-
-    // PATH search
-    if (std.process.Environ.getPosix(environ, "PATH")) |path_env| {
-        var it = std.mem.splitScalar(u8, path_env, ':');
-        while (it.next()) |dir| {
-            if (dir.len == 0) continue;
-            const candidate = std.fmt.bufPrint(&buf, "{s}/ruby", .{dir}) catch continue;
-            std.Io.Dir.accessAbsolute(io, candidate, .{}) catch continue;
-            return allocator.dupe(u8, candidate) catch return null;
-        }
-    }
-
     return null;
 }
 
@@ -170,17 +153,25 @@ test "resolveFormulaRbPath falls back to the flat Formula/{name}.rb layout" {
     try testing.expect(std.mem.endsWith(u8, got.?, "/Formula/wget.rb"));
 }
 
-test "detectRuby returns a heap-owned slice that the caller can free" {
-    // The contract requires the returned slice to be allocator-owned so
-    // the call site can pair it with `defer allocator.free`. We can't
-    // assert the path itself (machine-dependent), but we *can* verify that
-    // freeing the result does not double-free or fault — which only holds
-    // if every branch returns heap memory rather than a mix of static and
-    // heap slices. An empty environ exercises the hardcoded-candidate
-    // branch, which is exactly the one that used to return static slices.
-    if (detectRuby(testIo(), .empty, testing.allocator)) |path| {
-        defer testing.allocator.free(path);
-        try testing.expect(path.len > 0);
-        try testing.expect(std.mem.startsWith(u8, path, "/"));
+test "detectRuby returns a heap-owned path and always finds one on macOS" {
+    // Heap-owned so the call site can pair it with one `defer allocator.free`.
+    // /usr/bin/ruby is part of the macOS base system, so null there means the
+    // probe itself is broken, not the box.
+    const path = detectRuby(testIo(), testing.allocator) orelse {
+        try testing.expect(builtin.os.tag != .macos);
+        return;
+    };
+    defer testing.allocator.free(path);
+    try testing.expect(std.mem.startsWith(u8, path, "/"));
+}
+
+test "detectRuby only offers interpreters the sandbox fence can start" {
+    // The fence only re-grants reads for a `/opt/ruby/bin/ruby` prefix and
+    // never denies the system tree; any other shape is detected only to die
+    // inside the fence. Checked over the whole list, not the runtime pick,
+    // so a bad candidate fails on every box.
+    for (candidates) |path| {
+        try testing.expect(std.mem.endsWith(u8, path, "/opt/ruby/bin/ruby") or
+            std.mem.eql(u8, path, "/usr/bin/ruby"));
     }
 }

--- a/src/core/ruby_subprocess.zig
+++ b/src/core/ruby_subprocess.zig
@@ -41,7 +41,7 @@ pub const RubyError = error{
 /// core/* itself emits no UI.
 pub fn describeError(err: RubyError) []const u8 {
     return switch (err) {
-        RubyError.RubyNotFound => "no Ruby interpreter found (tried /opt/homebrew, /usr/local, rbenv, asdf, PATH)",
+        RubyError.RubyNotFound => "no Ruby interpreter found (tried /opt/homebrew, /usr/local, /usr/bin)",
         RubyError.TapNotFound => "no local homebrew-core tap clone, and the hash-pinned GitHub fallback was not viable for this formula",
         RubyError.FormulaSourceNotFound => "formula .rb source not found in the homebrew-core tap, and the hash-pinned GitHub fallback could not recover it",
         RubyError.PostInstallBodyNotFound => "could not extract a post_install body from the formula source",
@@ -304,7 +304,7 @@ pub fn runPostInstallWithBody(
     // maps each RubyError variant to user-facing text.
 
     // 1. Find Ruby (caller-owned heap slice — see detectRuby contract).
-    const ruby_path = detectRuby(io, environ, allocator) orelse return RubyError.RubyNotFound;
+    const ruby_path = detectRuby(io, allocator) orelse return RubyError.RubyNotFound;
     defer allocator.free(ruby_path);
 
     // 5. Generate wrapper script


### PR DESCRIPTION
## Description

The Ruby fallback detected rbenv/asdf shims and the first `ruby` on `$PATH`, but the sandbox fence denies reads under `$HOME` and scrubs `$PATH`, so none of those interpreters could ever start. Detection now stops at the package-manager and system Rubies the fence can actually run, and the `RubyNotFound` message names what is really tried.

## Related Issue

- None

## Notes for Reviewers

- None