### PR TITLE
fix(doctor): report only what purge --cache will reclaim from the tap cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,9 @@ jobs:
       - name: Regression guard - doctor survives a relative keg path
         run: ./scripts/regressions/doctor-survives-a-relative-keg-path.sh
 
+      - name: Regression guard - doctor tap-cache figure matches purge --cache
+        run: ./scripts/regressions/doctor-tap-cache-figure-matches-purge-cache-doctor-suggests-purge-cache-but-running-it-nothing-to-reclaim.sh
+
       - name: Regression guard - wipe manifest matches mt backup
         run: ./scripts/regressions/wipe-manifest-tap-qualification-wipe-manifest-drops-tap-qualification-for-casks.sh
 

--- a/scripts/regressions/doctor-tap-cache-figure-matches-purge-cache-doctor-suggests-purge-cache-but-running-it-nothing-to-reclaim.sh
+++ b/scripts/regressions/doctor-tap-cache-figure-matches-purge-cache-doctor-suggests-purge-cache-but-running-it-nothing-to-reclaim.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Regression: the tap-cache figure `doctor` attaches to `mt purge --cache`
+# must be what that command actually frees.
+#
+# `purge --cache` only deletes entries older than the default retention
+# window, but doctor used to report the cache's total size and name the
+# sweep as its reclaim - so a fresh cache advertised megabytes that the
+# command then freed 0 B of. Doctor now splits total from reclaimable and
+# drops the hint when nothing is old enough.
+#
+# Drives the built binary end-to-end under a throwaway prefix, offline, and
+# cleans up. Exits 0 when the advertised figure and the sweep agree;
+# non-zero with the mismatching line otherwise.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+# Shell regressions run the built binary, which `zig build test` does not
+# rebuild - build it here so a stale binary never masks the fix.
+zig build >/dev/null
+
+PREFIX="$(mktemp -d)/malt"
+export MALT_PREFIX="$PREFIX"
+trap 'rm -rf "$(dirname "$PREFIX")"' EXIT
+export MALT_OFFLINE=1
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+
+mkdir -p "$PREFIX/cache/Tap"
+fresh="$PREFIX/cache/Tap/$(printf 'ab%.0s' {1..32}).tar.gz"
+stale="$PREFIX/cache/Tap/$(printf 'cd%.0s' {1..32}).tar.gz"
+head -c 1048576 /dev/zero >"$fresh"
+head -c 2097152 /dev/zero >"$stale"
+# Back-dated past the default retention window.
+touch -t "$(date -v-40d +%Y%m%d%H%M)" "$stale"
+
+line=$("$BIN" doctor 2>&1 | grep 'Tap archive cache' || true)
+[[ "$line" == *"3.0 MB"* && "$line" == *"2.0 MB older than 30 days"* && "$line" == *"Run: mt purge --cache"* ]] ||
+  {
+    echo "FAIL: doctor line does not split total vs reclaimable: $line" >&2
+    exit 1
+  }
+
+json=$("$BIN" doctor --json 2>/dev/null || true)
+[[ "$json" == *'"tap_cache":{"bytes":3145728,"reclaimable_bytes":2097152}'* ]] ||
+  {
+    echo "FAIL: doctor --json tap_cache does not expose reclaimable bytes: $json" >&2
+    exit 1
+  }
+
+"$BIN" purge --cache --yes >/dev/null 2>&1 || true
+[[ ! -e "$stale" && -e "$fresh" ]] ||
+  {
+    echo "FAIL: purge --cache did not free exactly the advertised entry" >&2
+    exit 1
+  }
+
+# A fresh-only cache must carry no reclaim hint (the original report).
+line=$("$BIN" doctor 2>&1 | grep 'Tap archive cache' || true)
+[[ "$line" == *"1.0 MB"* && "$line" != *"Run: mt purge --cache"* ]] ||
+  {
+    echo "FAIL: doctor still suggests purge --cache with nothing older than 30 days: $line" >&2
+    exit 1
+  }
+
+echo "PASS: doctor's tap-cache figure matches what purge --cache reclaims"

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -25,6 +25,7 @@ const mirror_mod = @import("../net/mirror.zig");
 const color = @import("../ui/color.zig");
 const output = @import("../ui/output.zig");
 const bytes = @import("../ui/bytes.zig");
+const purge_args = @import("purge/args.zig");
 pub const cask_history = @import("doctor/cask_history.zig");
 const fix_mod = @import("doctor/fix.zig");
 pub const FixKind = fix_mod.FixKind;
@@ -267,20 +268,38 @@ pub fn emitCaskHistoryReport(allocator: std.mem.Allocator, io: std.Io, prefix: [
     output.writeStderrAll(aw.written());
 }
 
-/// Walk `<prefix>/cache/Tap` and emit the warmed tap-archive size as a
-/// human line, silent when the cache is empty so the clean case adds no
-/// noise. The `--json` view is a member of the merged document built in
+/// One human line for the tap-archive cache, silent when empty so the
+/// clean case adds no noise. The reclaim hint appears only when the
+/// sweep it names would actually free something. Pure for byte-pinning.
+pub fn writeTapCacheHuman(w: *std.Io.Writer, usage: tap_cache_mod.Usage, max_age_days: i64) !void {
+    if (usage.total == 0) return;
+    var total_buf: [32]u8 = undefined;
+    const total = bytes.humanize(usage.total, &total_buf);
+    if (usage.reclaimable == 0) {
+        try w.print("  > Tap archive cache: {s} (nothing older than {d} days to reclaim)\n", .{ total, max_age_days });
+        return;
+    }
+    var reclaim_buf: [32]u8 = undefined;
+    const reclaim = bytes.humanize(usage.reclaimable, &reclaim_buf);
+    try w.print("  > Tap archive cache: {s} ({s} older than {d} days). Run: mt purge --cache\n", .{ total, reclaim, max_age_days });
+}
+
+/// Walk `<prefix>/cache/Tap` and emit its usage as a human line. The
+/// `--json` view is a member of the merged document built in
 /// `emitDoctorJson`. Pure read; safe to invoke from `execute` post-checks.
 pub fn emitTapCacheReport(allocator: std.mem.Allocator, io: std.Io, prefix: []const u8) void {
-    const byte_count = tap_cache_mod.bytesUnder(io, allocator, prefix);
-
-    if (byte_count == 0) return;
+    const usage = collectTapCacheUsage(allocator, io, prefix);
     var aw: std.Io.Writer.Allocating = .init(allocator);
     defer aw.deinit();
-    var size_buf: [32]u8 = undefined;
-    const size = bytes.humanize(byte_count, &size_buf);
-    aw.writer.print("  > Tap archive cache: {s}. Run: mt purge --cache\n", .{size}) catch return;
+    writeTapCacheHuman(&aw.writer, usage, purge_args.default_cache_days) catch return;
     output.writeStderrAll(aw.written());
+}
+
+/// Measure the tap cache against the same retention window
+/// `mt purge --cache` applies by default.
+fn collectTapCacheUsage(allocator: std.mem.Allocator, io: std.Io, prefix: []const u8) tap_cache_mod.Usage {
+    const now = std.Io.Clock.real.now(io).toSeconds();
+    return tap_cache_mod.usageUnder(io, allocator, prefix, now, purge_args.default_cache_days);
 }
 
 /// Emit the registered-tap forge/host block doctor shows after the
@@ -366,14 +385,14 @@ pub fn writeDoctorJson(
     w: *std.Io.Writer,
     findings: []const render.Finding,
     census: cask_history.Census,
-    tap_cache_bytes: u64,
+    tap_cache: tap_cache_mod.Usage,
     taps: []const tap_mod.TapInfo,
 ) !void {
     try output.writeSchemaVersionPrefix(w);
     try render.writeChecksField(w, findings);
     try w.writeAll(",");
     try cask_history.writeField(w, census);
-    try w.print(",\"tap_cache\":{{\"bytes\":{d}}}", .{tap_cache_bytes});
+    try w.print(",\"tap_cache\":{{\"bytes\":{d},\"reclaimable_bytes\":{d}}}", .{ tap_cache.total, tap_cache.reclaimable });
     try w.writeAll(",");
     try writeTapForgeField(w, taps);
     try w.writeAll("}\n");
@@ -386,7 +405,7 @@ pub fn writeDoctorJson(
 pub fn emitDoctorJson(allocator: std.mem.Allocator, io: std.Io, prefix: []const u8, findings: []const render.Finding) void {
     var census = cask_history.collectCensus(allocator, io, prefix);
     defer census.deinit(allocator);
-    const tap_cache_bytes = tap_cache_mod.bytesUnder(io, allocator, prefix);
+    const tap_cache = collectTapCacheUsage(allocator, io, prefix);
     // Free the collected slice even when empty-but-allocated; only the
     // collection-failed (`null`) case substitutes a static empty slice.
     const taps_opt = collectTaps(allocator, prefix);
@@ -395,7 +414,7 @@ pub fn emitDoctorJson(allocator: std.mem.Allocator, io: std.Io, prefix: []const 
 
     var aw: std.Io.Writer.Allocating = .init(allocator);
     defer aw.deinit();
-    writeDoctorJson(&aw.writer, findings, census, tap_cache_bytes, taps) catch return;
+    writeDoctorJson(&aw.writer, findings, census, tap_cache, taps) catch return;
     output.writeStdoutAll(aw.written());
 }
 
@@ -1877,9 +1896,50 @@ test "emitTapCacheReport: human one-liner when cache holds bytes" {
     defer output.endStderrCapture();
     emitTapCacheReport(allocator, std.Options.debug_io, prefix);
 
+    // The entry was just written, so the sweep would free nothing: the
+    // line must say so instead of naming a command that reclaims 0 B.
     try testing.expectEqualStrings(
-        "  > Tap archive cache: 256.0 B. Run: mt purge --cache\n",
+        "  > Tap archive cache: 256.0 B (nothing older than 30 days to reclaim)\n",
         buf.items,
+    );
+}
+
+test "writeTapCacheHuman: silent when the cache is empty" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try writeTapCacheHuman(&aw.writer, .{}, 30);
+    try testing.expectEqualStrings("", aw.written());
+}
+
+test "writeTapCacheHuman: no reclaim hint when nothing is older than the window" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try writeTapCacheHuman(&aw.writer, .{ .total = 129 * 1024 * 1024 + 100 * 1024, .reclaimable = 0 }, 30);
+    try testing.expectEqualStrings(
+        "  > Tap archive cache: 129.1 MB (nothing older than 30 days to reclaim)\n",
+        aw.written(),
+    );
+}
+
+test "writeTapCacheHuman: names the sweep with only the bytes it will free" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try writeTapCacheHuman(&aw.writer, .{ .total = 129 * 1024 * 1024 + 100 * 1024, .reclaimable = 45 * 1024 * 1024 + 200 * 1024 }, 30);
+    try testing.expectEqualStrings(
+        "  > Tap archive cache: 129.1 MB (45.2 MB older than 30 days). Run: mt purge --cache\n",
+        aw.written(),
+    );
+}
+
+test "writeTapCacheHuman: the window in the line follows the parameter" {
+    // The hint must quote the same retention the sweep uses, not a
+    // literal that drifts when the default changes.
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try writeTapCacheHuman(&aw.writer, .{ .total = 2048, .reclaimable = 1024 }, 7);
+    try testing.expectEqualStrings(
+        "  > Tap archive cache: 2.0 KB (1.0 KB older than 7 days). Run: mt purge --cache\n",
+        aw.written(),
     );
 }
 
@@ -2221,13 +2281,13 @@ test "writeDoctorJson merges all four members under one versioned root" {
 
     var aw: std.Io.Writer.Allocating = .init(testing.allocator);
     defer aw.deinit();
-    try writeDoctorJson(&aw.writer, &findings, census, 7, &taps);
+    try writeDoctorJson(&aw.writer, &findings, census, .{ .total = 7, .reclaimable = 3 }, &taps);
 
     try testing.expectEqualStrings(
         "{\"schema_version\":1," ++
             "\"checks\":[{\"id\":\"stale_lock\",\"severity\":\"warn\",\"title\":\"Stale lock\",\"detail\":\"d\",\"fixable\":true,\"fix_class\":\"stale_lock\"}]," ++
             "\"cask_history\":{\"retained_versions\":0,\"bytes\":42}," ++
-            "\"tap_cache\":{\"bytes\":7}," ++
+            "\"tap_cache\":{\"bytes\":7,\"reclaimable_bytes\":3}," ++
             "\"taps\":[{\"name\":\"u/r\",\"host\":\"gitlab.com\"}]}\n",
         aw.written(),
     );
@@ -2240,7 +2300,7 @@ test "writeDoctorJson stays one valid JSON object with schema_version on the emp
 
     var aw: std.Io.Writer.Allocating = .init(testing.allocator);
     defer aw.deinit();
-    try writeDoctorJson(&aw.writer, &.{}, census, 0, &.{});
+    try writeDoctorJson(&aw.writer, &.{}, census, .{}, &.{});
 
     const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, aw.written(), .{});
     defer parsed.deinit();
@@ -2248,6 +2308,7 @@ test "writeDoctorJson stays one valid JSON object with schema_version on the emp
     try testing.expectEqual(@as(usize, 0), parsed.value.object.get("checks").?.array.items.len);
     try testing.expectEqual(@as(usize, 0), parsed.value.object.get("taps").?.array.items.len);
     try testing.expectEqual(@as(i64, 0), parsed.value.object.get("tap_cache").?.object.get("bytes").?.integer);
+    try testing.expectEqual(@as(i64, 0), parsed.value.object.get("tap_cache").?.object.get("reclaimable_bytes").?.integer);
 }
 
 fn infoCheckForTest(ctx: CheckCtx, name: []const u8) CheckResult {

--- a/src/cli/purge/scopes.zig
+++ b/src/cli/purge/scopes.zig
@@ -16,6 +16,7 @@ const cellar_mod = @import("../../core/cellar.zig");
 const formula_mod = @import("../../core/formula.zig");
 const cask_mod = @import("../../core/cask.zig");
 const relocated_store = @import("../../core/relocated_store.zig");
+const tap_cache = @import("../../core/tap_cache.zig");
 const symlink = @import("../../fs/symlink.zig");
 const store_path = @import("../../fs/store_path.zig");
 const util = @import("util.zig");
@@ -285,7 +286,6 @@ fn pruneCacheRecursive(io: std.Io, cache_dir: []const u8, max_age_days: i64, dry
     defer dir.close(io);
 
     const now = std.Io.Clock.real.now(io).toSeconds();
-    const max_age_secs = max_age_days * 86400;
 
     var iter = dir.iterate();
     while (iter.next(io) catch null) |entry| {
@@ -297,7 +297,7 @@ fn pruneCacheRecursive(io: std.Io, cache_dir: []const u8, max_age_days: i64, dry
         }
         const stat = dir.statFile(io, entry.name, .{}) catch continue;
         const mtime_secs: i64 = @intCast(@divTrunc(stat.mtime.nanoseconds, std.time.ns_per_s));
-        if (now - mtime_secs > max_age_secs) {
+        if (tap_cache.olderThan(now, mtime_secs, max_age_days)) {
             if (!dry_run) dir.deleteFile(io, entry.name) catch continue;
             // Full path so users (and the smoke tests) can see WHERE the
             // file lived; the leaf alone hides path-of-cleanup hot spots.

--- a/src/core/tap_cache.zig
+++ b/src/core/tap_cache.zig
@@ -60,22 +60,39 @@ pub fn promoteStagingToCache(
     return cache_path;
 }
 
-/// Recursive byte sum under `<prefix>/cache/Tap`. Best-effort: any
-/// I/O failure contributes zero so doctor's read stays infallible.
-pub fn bytesUnder(io: std.Io, allocator: std.mem.Allocator, prefix: []const u8) u64 {
+/// Byte totals under `<prefix>/cache/Tap`: everything on disk, and the
+/// subset `mt purge --cache` would free at the given retention window.
+pub const Usage = struct { total: u64 = 0, reclaimable: u64 = 0 };
+
+/// The `mt purge --cache` age gate, applied to every entry under
+/// `<prefix>/cache` (not just tap archives). Strictly older: an entry
+/// exactly `max_age_days` old is kept. Shared with the sweep so doctor's
+/// figure can never drift from what the sweep deletes. Saturating:
+/// `--cache=N` is unbounded and an absurd window means "keep
+/// everything", not an overflow abort.
+pub fn olderThan(now_secs: i64, mtime_secs: i64, max_age_days: i64) bool {
+    return now_secs - mtime_secs > max_age_days *| 86400;
+}
+
+/// Recursive walk of `<prefix>/cache/Tap`. Best-effort: any I/O failure
+/// contributes zero so doctor's read stays infallible. `now_secs` is a
+/// parameter so tests can move the clock instead of back-dating files.
+pub fn usageUnder(io: std.Io, allocator: std.mem.Allocator, prefix: []const u8, now_secs: i64, max_age_days: i64) Usage {
     var buf: [512]u8 = undefined;
-    const dir_path = std.fmt.bufPrint(&buf, "{s}/cache/Tap", .{prefix}) catch return 0;
-    var dir = std.Io.Dir.openDirAbsolute(io, dir_path, .{ .iterate = true }) catch return 0;
+    const dir_path = std.fmt.bufPrint(&buf, "{s}/cache/Tap", .{prefix}) catch return .{};
+    var dir = std.Io.Dir.openDirAbsolute(io, dir_path, .{ .iterate = true }) catch return .{};
     defer dir.close(io);
-    var walker = dir.walk(allocator) catch return 0;
+    var walker = dir.walk(allocator) catch return .{};
     defer walker.deinit();
-    var total: u64 = 0;
+    var usage: Usage = .{};
     while (walker.next(io) catch null) |entry| {
         if (entry.kind != .file) continue;
         const stat = std.Io.Dir.statFile(entry.dir, io, entry.basename, .{}) catch continue;
-        total += stat.size;
+        usage.total += stat.size;
+        const mtime_secs: i64 = @intCast(@divTrunc(stat.mtime.nanoseconds, std.time.ns_per_s));
+        if (olderThan(now_secs, mtime_secs, max_age_days)) usage.reclaimable += stat.size;
     }
-    return total;
+    return usage;
 }
 
 // ─── inline test scratch ──────────────────────────────────────────────
@@ -215,36 +232,89 @@ test "promoteStagingToCache: renames staging file to SHA-keyed slot" {
     try std.Io.Dir.accessAbsolute(io, cache_path, .{});
 }
 
-test "bytesUnder: returns 0 when cache dir is absent" {
-    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
-    defer threaded.deinit();
-    const io = threaded.io();
-    var s = try Scratch.init("tap_cache_bytes_absent");
-    defer s.deinit();
-    // Deliberately do not create <prefix>/cache/Tap.
-    try std.testing.expectEqual(@as(u64, 0), bytesUnder(io, std.testing.allocator, s.base));
+test "olderThan: strictly older than the window, so the boundary is kept" {
+    // Exactly `max_age_days` old is NOT older - the sweep keeps it, so
+    // the doctor figure must not count it either.
+    const day: i64 = 86400;
+    try std.testing.expect(!olderThan(30 * day, 0, 30));
+    try std.testing.expect(olderThan(30 * day + 1, 0, 30));
+    try std.testing.expect(!olderThan(10 * day, 0, 30));
+    // A zero-day window reclaims anything strictly in the past.
+    try std.testing.expect(olderThan(1, 0, 0));
+    try std.testing.expect(!olderThan(0, 0, 0));
 }
 
-test "bytesUnder: sums regular file sizes under cache/Tap" {
+test "olderThan: an absurdly wide window keeps everything instead of overflowing" {
+    // `--cache=N` is an unbounded i64; N * 86400 past i64 must read as
+    // "nothing is that old", not abort the sweep.
+    try std.testing.expect(!olderThan(std.math.maxInt(i64), 0, std.math.maxInt(i64)));
+    try std.testing.expect(!olderThan(1, 0, std.math.maxInt(i64) / 86400 + 1));
+}
+
+test "usageUnder: zero usage when cache dir is absent" {
     var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
     defer threaded.deinit();
     const io = threaded.io();
-    var s = try Scratch.init("tap_cache_bytes_sum");
+    var s = try Scratch.init("tap_cache_usage_absent");
     defer s.deinit();
-    const prefix = s.base;
+    // Deliberately do not create <prefix>/cache/Tap.
+    const u = usageUnder(io, std.testing.allocator, s.base, 0, 30);
+    try std.testing.expectEqual(@as(u64, 0), u.total);
+    try std.testing.expectEqual(@as(u64, 0), u.reclaimable);
+}
+
+fn seedEntry(io: std.Io, s: *Scratch, comptime sha: []const u8, comptime size: usize) !void {
+    var entry_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const entry = try cachePath(&entry_buf, s.base, sha, ".tar.gz");
+    const f = try std.Io.Dir.createFileAbsolute(io, entry, .{});
+    defer f.close(io);
+    try f.writeStreamingAll(io, "x" ** size);
+}
+
+test "usageUnder: a fresh entry counts toward total but not reclaimable" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+    var s = try Scratch.init("tap_cache_usage_fresh");
+    defer s.deinit();
 
     // Production callers reach `ensureCacheDir` only after the
     // top-level `ensureDirs` has seeded `<prefix>/cache`; mirror
     // that here so the test pins the production invariant.
     try std.Io.Dir.cwd().createDirPath(io, s.p("/cache"));
+    try ensureCacheDir(io, s.base);
+    try seedEntry(io, &s, "00" ** 32, 256);
 
-    try ensureCacheDir(io, prefix);
+    const now = std.Io.Clock.real.now(io).toSeconds();
+    const u = usageUnder(io, std.testing.allocator, s.base, now, 30);
+    try std.testing.expectEqual(@as(u64, 256), u.total);
+    try std.testing.expectEqual(@as(u64, 0), u.reclaimable);
+}
 
-    var entry_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const entry = try cachePath(&entry_buf, prefix, "00" ** 32, ".tar.gz");
-    const f = try std.Io.Dir.createFileAbsolute(io, entry, .{});
-    defer f.close(io);
-    try f.writeStreamingAll(io, "x" ** 256);
+test "usageUnder: total is stable while reclaimable swings with the window" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+    var s = try Scratch.init("tap_cache_usage_mixed");
+    defer s.deinit();
 
-    try std.testing.expectEqual(@as(u64, 256), bytesUnder(io, std.testing.allocator, prefix));
+    try std.Io.Dir.cwd().createDirPath(io, s.p("/cache"));
+    try ensureCacheDir(io, s.base);
+    try seedEntry(io, &s, "00" ** 32, 100);
+    try seedEntry(io, &s, "11" ** 32, 300);
+
+    // Both entries were just written. Move the clock instead of
+    // back-dating files: the default window reclaims nothing now and
+    // everything 40 days on; a zero-day window reclaims everything one
+    // second on. Total never moves.
+    const now = std.Io.Clock.real.now(io).toSeconds();
+    const none = usageUnder(io, std.testing.allocator, s.base, now, 30);
+    try std.testing.expectEqual(@as(u64, 400), none.total);
+    try std.testing.expectEqual(@as(u64, 0), none.reclaimable);
+    const aged = usageUnder(io, std.testing.allocator, s.base, now + 40 * 86400, 30);
+    try std.testing.expectEqual(@as(u64, 400), aged.total);
+    try std.testing.expectEqual(@as(u64, 400), aged.reclaimable);
+    const all = usageUnder(io, std.testing.allocator, s.base, now + 1, 0);
+    try std.testing.expectEqual(@as(u64, 400), all.total);
+    try std.testing.expectEqual(@as(u64, 400), all.reclaimable);
 }

--- a/src/tui/doctor_tab.zig
+++ b/src/tui/doctor_tab.zig
@@ -1512,7 +1512,7 @@ test "a loaded doctor read repoints findings + reclaimable stats; a cleared read
     defer storage.deinit(allocator);
     const json =
         \\{"checks":[{"id":"a","severity":"warn","title":"A","fixable":true,"fix_class":"stale_lock"}],
-        \\"cask_history":{"retained_versions":3,"bytes":4096},"tap_cache":{"bytes":512}}
+        \\"cask_history":{"retained_versions":3,"bytes":4096},"tap_cache":{"bytes":1024,"reclaimable_bytes":512}}
     ;
     const parsed = try doctor_json.parse(allocator, json);
     _ = update(allocator, "/bin/mt", &st, &storage, &shared, .{ .loaded = .{ .doctor = parsed } });
@@ -1571,7 +1571,7 @@ test "update on a loaded document swaps in findings + stats and returns none" {
     var shared: ctx.SharedModel = .{};
     const parsed = try doctor_json.parse(testing.allocator,
         \\{"checks":[{"id":"a","severity":"warn","title":"A","fixable":true,"fix_class":"stale_lock"}],
-        \\"cask_history":{"retained_versions":3,"bytes":4096},"tap_cache":{"bytes":512}}
+        \\"cask_history":{"retained_versions":3,"bytes":4096},"tap_cache":{"bytes":1024,"reclaimable_bytes":512}}
     );
     const next = update(testing.allocator, "/bin/mt", &st, &storage, &shared, .{ .loaded = .{ .doctor = parsed } });
     try testing.expect(next == .none);

--- a/src/tui/json/doctor.zig
+++ b/src/tui/json/doctor.zig
@@ -2,7 +2,7 @@
 //!
 //! Leaf module: imports only `std`. The versioned `checks` array drives the
 //! findings list; `cask_history`, `tap_cache`, and `taps` are read for their
-//! disk/tap totals (flat `Stats`). `schema_version` and any future field are
+//! reclaimable/tap figures (flat `Stats`). `schema_version` and any future field are
 //! ignored, and the consumed keys are defaulted, so a schema addition or an
 //! older payload never breaks parsing. `Finding` is TUI-local — never the core
 //! `render.Finding` — so the `--json` shape is the only coupling. Unlike the
@@ -40,10 +40,12 @@ pub const Finding = struct {
     fix_class: FixClass = .none,
 };
 
-/// Flat, copy-by-value disk/tap totals lifted off the wire. Plain scalars, so
-/// they outlive the parsed document's arena without borrowing it.
+/// Flat, copy-by-value figures lifted off the wire. Plain scalars, so they
+/// outlive the parsed document's arena without borrowing it.
 pub const Stats = struct {
     cask_bytes: u64 = 0,
+    /// The share `mt purge --cache` would free, not the cache total - the
+    /// tab renders it under "Reclaimable".
     tap_cache_bytes: u64 = 0,
     retained_versions: usize = 0,
     taps: usize = 0,
@@ -69,7 +71,7 @@ const Doc = struct {
     taps: []Tap = &.{},
 
     const CaskHistory = struct { retained_versions: usize = 0, bytes: u64 = 0 };
-    const TapCache = struct { bytes: u64 = 0 };
+    const TapCache = struct { bytes: u64 = 0, reclaimable_bytes: u64 = 0 };
     const Tap = struct {}; // only its count is used
 };
 
@@ -91,7 +93,7 @@ pub fn parse(allocator: std.mem.Allocator, bytes: []const u8) Error!Parsed {
         .items = doc.value.checks,
         .stats = .{
             .cask_bytes = doc.value.cask_history.bytes,
-            .tap_cache_bytes = doc.value.tap_cache.bytes,
+            .tap_cache_bytes = doc.value.tap_cache.reclaimable_bytes,
             .retained_versions = doc.value.cask_history.retained_versions,
             .taps = doc.value.taps.len,
         },
@@ -117,13 +119,15 @@ test "parse populates stats from cask_history, tap_cache, and the taps count" {
     const bytes =
         \\{"checks":[{"id":"a","severity":"ok","title":"A"}],
         \\"cask_history":{"retained_versions":3,"bytes":4096},
-        \\"tap_cache":{"bytes":512},
+        \\"tap_cache":{"bytes":512,"reclaimable_bytes":128},
         \\"taps":[{"name":"x/y"},{"name":"z/w"}]}
     ;
     var p = try parse(testing.allocator, bytes);
     defer p.deinit();
     try testing.expectEqual(@as(u64, 4096), p.stats.cask_bytes);
-    try testing.expectEqual(@as(u64, 512), p.stats.tap_cache_bytes);
+    // The tab renders this under "Reclaimable", so it must be the
+    // sweepable figure, not the cache total.
+    try testing.expectEqual(@as(u64, 128), p.stats.tap_cache_bytes);
     try testing.expectEqual(@as(usize, 3), p.stats.retained_versions);
     try testing.expectEqual(@as(usize, 2), p.stats.taps);
 }
@@ -269,11 +273,22 @@ test "parse propagates a parse-time OOM instead of relabeling it BadJson" {
     try testing.expectError(error.OutOfMemory, parse(fa.allocator(), bytes));
 }
 
+test "parse treats a tap_cache without reclaimable_bytes as nothing to reclaim" {
+    // An older `mt` reports only the total; advertising it as reclaimable
+    // is the bug this field exists to fix, so default to zero.
+    const bytes =
+        \\{"checks":[],"tap_cache":{"bytes":512}}
+    ;
+    var p = try parse(testing.allocator, bytes);
+    defer p.deinit();
+    try testing.expectEqual(@as(u64, 0), p.stats.tap_cache_bytes);
+}
+
 test "stats survive overwriting the source buffer — plain scalars, no borrow" {
     // T-004 keeps `stats` after the shell frees the captured buffer; the scalars
     // must be copied, never sliced into the input.
     const src =
-        \\{"checks":[{"id":"a","severity":"ok","title":"A"}],"cask_history":{"retained_versions":7,"bytes":2048},"tap_cache":{"bytes":64},"taps":[{"name":"x/y"}]}
+        \\{"checks":[{"id":"a","severity":"ok","title":"A"}],"cask_history":{"retained_versions":7,"bytes":2048},"tap_cache":{"bytes":96,"reclaimable_bytes":64},"taps":[{"name":"x/y"}]}
     ;
     const buf = try testing.allocator.dupe(u8, src);
     defer testing.allocator.free(buf);


### PR DESCRIPTION
## Description

`mt doctor` reported the tap cache's total size and told the user to run `mt purge --cache` to reclaim it, but that sweep only deletes entries older than the default retention window - so a fresh cache advertised megabytes the command then freed nothing of. Doctor now splits total from reclaimable, drops the hint when nothing is old enough, and `--json` gains an additive `tap_cache.reclaimable_bytes` member so the TUI's "Reclaimable" band shows the sweepable figure.

## Related Issue

- None

## Notes for Reviewers

- `tap_cache.bytes` keeps its meaning (total); the new member is additive, so scripted consumers keep working.