### PR TITLE
fix(cellar): refuse a cached keg restored under a name or version it was not installed as

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,9 @@ jobs:
       - name: Regression guard - store entry without the requested keg is refused
         run: ./scripts/regressions/materialize-refuses-store-entry-root-keg-source-falls-back-to-store-entry-root.sh
 
+      - name: Regression guard - relocated cache warm hit checks the keg label
+        run: ./scripts/regressions/relocated-cache-warm-hit-checks-label-relocated-cache-warm-hit-ignores-the-requested-name-and-version.sh
+
       - name: Build universal binary
         run: just build-universal
 

--- a/scripts/regressions/relocated-cache-warm-hit-checks-label-relocated-cache-warm-hit-ignores-the-requested-name-and-version.sh
+++ b/scripts/regressions/relocated-cache-warm-hit-checks-label-relocated-cache-warm-hit-ignores-the-requested-name-and-version.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Regression: a relocated-cache snapshot must only be restored under the
+# name/version it was taken as.
+#
+# The bug: `store-relocated/v<N>/<sha>` was keyed by bottle sha alone and
+# carried no record of the label it was snapshotted under. The warm path in
+# `materializeWithCellar` probed the cache before it ever resolved
+# `store/<sha>/<name>/<version>`, so a tap that served one bottle sha under
+# two labels got a correctly relocated, `.verified`-trusted keg of package A
+# cloned into `Cellar/<B>/<ver>`, receipted and DB-recorded as package B -
+# exactly the case the cold path refuses with `KegSourceMissing`.
+#
+# Two arms, both offline:
+#   1. the label sidecar, its error and the eviction on mismatch stay in the
+#      tree;
+#   2. the cellar integration suite, which pins that a warm hit for a label
+#      the snapshot was not taken under is refused and evicted.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+# --- Arm 1: the label check cannot be silently removed -----------------------
+if ! grep -Fq "LabelMismatch" src/core/relocated_store.zig; then
+  echo "FAIL: RelocatedStoreError.LabelMismatch is gone" >&2
+  exit 1
+fi
+if ! grep -Fq '.keg"' src/core/relocated_store.zig; then
+  echo "FAIL: relocated_store no longer writes the <sha>.keg label mark" >&2
+  exit 1
+fi
+if ! grep -Fq "LabelMismatch" src/core/cellar.zig; then
+  echo "FAIL: the warm path no longer evicts on LabelMismatch" >&2
+  exit 1
+fi
+
+# --- Arm 2: the refusal holds at runtime -------------------------------------
+BIN="$ROOT/zig-out/test-bin/cellar_test"
+if ! zig build test-bin >/dev/null 2>&1; then
+  echo "FAIL: could not build the test binaries (zig build test-bin)" >&2
+  exit 1
+fi
+SCRATCH=$(mktemp -d "${TMPDIR:-/tmp}/malt-reg-warmlabel.XXXXXX")
+trap 'rm -rf "$SCRATCH"' EXIT
+if ! MALT_PREFIX="$SCRATCH" "$BIN" >"$SCRATCH/log" 2>&1; then
+  echo "FAIL: a relocated snapshot was restored under a name/version it was not taken as" >&2
+  tail -n 30 "$SCRATCH/log" >&2
+  exit 1
+fi
+
+echo "OK: warm hit refuses a label the snapshot was not taken under"

--- a/scripts/regressions/relocated-store-logic-version.pin
+++ b/scripts/regressions/relocated-store-logic-version.pin
@@ -1,2 +1,2 @@
-version=8
-digest=8a2d9b2b05a8cf29692f07842d08d46516f4ff89a9e598c150a35cd3252db6b8
+version=9
+digest=ffea59cf96e333a05e1b5b58cea95c21fde81d288cf7c2a40b71a1d0b21b893a

--- a/src/core/cellar.zig
+++ b/src/core/cellar.zig
@@ -150,10 +150,15 @@ pub fn materializeWithCellar(
     // bottle sha is already on disk, fully relocated. Clonefile-restore
     // it and skip the expensive extract → patch → codesign pipeline.
     // Falls through on any cache miss/error so a flaky cache never breaks
-    // the install.
+    // the install. The label is checked from the snapshot's own sidecar,
+    // not the store entry: a warm hit must work with no `store/<sha>/` on
+    // disk at all.
     if (relocated_store.has(io, prefix, store_sha256)) cache_hit: {
         relocated_store.materialize(io, allocator, prefix, store_sha256, name, version) catch |e| {
             std.log.debug("relocated cache miss for {s}: {s}", .{ store_sha256, @errorName(e) });
+            // Evict rather than skip: `save` is idempotent on the sha, so a
+            // stale label would otherwise win forever.
+            if (e == error.LabelMismatch) relocated_store.remove(io, prefix, store_sha256) catch {};
             break :cache_hit;
         };
         // A snapshot taken by an older, buggier relocation outlives the fix

--- a/src/core/relocated_store.zig
+++ b/src/core/relocated_store.zig
@@ -18,7 +18,7 @@ const clonefile = @import("../fs/clonefile.zig");
 const dirsize = @import("../fs/dirsize.zig");
 const store_path = @import("../fs/store_path.zig");
 
-pub const RelocatedStoreError = store_path.Error || error{ SaveFailed, MaterializeFailed };
+pub const RelocatedStoreError = store_path.Error || error{ SaveFailed, MaterializeFailed, LabelMismatch };
 
 /// Relocation-logic version, folded into the cache path as
 /// `store-relocated/v<N>/<sha>`. The cached bytes are the output of
@@ -55,7 +55,10 @@ pub const RelocatedStoreError = store_path.Error || error{ SaveFailed, Materiali
 /// v8: a store entry without the requested keg is refused instead of cloned
 /// whole. A v7 entry snapshotted from one is the entry root itself, with the
 /// real keg nested below and nothing linkable at the top.
-pub const RELOC_LOGIC_VERSION: u32 = 8;
+///
+/// v9: a snapshot records the name/version it was taken under; a v8 entry
+/// carries no label and is restored under any label that presents its sha.
+pub const RELOC_LOGIC_VERSION: u32 = 9;
 
 /// Borrow the store constructor's key rule rather than keep a second copy.
 /// Its path is shorter than ours for the same prefix, so any `buf` that fits
@@ -110,7 +113,7 @@ pub fn save(
     // the loser would otherwise fail at `renameAbsolute` below.
     std.Io.Dir.accessAbsolute(io, dst, .{}) catch {
         // Not present yet — proceed with snapshot.
-        try saveFresh(io, allocator, prefix, name, version, dst);
+        try saveFresh(io, allocator, prefix, sha, name, version, dst);
         // A fresh save under the current version is the natural point to
         // reclaim kegs orphaned by a past logic-version bump. Best-effort.
         _ = reapStaleVersions(io, allocator, prefix, true);
@@ -123,6 +126,7 @@ fn saveFresh(
     io: std.Io,
     allocator: std.mem.Allocator,
     prefix: []const u8,
+    sha: []const u8,
     name: []const u8,
     version: []const u8,
     dst: []const u8,
@@ -168,6 +172,10 @@ fn saveFresh(
     std.Io.Dir.accessAbsolute(io, dst, .{}) catch {
         std.Io.Dir.renameAbsolute(tmp, dst, io) catch return RelocatedStoreError.SaveFailed;
         tmp_consumed = true;
+        // After the rename so the label never outlives a failed snapshot;
+        // best-effort because a lost label costs one eviction, never a
+        // wrong keg.
+        writeLabel(io, prefix, sha, name, version);
     };
 }
 
@@ -183,6 +191,9 @@ pub fn materialize(
 ) RelocatedStoreError!void {
     var src_buf: [512]u8 = undefined;
     const src = try cacheDir(&src_buf, prefix, RELOC_LOGIC_VERSION, sha);
+    // The sha names the bytes, the label names the keg they may be
+    // installed as. Check it before anything touches the Cellar.
+    if (!labelMatches(io, prefix, sha, name, version)) return RelocatedStoreError.LabelMismatch;
     std.Io.Dir.accessAbsolute(io, src, .{}) catch return RelocatedStoreError.MaterializeFailed;
 
     var parent_buf: [512]u8 = undefined;
@@ -212,6 +223,9 @@ pub fn remove(io: std.Io, prefix: []const u8, sha: []const u8) RelocatedStoreErr
     if (verifiedMark(&mark_buf, prefix, sha)) |mark| {
         std.Io.Dir.cwd().deleteFile(io, mark) catch {};
     } else |_| {}
+    if (labelMark(&mark_buf, prefix, sha)) |mark| {
+        std.Io.Dir.cwd().deleteFile(io, mark) catch {};
+    } else |_| {}
 
     std.Io.Dir.cwd().deleteTree(io, dir) catch return;
 }
@@ -222,6 +236,38 @@ fn verifiedMark(buf: []u8, prefix: []const u8, sha: []const u8) RelocatedStoreEr
     try checkSha(buf, prefix, sha);
     return std.fmt.bufPrint(buf, "{s}/store-relocated/v{d}/{s}.verified", .{ prefix, RELOC_LOGIC_VERSION, sha }) catch
         return RelocatedStoreError.PathTooLong;
+}
+
+/// `<sha>.keg`, the `name/version` a snapshot was taken under. A sibling of
+/// the snapshot dir for the same reason as the verified mark.
+fn labelMark(buf: []u8, prefix: []const u8, sha: []const u8) RelocatedStoreError![]u8 {
+    try checkSha(buf, prefix, sha);
+    return std.fmt.bufPrint(buf, "{s}/store-relocated/v{d}/{s}.keg", .{ prefix, RELOC_LOGIC_VERSION, sha }) catch
+        return RelocatedStoreError.PathTooLong;
+}
+
+fn writeLabel(io: std.Io, prefix: []const u8, sha: []const u8, name: []const u8, version: []const u8) void {
+    var buf: [512]u8 = undefined;
+    const mark = labelMark(&buf, prefix, sha) catch return;
+    var body_buf: [512]u8 = undefined;
+    const body = std.fmt.bufPrint(&body_buf, "{s}/{s}\n", .{ name, version }) catch return;
+    const f = std.Io.Dir.createFileAbsolute(io, mark, .{}) catch return;
+    defer f.close(io);
+    f.writeStreamingAll(io, body) catch {};
+}
+
+/// False on a missing or unreadable mark: an unlabelled snapshot is nobody's.
+fn labelMatches(io: std.Io, prefix: []const u8, sha: []const u8, name: []const u8, version: []const u8) bool {
+    var buf: [512]u8 = undefined;
+    const mark = labelMark(&buf, prefix, sha) catch return false;
+    var want_buf: [512]u8 = undefined;
+    const want = std.fmt.bufPrint(&want_buf, "{s}/{s}\n", .{ name, version }) catch return false;
+    const f = std.Io.Dir.openFileAbsolute(io, mark, .{}) catch return false;
+    defer f.close(io);
+    // One byte past `want` so a longer label cannot pass as a prefix match.
+    var got_buf: [513]u8 = undefined;
+    const n = f.readPositionalAll(io, &got_buf, 0) catch return false;
+    return std.mem.eql(u8, got_buf[0..n], want);
 }
 
 /// True when this snapshot was checked after the malt that wrote it relocated
@@ -601,7 +647,7 @@ test "saveFresh cleans the tempdir on the race-loss branch" {
     const dst = try cacheDir(&dst_buf, prefix, RELOC_LOGIC_VERSION, valid_sha_for_tests);
     try std.Io.Dir.cwd().createDirPath(testIo(), dst);
 
-    try saveFresh(testIo(), testing.allocator, prefix, "rl", "1.0", dst);
+    try saveFresh(testIo(), testing.allocator, prefix, valid_sha_for_tests, "rl", "1.0", dst);
 
     // Race winner kept dst; the loser's tempdir must not survive. The temp is
     // a sibling of dst, so scan dst's parent (the versioned segment dir).
@@ -801,6 +847,98 @@ test "markVerified round-trips and only answers for the marked sha" {
     try testing.expect(!isVerified(testIo(), prefix, other));
     try testing.expect(!isVerified(testIo(), prefix, valid_sha_for_tests[0..63]));
     try testing.expect(!isVerified(testIo(), prefix, "../../etc/passwd"));
+}
+
+test "materialize restores a snapshot under the label it was saved as" {
+    const prefix = try tmpPrefixForTests(testing.allocator, "label_ok");
+    defer {
+        std.Io.Dir.cwd().deleteTree(testIo(), prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+    try buildKegForTests(testing.allocator, prefix, "labelled", "1.0");
+    try save(testIo(), testing.allocator, prefix, valid_sha_for_tests, "labelled", "1.0");
+    try materialize(testIo(), testing.allocator, prefix, valid_sha_for_tests, "labelled", "1.0");
+}
+
+test "materialize refuses a different name for the same sha" {
+    const prefix = try tmpPrefixForTests(testing.allocator, "label_name");
+    defer {
+        std.Io.Dir.cwd().deleteTree(testIo(), prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+    try buildKegForTests(testing.allocator, prefix, "labelled", "1.0");
+    try save(testIo(), testing.allocator, prefix, valid_sha_for_tests, "labelled", "1.0");
+    try testing.expectError(
+        RelocatedStoreError.LabelMismatch,
+        materialize(testIo(), testing.allocator, prefix, valid_sha_for_tests, "other", "1.0"),
+    );
+    // A refused label never touches the Cellar.
+    const dst = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/other", .{prefix});
+    defer testing.allocator.free(dst);
+    try testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(testIo(), dst, .{}));
+}
+
+test "materialize refuses a different version for the same sha" {
+    const prefix = try tmpPrefixForTests(testing.allocator, "label_version");
+    defer {
+        std.Io.Dir.cwd().deleteTree(testIo(), prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+    try buildKegForTests(testing.allocator, prefix, "labelled", "1.0");
+    try save(testIo(), testing.allocator, prefix, valid_sha_for_tests, "labelled", "1.0");
+    try testing.expectError(
+        RelocatedStoreError.LabelMismatch,
+        materialize(testIo(), testing.allocator, prefix, valid_sha_for_tests, "labelled", "1.0_1"),
+    );
+}
+
+test "materialize refuses a request that is only a prefix of the stored label" {
+    const prefix = try tmpPrefixForTests(testing.allocator, "label_prefix");
+    defer {
+        std.Io.Dir.cwd().deleteTree(testIo(), prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+    try buildKegForTests(testing.allocator, prefix, "labelled", "1.0_1");
+    try save(testIo(), testing.allocator, prefix, valid_sha_for_tests, "labelled", "1.0_1");
+    try testing.expectError(
+        RelocatedStoreError.LabelMismatch,
+        materialize(testIo(), testing.allocator, prefix, valid_sha_for_tests, "labelled", "1.0"),
+    );
+}
+
+test "materialize treats a snapshot without a label mark as a mismatch" {
+    const prefix = try tmpPrefixForTests(testing.allocator, "label_missing");
+    defer {
+        std.Io.Dir.cwd().deleteTree(testIo(), prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+    try buildKegForTests(testing.allocator, prefix, "labelled", "1.0");
+    try save(testIo(), testing.allocator, prefix, valid_sha_for_tests, "labelled", "1.0");
+
+    var buf: [512]u8 = undefined;
+    const mark = try labelMark(&buf, prefix, valid_sha_for_tests);
+    try std.Io.Dir.cwd().deleteFile(testIo(), mark);
+    // Without a label there is no way to know whose bytes these are.
+    try testing.expectError(
+        RelocatedStoreError.LabelMismatch,
+        materialize(testIo(), testing.allocator, prefix, valid_sha_for_tests, "labelled", "1.0"),
+    );
+}
+
+test "remove clears the label mark with the entry" {
+    const prefix = try tmpPrefixForTests(testing.allocator, "label_remove");
+    defer {
+        std.Io.Dir.cwd().deleteTree(testIo(), prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+    try buildKegForTests(testing.allocator, prefix, "labelled", "1.0");
+    try save(testIo(), testing.allocator, prefix, valid_sha_for_tests, "labelled", "1.0");
+    try remove(testIo(), prefix, valid_sha_for_tests);
+
+    var buf: [512]u8 = undefined;
+    const mark = try labelMark(&buf, prefix, valid_sha_for_tests);
+    // A surviving label would vouch for whatever the next save puts here.
+    try testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(testIo(), mark, .{}));
 }
 
 test "remove clears the verified mark with the entry" {

--- a/tests/cellar_test.zig
+++ b/tests/cellar_test.zig
@@ -858,6 +858,64 @@ test "materializeWithCellar refuses a name dir with no matching version" {
     try expectKegSourceMissing("pkg");
 }
 
+test "materializeWithCellar refuses a warm hit under a label the snapshot was not taken as" {
+    const prefix = try createTestDir(testing.allocator);
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+    try setupMaltDirs(testing.allocator, prefix);
+    try createBottleFixture(testing.allocator, prefix, valid_test_sha, "other-name", "1.0");
+
+    const old_env = setMaltPrefix(prefix);
+    defer restoreMaltPrefix(old_env);
+
+    // Cold install snapshots the keg under its real label.
+    const first = try cellar_mod.materializeWithCellar(
+        std.Options.debug_io,
+        testing.allocator,
+        prefix,
+        valid_test_sha,
+        "other-name",
+        "1.0",
+        ":any",
+        null,
+    );
+    testing.allocator.free(first.path);
+    try testing.expect(relocated_mod.has(std.Options.debug_io, prefix, valid_test_sha));
+
+    // Same sha, different label: the warm path answers LabelMismatch and
+    // evicts the snapshot, so the cold path's store-entry check refuses it
+    // exactly as it would have without a cache.
+    const result = cellar_mod.materializeWithCellar(
+        std.Options.debug_io,
+        testing.allocator,
+        prefix,
+        valid_test_sha,
+        "pkg",
+        "9.9",
+        ":any",
+        null,
+    );
+    try testing.expectError(cellar_mod.CellarError.KegSourceMissing, result);
+    try testing.expect(!try fileExists(testing.allocator, "{s}/Cellar/pkg", .{prefix}));
+    try testing.expect(!relocated_mod.has(std.Options.debug_io, prefix, valid_test_sha));
+
+    // The legitimate label re-snapshots instead of staying cold forever.
+    const again = try cellar_mod.materializeWithCellar(
+        std.Options.debug_io,
+        testing.allocator,
+        prefix,
+        valid_test_sha,
+        "other-name",
+        "1.0",
+        ":any",
+        null,
+    );
+    testing.allocator.free(again.path);
+    try testing.expect(relocated_mod.has(std.Options.debug_io, prefix, valid_test_sha));
+}
+
 // ---------------------------------------------------------------------------
 // Post-relocation keg verification
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

A relocated-keg snapshot could be warm-restored under any `name/version` that presented the same bottle sha, so a tap serving one bottle under two labels got package A installed, receipted and recorded as package B. Each snapshot now carries the label it was taken under; a warm hit for a different label evicts the entry and falls through to the cold path, which refuses it. The cache logic version is bumped so pre-existing unlabelled entries are reaped rather than trusted.

## Related Issue

- None

## Notes for Reviewers

- Stacked on `fix/cellar-refuse-store-entry-root-as-keg-source` (#994): depends on `KegSourceMissing` for the cold-path refusal.