### PR TITLE
fix(linker): refuse to link over a sibling version's symlink or a plain file the pre-check could not read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,9 @@ jobs:
       - name: Regression guard - a patched Mach-O always reaches the re-sign list
         run: ./scripts/regressions/walk-refuses-to-drop-a-mutated-macho-mutated-macho-can-skip-resigning-on-append-failure.sh
 
+      - name: Regression guard - link pre-check refuses sibling-version symlinks and occupied plain-file slots
+        run: ./scripts/regressions/conflict-precheck-boundary-and-plain-file-conflict-precheck-prefix-match-and-skipped-targets.sh
+
       - name: Build universal binary
         run: just build-universal
 

--- a/justfile
+++ b/justfile
@@ -77,6 +77,7 @@ regressions-hermetic:
 regressions-harness:
     @./scripts/regressions/cached-outdated-drops-revision-bumped-packages.sh
     @./scripts/regressions/child-run-sequential-pipe-drain-deadlock.sh
+    @./scripts/regressions/conflict-precheck-boundary-and-plain-file-conflict-precheck-prefix-match-and-skipped-targets.sh
     @./scripts/regressions/cosign-guard-fails-open-and-spawn-not-pinned.sh
     @./scripts/regressions/csi-whitelist-ignores-private-parameter-bytes.sh
     @./scripts/regressions/dsl-chmod-mode-cast-panic-large-literal.sh

--- a/justfile
+++ b/justfile
@@ -77,7 +77,6 @@ regressions-hermetic:
 regressions-harness:
     @./scripts/regressions/cached-outdated-drops-revision-bumped-packages.sh
     @./scripts/regressions/child-run-sequential-pipe-drain-deadlock.sh
-    @./scripts/regressions/conflict-precheck-boundary-and-plain-file-conflict-precheck-prefix-match-and-skipped-targets.sh
     @./scripts/regressions/cosign-guard-fails-open-and-spawn-not-pinned.sh
     @./scripts/regressions/csi-whitelist-ignores-private-parameter-bytes.sh
     @./scripts/regressions/dsl-chmod-mode-cast-panic-large-literal.sh

--- a/scripts/regressions/conflict-precheck-boundary-and-plain-file-conflict-precheck-prefix-match-and-skipped-targets.sh
+++ b/scripts/regressions/conflict-precheck-boundary-and-plain-file-conflict-precheck-prefix-match-and-skipped-targets.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Regression: the link pre-check accepted any existing symlink whose target
+# merely started with the keg path, so a link into a sibling version
+# (Cellar/foo/1.0_1 vs Cellar/foo/1.0) passed as "same keg". Independently,
+# a regular file occupying a leaf slot made readLink fail and the failure
+# was swallowed, so the slot looked free. `malt link` then replaced both
+# entries: the sibling's live symlink was retargeted and the user's file
+# was lost, with exit 0.
+#
+# This script seeds a throwaway prefix with a kegs row for Cellar/foo/1.0,
+# a prefix symlink into sibling Cellar/foo/1.0_1, and a regular file in a
+# second leaf slot, then runs `malt link foo` without --overwrite. After
+# the fix the pre-check must refuse both and leave the prefix untouched.
+#
+# Exits 0 when the bug is absent, non-zero (with a clear message) when
+# present. No network required; finishes well under 30s once built.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+command -v sqlite3 >/dev/null || {
+  echo "sqlite3 required" >&2
+  exit 2
+}
+
+PREFIX="$(mktemp -d)/malt-prefix"
+export MALT_PREFIX="$PREFIX"
+trap 'rm -rf "$(dirname "$PREFIX")"' EXIT
+
+pass() { printf '  ✓ %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+DB="$PREFIX/db/malt.db"
+mkdir -p "$PREFIX/db" "$PREFIX/bin"
+
+# Init the schema with a benign command against the empty DB file.
+: >"$DB"
+"$BIN" link __absent__ >/dev/null 2>&1 || true
+sqlite3 "$DB" "SELECT 1 FROM kegs LIMIT 1;" >/dev/null 2>&1 ||
+  fail "schema init did not create the kegs table"
+
+# Keg under test plus a sibling version dir whose path continues the
+# version string without a separator.
+KEG="$PREFIX/Cellar/foo/1.0"
+SIBLING="$PREFIX/Cellar/foo/1.0_1"
+mkdir -p "$KEG/bin" "$SIBLING/bin"
+printf '#!/bin/sh\n' >"$KEG/bin/foo"
+printf '#!/bin/sh\n' >"$KEG/bin/plain"
+printf '#!/bin/sh\n' >"$SIBLING/bin/foo"
+
+sqlite3 "$DB" \
+  "INSERT INTO kegs(name,full_name,version,store_sha256,cellar_path) \
+   VALUES('foo','foo','1.0','sha','$KEG');"
+
+ln -s "$SIBLING/bin/foo" "$PREFIX/bin/foo" # live link into the sibling version
+printf 'USER DATA\n' >"$PREFIX/bin/plain"  # non-malt regular file in a leaf slot
+
+OUT="$(dirname "$PREFIX")/out"
+if "$BIN" link foo >"$OUT" 2>&1; then
+  fail "malt link exited 0 with two conflicting leaves in place"
+fi
+pass "malt link refused"
+
+grep -q 'Cellar/foo/1.0_1' "$OUT" ||
+  fail "sibling-version symlink not reported as a conflict"
+pass "sibling-version symlink reported"
+grep -q 'bin/plain' "$OUT" ||
+  fail "regular file in leaf slot not reported as a conflict"
+pass "regular file in leaf slot reported"
+
+[[ "$(readlink "$PREFIX/bin/foo")" == "$SIBLING/bin/foo" ]] ||
+  fail "sibling-version symlink was retargeted"
+pass "sibling-version symlink untouched"
+[[ ! -L "$PREFIX/bin/plain" && "$(cat "$PREFIX/bin/plain")" == "USER DATA" ]] ||
+  fail "regular file was clobbered"
+pass "regular file untouched"
+
+[[ -z "$(sqlite3 "$DB" 'SELECT 1 FROM links LIMIT 1;')" ]] ||
+  fail "links rows written despite refused pre-check"
+pass "no links rows written"
+
+printf '\n✔ conflict pre-check boundary and plain-file regression passed\n'

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -1285,21 +1285,37 @@ fn runInstall(
     }
 }
 
-/// `--force` and `uninstall` only clear links a keg owns; a stray file or
-/// directory in the slot has to be removed by hand.
-fn conflictHint(conflicts: []const linker_mod.Conflict) []const u8 {
+/// `--force` only sweeps links a keg of the same name left behind; another
+/// package's links need an uninstall, and a stray file or directory in the
+/// slot has to be removed by hand.
+fn conflictHint(conflicts: []const linker_mod.Conflict, name: []const u8) []const u8 {
+    var other_keg = false;
     for (conflicts) |c| {
         if (!c.owned_by_keg) return "Remove the conflicting file or directory first.";
+        if (!kegOwnedBy(c.existing_keg, name)) other_keg = true;
     }
-    return "Use --force to overwrite, or uninstall the conflicting package first.";
+    return if (other_keg) "Uninstall the conflicting package first." else "Use --force to overwrite.";
 }
 
-test "conflictHint points at --force/uninstall only when every slot is keg-owned" {
-    const keg: linker_mod.Conflict = .{ .link_path = "/p/bin/a", .existing_keg = "Cellar/a/1.0" };
-    const file: linker_mod.Conflict = .{ .link_path = "/p/bin/b", .existing_keg = "existing file", .owned_by_keg = false };
-    try std.testing.expect(std.mem.indexOf(u8, conflictHint(&.{keg}), "--force") != null);
-    try std.testing.expect(std.mem.indexOf(u8, conflictHint(&.{file}), "--force") == null);
-    try std.testing.expect(std.mem.indexOf(u8, conflictHint(&.{ keg, file }), "Remove") != null);
+/// `existing_keg` is `Cellar/<name>/<ver>`; match the name segment only.
+fn kegOwnedBy(existing_keg: []const u8, name: []const u8) bool {
+    const marker = "Cellar/";
+    if (!std.mem.startsWith(u8, existing_keg, marker)) return false;
+    const rest = existing_keg[marker.len..];
+    return rest.len > name.len and rest[name.len] == '/' and std.mem.startsWith(u8, rest, name);
+}
+
+test "conflictHint names the one action that actually clears the slot" {
+    const same: linker_mod.Conflict = .{ .link_path = "/p/bin/a", .existing_keg = "Cellar/a/1.0" };
+    const other: linker_mod.Conflict = .{ .link_path = "/p/bin/b", .existing_keg = "Cellar/ab/2.0" };
+    const file: linker_mod.Conflict = .{ .link_path = "/p/bin/c", .existing_keg = "existing file", .owned_by_keg = false };
+    try std.testing.expectEqualStrings("Use --force to overwrite.", conflictHint(&.{same}, "a"));
+    try std.testing.expectEqualStrings("Uninstall the conflicting package first.", conflictHint(&.{other}, "a"));
+    try std.testing.expectEqualStrings("Uninstall the conflicting package first.", conflictHint(&.{ same, other }, "a"));
+    try std.testing.expectEqualStrings("Remove the conflicting file or directory first.", conflictHint(&.{ same, other, file }, "a"));
+    // Name compare is whole-segment: `a` must not claim `ab`'s keg.
+    try std.testing.expect(!kegOwnedBy("Cellar/ab/2.0", "a"));
+    try std.testing.expect(kegOwnedBy("Cellar/a/1.0", "a"));
 }
 
 /// Link + record a materialised keg. Must run serially: linker conflict
@@ -1344,7 +1360,7 @@ fn linkAndRecord(
             for (conflicts) |conflict| {
                 sink.err("  {s} already linked by {s}", .{ conflict.link_path, conflict.existing_keg });
             }
-            sink.err("{s}", .{conflictHint(conflicts)});
+            sink.err("{s}", .{conflictHint(conflicts, job.name)});
             cellar_mod.remove(io, prefix, job.name, job.version_str) catch {};
             return InstallError.LinkFailed;
         }

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -1285,6 +1285,23 @@ fn runInstall(
     }
 }
 
+/// `--force` and `uninstall` only clear links a keg owns; a stray file or
+/// directory in the slot has to be removed by hand.
+fn conflictHint(conflicts: []const linker_mod.Conflict) []const u8 {
+    for (conflicts) |c| {
+        if (!c.owned_by_keg) return "Remove the conflicting file or directory first.";
+    }
+    return "Use --force to overwrite, or uninstall the conflicting package first.";
+}
+
+test "conflictHint points at --force/uninstall only when every slot is keg-owned" {
+    const keg: linker_mod.Conflict = .{ .link_path = "/p/bin/a", .existing_keg = "Cellar/a/1.0" };
+    const file: linker_mod.Conflict = .{ .link_path = "/p/bin/b", .existing_keg = "existing file", .owned_by_keg = false };
+    try std.testing.expect(std.mem.indexOf(u8, conflictHint(&.{keg}), "--force") != null);
+    try std.testing.expect(std.mem.indexOf(u8, conflictHint(&.{file}), "--force") == null);
+    try std.testing.expect(std.mem.indexOf(u8, conflictHint(&.{ keg, file }), "Remove") != null);
+}
+
 /// Link + record a materialised keg. Must run serially: linker conflict
 /// checks read live symlink state and SQLite is single-writer.
 ///
@@ -1327,7 +1344,7 @@ fn linkAndRecord(
             for (conflicts) |conflict| {
                 sink.err("  {s} already linked by {s}", .{ conflict.link_path, conflict.existing_keg });
             }
-            sink.err("Use --force to overwrite, or uninstall the conflicting package first.", .{});
+            sink.err("{s}", .{conflictHint(conflicts)});
             cellar_mod.remove(io, prefix, job.name, job.version_str) catch {};
             return InstallError.LinkFailed;
         }

--- a/src/core/linker.zig
+++ b/src/core/linker.zig
@@ -9,6 +9,9 @@ pub const LinkError = error{ ConflictFound, LinkFailed, UnlinkFailed, OutOfMemor
 pub const Conflict = struct {
     link_path: []const u8,
     existing_keg: []const u8,
+    /// False when the slot holds a stray file or directory rather than a
+    /// keg's symlink: no package owns it, so only the user can clear it.
+    owned_by_keg: bool = true,
 };
 
 pub const Linker = struct {
@@ -65,13 +68,14 @@ pub const Linker = struct {
                     // Name the owning keg when the clashing node is a keg
                     // symlink; otherwise report the bare structural clash.
                     var owner_buf: [std.fs.max_path_bytes]u8 = undefined;
-                    const owner: []const u8 = if (prefix_dir.readLink(self.io, clash, &owner_buf)) |n|
+                    const owner: ?[]const u8 = if (prefix_dir.readLink(self.io, clash, &owner_buf)) |n|
                         (extractKegFromPath(owner_buf[0..n]) orelse owner_buf[0..n])
                     else |_|
-                        "existing directory";
+                        null;
                     conflicts.append(self.allocator, .{
                         .link_path = self.allocator.dupe(u8, link_path) catch continue,
-                        .existing_keg = self.allocator.dupe(u8, owner) catch continue,
+                        .existing_keg = self.allocator.dupe(u8, owner orelse "existing directory") catch continue,
+                        .owned_by_keg = owner != null,
                     }) catch continue;
                     continue;
                 }
@@ -82,37 +86,27 @@ pub const Linker = struct {
                 // scanning kegs with many files. `rel` is the full nested
                 // path relative to the linkable dir.
                 var link_target_buf: [1024]u8 = undefined;
-                const link_target_len = prefix_dir.readLink(self.io, rel, &link_target_buf) catch |err| switch (err) {
-                    error.FileNotFound => continue, // slot is free
-                    // Anything else (a regular file, an unreadable entry) is
-                    // occupied by something we cannot verify; `link` would
-                    // replace it, so refuse here.
-                    else => {
-                        var lp_buf: [std.fs.max_path_bytes]u8 = undefined;
-                        const link_path = std.fmt.bufPrint(&lp_buf, "{s}/{s}/{s}", .{ self.prefix, subdir, rel }) catch continue;
-                        conflicts.append(self.allocator, .{
-                            .link_path = self.allocator.dupe(u8, link_path) catch continue,
-                            .existing_keg = self.allocator.dupe(u8, "existing file") catch continue,
-                        }) catch continue;
-                        continue;
-                    },
-                };
-                const link_target = link_target_buf[0..link_target_len];
-
-                // If the existing symlink points into a different keg, it's a conflict
-                if (!isUnderKeg(link_target, keg_path)) {
-                    var link_path_buf: [std.fs.max_path_bytes]u8 = undefined;
-                    const link_path = std.fmt.bufPrint(&link_path_buf, "{s}/{s}/{s}", .{ self.prefix, subdir, rel }) catch continue;
-
-                    // Extract the existing keg path from the symlink target
+                const existing_keg: []const u8, const owned_by_keg = blk: {
+                    const n = prefix_dir.readLink(self.io, rel, &link_target_buf) catch |err| switch (err) {
+                        error.FileNotFound => continue, // slot is free
+                        // Anything else (a regular file, an unreadable entry)
+                        // is occupied by something we cannot verify; `link`
+                        // would replace it, so refuse here.
+                        else => break :blk .{ "existing file", false },
+                    };
+                    const target = link_target_buf[0..n];
+                    if (isUnderKeg(target, keg_path)) continue; // our own link
                     // Targets look like: /opt/malt/Cellar/<name>/<ver>/bin/<file>
-                    const existing_keg = extractKegFromPath(link_target) orelse link_target;
+                    break :blk .{ extractKegFromPath(target) orelse target, true };
+                };
 
-                    conflicts.append(self.allocator, .{
-                        .link_path = self.allocator.dupe(u8, link_path) catch continue,
-                        .existing_keg = self.allocator.dupe(u8, existing_keg) catch continue,
-                    }) catch continue;
-                }
+                var link_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+                const link_path = std.fmt.bufPrint(&link_path_buf, "{s}/{s}/{s}", .{ self.prefix, subdir, rel }) catch continue;
+                conflicts.append(self.allocator, .{
+                    .link_path = self.allocator.dupe(u8, link_path) catch continue,
+                    .existing_keg = self.allocator.dupe(u8, existing_keg) catch continue,
+                    .owned_by_keg = owned_by_keg,
+                }) catch continue;
             }
         }
 

--- a/src/core/linker.zig
+++ b/src/core/linker.zig
@@ -82,11 +82,25 @@ pub const Linker = struct {
                 // scanning kegs with many files. `rel` is the full nested
                 // path relative to the linkable dir.
                 var link_target_buf: [1024]u8 = undefined;
-                const link_target_len = prefix_dir.readLink(self.io, rel, &link_target_buf) catch continue;
+                const link_target_len = prefix_dir.readLink(self.io, rel, &link_target_buf) catch |err| switch (err) {
+                    error.FileNotFound => continue, // slot is free
+                    // Anything else (a regular file, an unreadable entry) is
+                    // occupied by something we cannot verify; `link` would
+                    // replace it, so refuse here.
+                    else => {
+                        var lp_buf: [std.fs.max_path_bytes]u8 = undefined;
+                        const link_path = std.fmt.bufPrint(&lp_buf, "{s}/{s}/{s}", .{ self.prefix, subdir, rel }) catch continue;
+                        conflicts.append(self.allocator, .{
+                            .link_path = self.allocator.dupe(u8, link_path) catch continue,
+                            .existing_keg = self.allocator.dupe(u8, "existing file") catch continue,
+                        }) catch continue;
+                        continue;
+                    },
+                };
                 const link_target = link_target_buf[0..link_target_len];
 
                 // If the existing symlink points into a different keg, it's a conflict
-                if (!std.mem.startsWith(u8, link_target, keg_path)) {
+                if (!isUnderKeg(link_target, keg_path)) {
                     var link_path_buf: [std.fs.max_path_bytes]u8 = undefined;
                     const link_path = std.fmt.bufPrint(&link_path_buf, "{s}/{s}/{s}", .{ self.prefix, subdir, rel }) catch continue;
 
@@ -174,6 +188,14 @@ pub const Linker = struct {
             pos = (slash orelse rel.len) + 1;
         }
         return null;
+    }
+
+    /// True when `target` lies inside `keg_path`. A bare prefix match is not
+    /// enough: `Cellar/foo/1.0_1` continues `Cellar/foo/1.0` byte-for-byte.
+    fn isUnderKeg(target: []const u8, keg_path: []const u8) bool {
+        return target.len > keg_path.len and
+            std.mem.startsWith(u8, target, keg_path) and
+            target[keg_path.len] == '/';
     }
 
     /// Extract "Cellar/<name>/<ver>" from a full path like "/opt/malt/Cellar/foo/1.0/bin/foo"
@@ -464,6 +486,16 @@ test "the broken-link sweep covers every dir the linker writes into" {
     }
     try testing.expect(has_etc);
     try testing.expectEqual(@as(usize, 6), swept.len);
+}
+
+test "isUnderKeg: only a '/' after the keg path counts as inside it" {
+    const keg = "/opt/malt/Cellar/foo/1.0";
+    try testing.expect(Linker.isUnderKeg("/opt/malt/Cellar/foo/1.0/bin/x", keg));
+    try testing.expect(!Linker.isUnderKeg("/opt/malt/Cellar/foo/1.0_1/bin/x", keg));
+    try testing.expect(!Linker.isUnderKeg("/opt/malt/Cellar/foo/1.0.1/bin/x", keg));
+    try testing.expect(!Linker.isUnderKeg("/opt/malt/Cellar/foo/1.0", keg));
+    try testing.expect(!Linker.isUnderKeg("/opt/malt/Cellar/foo/1.", keg));
+    try testing.expect(!Linker.isUnderKeg("/opt/malt/Cellar/bar/1.0/bin/x", keg));
 }
 
 test "isDanglingLinkError: only a missing target counts" {

--- a/tests/linker_core_test.zig
+++ b/tests/linker_core_test.zig
@@ -239,6 +239,92 @@ test "checkConflicts detects a nested cross-keg collision" {
     try testing.expect(matched);
 }
 
+test "checkConflicts stays empty when the keg's own links are already in place" {
+    const prefix = try uniquePrefix("link_self_no_conflict");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+
+    const keg = try makeKegWithBinary(prefix, "foo", "1.0", "foo");
+    defer testing.allocator.free(keg);
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    try insertKeg(&db, 1, "foo", keg);
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+    try linker.link(keg, "foo", 1, false);
+
+    // The boundary check must not turn a relink into a self-conflict.
+    const conflicts = try linker.checkConflicts(keg, false);
+    defer testing.allocator.free(conflicts);
+    try testing.expectEqual(@as(usize, 0), conflicts.len);
+}
+
+test "checkConflicts flags a symlink into a sibling version of the same formula" {
+    const prefix = try uniquePrefix("link_sibling_version_conflict");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+
+    // Cellar/foo/1.0_1 continues Cellar/foo/1.0 without a separator, so a
+    // bare prefix match would call the sibling's symlink "same keg".
+    const keg_new = try makeKegWithBinary(prefix, "foo", "1.0", "foo");
+    defer testing.allocator.free(keg_new);
+    const keg_sibling = try makeKegWithBinary(prefix, "foo", "1.0_1", "foo");
+    defer testing.allocator.free(keg_sibling);
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    try insertKeg(&db, 1, "foo", keg_sibling);
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+    try linker.link(keg_sibling, "foo", 1, false);
+
+    const conflicts = try linker.checkConflicts(keg_new, false);
+    defer {
+        for (conflicts) |c| {
+            testing.allocator.free(c.link_path);
+            testing.allocator.free(c.existing_keg);
+        }
+        testing.allocator.free(conflicts);
+    }
+    try testing.expectEqual(@as(usize, 1), conflicts.len);
+    try testing.expect(std.mem.endsWith(u8, conflicts[0].link_path, "/bin/foo"));
+    try testing.expect(std.mem.indexOf(u8, conflicts[0].existing_keg, "foo/1.0_1") != null);
+}
+
+test "checkConflicts flags a regular file occupying a leaf slot" {
+    const prefix = try uniquePrefix("link_plain_file_conflict");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+
+    const keg = try makeKegWithBinary(prefix, "foo", "1.0", "tool");
+    defer testing.allocator.free(keg);
+    // Not a symlink: readLink fails on it, which must count as occupied.
+    const slot = try std.fmt.allocPrint(testing.allocator, "{s}/bin/tool", .{prefix});
+    defer testing.allocator.free(slot);
+    try writeFile(slot, "USER DATA\n");
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+
+    const conflicts = try linker.checkConflicts(keg, false);
+    defer {
+        for (conflicts) |c| {
+            testing.allocator.free(c.link_path);
+            testing.allocator.free(c.existing_keg);
+        }
+        testing.allocator.free(conflicts);
+    }
+    try testing.expectEqual(@as(usize, 1), conflicts.len);
+    try testing.expect(std.mem.endsWith(u8, conflicts[0].link_path, "/bin/tool"));
+    try testing.expectEqualStrings("existing file", conflicts[0].existing_keg);
+}
+
 test "unlink prunes emptied nested dirs but keeps dirs another keg still links" {
     const prefix = try uniquePrefix("unlink_prune");
     defer testing.allocator.free(prefix);

--- a/tests/linker_core_test.zig
+++ b/tests/linker_core_test.zig
@@ -292,6 +292,7 @@ test "checkConflicts flags a symlink into a sibling version of the same formula"
     try testing.expectEqual(@as(usize, 1), conflicts.len);
     try testing.expect(std.mem.endsWith(u8, conflicts[0].link_path, "/bin/foo"));
     try testing.expect(std.mem.indexOf(u8, conflicts[0].existing_keg, "foo/1.0_1") != null);
+    try testing.expect(conflicts[0].owned_by_keg);
 }
 
 test "checkConflicts flags a regular file occupying a leaf slot" {
@@ -323,6 +324,37 @@ test "checkConflicts flags a regular file occupying a leaf slot" {
     try testing.expectEqual(@as(usize, 1), conflicts.len);
     try testing.expect(std.mem.endsWith(u8, conflicts[0].link_path, "/bin/tool"));
     try testing.expectEqualStrings("existing file", conflicts[0].existing_keg);
+    try testing.expect(!conflicts[0].owned_by_keg);
+}
+
+test "checkConflicts flags a directory occupying a leaf slot as not keg-owned" {
+    const prefix = try uniquePrefix("link_dir_in_slot_conflict");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+
+    const keg = try makeKegWithBinary(prefix, "foo", "1.0", "tool");
+    defer testing.allocator.free(keg);
+    const slot = try std.fmt.allocPrint(testing.allocator, "{s}/bin/tool", .{prefix});
+    defer testing.allocator.free(slot);
+    try test_io.cwd().createDirPath(std.Options.debug_io, slot);
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+
+    const conflicts = try linker.checkConflicts(keg, false);
+    defer {
+        for (conflicts) |c| {
+            testing.allocator.free(c.link_path);
+            testing.allocator.free(c.existing_keg);
+        }
+        testing.allocator.free(conflicts);
+    }
+    try testing.expectEqual(@as(usize, 1), conflicts.len);
+    try testing.expectEqualStrings("existing directory", conflicts[0].existing_keg);
+    try testing.expect(!conflicts[0].owned_by_keg);
 }
 
 test "unlink prunes emptied nested dirs but keeps dirs another keg still links" {
@@ -820,7 +852,10 @@ test "checkConflicts flags a file-vs-directory collision the symlink probe misse
     }
     var hit = false;
     for (conflicts) |c| {
-        if (std.mem.endsWith(u8, c.link_path, "/share/data")) hit = true;
+        if (std.mem.endsWith(u8, c.link_path, "/share/data")) {
+            hit = true;
+            try testing.expect(c.owned_by_keg); // alpha's symlink, not a stray file
+        }
     }
     try testing.expect(hit);
 }


### PR DESCRIPTION
## Description

`mt link` (and a fresh `mt install`) could silently replace a live symlink into a sibling version of the same formula, or a non-malt file sitting in a leaf slot, and exit 0. Both are now reported as conflicts and nothing is touched unless `--overwrite` is passed. `install`'s hint now names the one action that clears the slot: `--force` only for a same-name keg's leftover links, uninstall for another package, removal by hand for a stray file or directory.

## Related Issue

- None

## Notes for Reviewers

- None
