### PR TITLE
test(smoke): revert casks on a red install smoke and excuse upstream outages as SKIP

### DIFF
--- a/justfile
+++ b/justfile
@@ -46,6 +46,7 @@ regressions-static:
     @./scripts/regressions/post-install-copy-deletes-destination-before-clone.sh
     @./scripts/regressions/tar-prescan-followups-925-926-follow-up.sh
     @./scripts/regressions/tui-background-fetch-no-double-reap-start-background-waits-after-kill.sh
+    @./scripts/regressions/install-smoke-red-run-reverts-casks-and-skips-upstream-outages-local-smoke-install.sh
     @MALT_STATIC_ONLY=1 ./scripts/regressions/post-install-steps-live-artefacts.sh
     @./scripts/test/bench_release_resolution_test.sh
 

--- a/scripts/regressions/install-smoke-red-run-reverts-casks-and-skips-upstream-outages-local-smoke-install.sh
+++ b/scripts/regressions/install-smoke-red-run-reverts-casks-and-skips-upstream-outages-local-smoke-install.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Regression: the install smoke must (1) classify an upstream artifact 404
+# on a tap formula as SKIP, not FAIL, and (2) still uninstall the casks it
+# installed when the run ends red. Casks are the only state that escapes
+# MALT_PREFIX, so a red run that skips teardown strands an app in
+# /Applications and makes every later run SKIP that case.
+#
+# Drives the real smoke with MT_BIN pointed at a stub malt: no network,
+# a few seconds.
+#
+# Usage: scripts/regressions/install-smoke-red-run-reverts-casks-and-skips-upstream-outages-local-smoke-install.sh
+
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+SMOKE="$ROOT/scripts/smokes/local-smoke-install.sh"
+
+T=$(mktemp -d)
+MARK="$T/uninstalls"
+trap 'rm -rf "$T"' EXIT
+
+cat >"$T/malt" <<STUB
+#!/usr/bin/env bash
+case "\$*" in
+  "install mongodb/brew/mongodb-community") echo "  x Download failed with status 404"; exit 1 ;;
+  "install go") echo "  x boom: unclassified"; exit 1 ;;
+  "uninstall --cask "*) echo "\$3" >>"$MARK"; exit 0 ;;
+  *) exit 0 ;;
+esac
+STUB
+chmod +x "$T/malt"
+
+OUT=$(MT_BIN="$T/malt" bash "$SMOKE" 2>&1)
+RC=$?
+
+# The red path drops the smoke's own EXIT trap by design: sweep the
+# PREFIX/CACHE/LOGDIR it printed so nothing is stranded under /tmp.
+# shellcheck disable=SC2046
+rm -rf $(grep -oE '/tmp/m[tcl]\.[[:alnum:]]{3}' <<<"$OUT" | sort -u) /tmp/mt_tahoe /tmp/mc_tahoe
+
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+[[ $RC -eq 1 ]] || fail "expected a red run (rc=1), got rc=$RC"
+grep -q 'SKIP  \[smoke.install.tap.mongodb\]' <<<"$OUT" ||
+  fail "upstream artifact 404 was not classified SKIP"
+grep -qx copilot-cli "$MARK" 2>/dev/null ||
+  fail "cask teardown did not run on the red path"
+
+echo "PASS"

--- a/scripts/regressions/install_download_only.sh
+++ b/scripts/regressions/install_download_only.sh
@@ -151,15 +151,17 @@ pass "follow-up cask install populated casks row"
 
 # ── 6. Tap formula --download-only: warm cache/Tap, no Cellar/db. ─────
 # Real binary tap that ships a single executable through the
-# materializeRubyFormula path. Transient classified failures (rate
-# limits, DNS) are skipped, not failures — same shape as
-# install_tap_tmp_cleanup.sh.
+# materializeRubyFormula path.
 TAP_TARGET="${TAP_TARGET:-indaco/tap/sley}"
+# Upstream failures only; no `Failed to install` (that also wraps malt's
+# extract/relocate/dep errors).
+TRANSIENT_RE='rate limit|Network failure|Cannot fetch tap from GitHub|Tap formula/cask not found|Could not resolve|Failed to download|Download failed with status|SHA256 mismatch'
 TAP_LOG="$PREFIX/tap_install.log"
 printf '▸ malt install --download-only %s\n' "$TAP_TARGET"
 if ! "$BIN" install --download-only "$TAP_TARGET" >"$TAP_LOG" 2>&1; then
-  if grep -qE "rate limit|Network failure|Cannot fetch tap from GitHub|Tap formula/cask not found" "$TAP_LOG"; then
+  if grep -qE "$TRANSIENT_RE" "$TAP_LOG"; then
     printf '  - %s: transient classified failure; skipping tap section\n' "$TAP_TARGET"
+    grep -m1 -E "$TRANSIENT_RE" "$TAP_LOG" | sed 's/^/    | /'
     printf '\n✔ install-download-only regression test passed (tap section skipped)\n'
     exit 0
   fi

--- a/scripts/smokes/local-smoke-install.sh
+++ b/scripts/smokes/local-smoke-install.sh
@@ -47,11 +47,12 @@
 #
 # Time/bandwidth: ~30-40 min, ~4 GB downloaded fresh.
 #
-# Cleanup: on success (FAIL=0), every cask installed by this run is
-# `mt uninstall`-ed and every formula too — so /Applications and any
-# other system-touching state malt knows about is reverted before the
-# EXIT trap wipes the temp PREFIX/CACHE/LOGDIR. On failure, artifacts
-# stay around for triage (matches scripts/local-bench.sh behavior).
+# Cleanup: every cask installed by this run is `mt uninstall`-ed on both
+# exit paths — casks are the only state that escapes MALT_PREFIX, and a
+# leftover /Applications app would make every later run SKIP that case.
+# On success (FAIL=0) formulas are uninstalled too and the EXIT trap wipes
+# the temp PREFIX/CACHE/LOGDIR. On failure, formulas and the prefix/cache/
+# logdir stay around for triage (matches scripts/local-bench.sh behavior).
 #
 # App casks are SKIPPED when the target /Applications/<App>.app
 # already exists — we never trample the user's pre-existing apps.
@@ -90,6 +91,10 @@ export MALT_CACHE="$CACHE"
 # Deterministic, machine-parseable output.
 export NO_COLOR=1
 export MALT_NO_EMOJI=1
+
+# Upstream failures only; no `Failed to install` (that also wraps malt's
+# extract/relocate/dep errors, which this smoke exists to catch).
+TRANSIENT_RE='rate limit|Network failure|Cannot fetch tap from GitHub|Tap formula/cask not found|Could not resolve|Failed to download|Download failed with status|SHA256 mismatch'
 
 PASS=0
 FAIL=0
@@ -328,8 +333,9 @@ install_download_only_tap_reuse() {
   dl_log="$LOGDIR/$(printf '%s' "$tag.dl" | tr -c 'A-Za-z0-9' _).log"
   printf '  RUN   [%s.dl] %s install --download-only %s\n' "$tag" "$MT_BIN" "$slug"
   if ! "$MT_BIN" install --download-only "$slug" >"$dl_log" 2>&1; then
-    if grep -qE "rate limit|Network failure|Cannot fetch tap from GitHub|Tap formula/cask not found" "$dl_log"; then
+    if grep -qE "$TRANSIENT_RE" "$dl_log"; then
       printf '  SKIP  [%s] %s: transient classified failure\n' "$tag" "$slug"
+      grep -m1 -E "$TRANSIENT_RE" "$dl_log" | sed 's/^/        | /'
       SKIP=$((SKIP + 1))
       SKIPS+=("$tag")
       return
@@ -434,8 +440,9 @@ install_tap_formula() {
   "$MT_BIN" install "$slug" >"$log" 2>&1 || rc=$?
 
   if [[ "$rc" -ne 0 ]]; then
-    if grep -qE "rate limit|Network failure|Cannot fetch tap from GitHub|Tap formula/cask not found" "$log"; then
+    if grep -qE "$TRANSIENT_RE" "$log"; then
       printf '  SKIP  [%s] %s: transient classified failure\n' "$tag" "$slug"
+      grep -m1 -E "$TRANSIENT_RE" "$log" | sed 's/^/        | /'
       SKIP=$((SKIP + 1))
       SKIPS+=("$tag")
       return
@@ -471,11 +478,13 @@ install_tap_formulas() {
   done
 }
 
-# Reverse what we installed. Casks first because they touch /Applications;
-# formulas second (they live entirely under MALT_PREFIX, but uninstalling
-# also exercises the uninstall path). Best-effort: a stuck uninstall must
-# not block the script from completing.
-cleanup_installs() {
+# Reverse what we installed. Best-effort: a stuck uninstall must not block
+# the script from completing.
+#
+# Casks run on both exit paths because they touch /Applications; formulas
+# live entirely under MALT_PREFIX and are torn down on success only, so a
+# red run keeps the prefix intact for triage.
+cleanup_casks() {
   printf '\n── Cleanup ───────────────────────────────────────\n'
   local item out
   for item in "${INSTALLED_CASKS[@]}"; do
@@ -483,6 +492,10 @@ cleanup_installs() {
     out=$("$MT_BIN" uninstall --cask "$item" 2>&1) ||
       printf '  WARN: uninstall --cask %s exited non-zero (continuing): %s\n' "$item" "$out"
   done
+}
+
+cleanup_formulas() {
+  local item out
   # Forced because only top-level installs are tracked: a dependency the
   # script never named still holds a reference and would refuse an otherwise
   # correct teardown (mongosh, pulled in by mongodb-community, pins node).
@@ -520,13 +533,16 @@ if ((SKIP > 0)); then
 fi
 if ((FAIL > 0)); then
   printf '  failures: %s\n' "${FAILURES[*]}"
+  cleanup_casks
   printf '\n  triage state preserved in:\n'
   printf '    PREFIX=%s\n' "$PREFIX"
+  printf '    CACHE=%s\n' "$CACHE"
   printf '    LOGDIR=%s\n' "$LOGDIR"
   # Drop the EXIT trap so artifacts survive for triage.
   trap - EXIT
   exit 1
 fi
 
-cleanup_installs
+cleanup_casks
+cleanup_formulas
 exit 0


### PR DESCRIPTION
## Description

A red install smoke used to leave its casks installed, so one unrelated failure stranded an app in /Applications and every later run SKIPped that case. Casks are now uninstalled on both exit paths; formulas and the prefix/cache/logdir still survive on failure for triage, and CACHE is listed with them.

The transient-failure classifier now also excuses upstream artifact failures (404, transport, retag) and a taken-down tap repo, as the header already promised, and prints the matched line so a masked failure stays visible. Guarded by a stub-driven regression (no network, under a second) wired into `just regressions-static`. The download-only tap regression carried the same narrow classifier and gets the same treatment.

## Related Issue

- None

## Notes for Reviewers

- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)